### PR TITLE
Add push to PyPI on release

### DIFF
--- a/.github/workflows/pypi_build_and_publish.yml
+++ b/.github/workflows/pypi_build_and_publish.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+ release:
+  types:
+   - created
+
+jobs:
+ build-n-publish:
+  name: Build and publish Python distribution to PyPI
+  runs-on: ubuntu-18.04
+  steps:
+   - name: Check out git repository
+     uses: actions/checkout@v2
+
+   - name: Set up Python 3.9
+     uses: actions/setup-python@v2
+     with:
+      python-version: 3.9
+
+   - name: Install poetry
+     uses: abatilo/actions-poetry@v2.0.0
+     with:
+      poetry-version: "1.1.12"
+
+   - name: Build and publish to PYPI
+     run: |
+       poetry publish --build
+     env:
+       GITHUB: 1
+       POETRY_PYPI_TOKEN_PYPI: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}


### PR DESCRIPTION
### This PR adds | fixes:
- Adds a workflow to push to PyPI on release.

### How to test:
- Not sure... Any idea, @henrikstranneheim?

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
