### PR TITLE
Use a temporary file when running the demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - Use a multi-stage build in Dockerfile to reduce its size
 - SQLite database launched instead of MySQL as the default demo database
 - Simpler docker-compose file and additional docker-compose file to show MySQL connection howto
+- Use a temporary file when running the demo app

--- a/src/chanjo2/dbutil.py
+++ b/src/chanjo2/dbutil.py
@@ -2,7 +2,7 @@ import os
 
 from sqlmodel import Session, create_engine
 
-DEMO_DB = "sqlite:///./chanjotest.db"
+DEMO_DB = "sqlite://"
 
 root_password = os.getenv("MYSQL_ROOT_PASSWORD")
 db_name = os.getenv("MYSQL_DATABASE_NAME")
@@ -11,6 +11,8 @@ port_no = os.getenv("MYSQL_PORT")
 
 if os.getenv("DEMO") or not db_name:
     mysql_url = DEMO_DB
+    engine = create_engine(mysql_url, echo=True, connect_args={"check_same_thread": False})
+
 else:
     if port_no is None:
         host = host_name
@@ -18,8 +20,7 @@ else:
         host = ":".join([host_name, port_no])
 
     mysql_url = f"mysql://root:{root_password}@{host}/{db_name}"
-
-engine = create_engine(mysql_url, echo=True)
+    engine = create_engine(mysql_url, echo=True)
 
 
 def get_session():


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #34 

### How to test:
- Locally, inside the conda env with the installed repo, launch the demo:
`gunicorn --config gunicorn.conf.py src.chanjo2.main:ap`

### Expected outcome:
- [ ] If you run the demo from main branch it will create a database file under the mail app folder
- [ ] Switch to this branch and no db file will be created by the demo (and no file will persist after the app is stopped

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
