### PR TITLE
Use uvicorn's log system and avoid printing double logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,4 +22,4 @@
 - Modified the command to run a demo instance in README file
 - Renamed table `Individuals` table to the more general `Samples`
 - Renamed table `Regions` table to `Intervals`
-- Use uvicorn logging and avoid printing database logs twice
+- Use uvicorn logging and avoid printing logs twice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
 - Modified the command to run a demo instance in README file
 - Renamed table `Individuals` table to the more general `Samples`
 - Renamed table `Regions` table to `Intervals`
+- Use uvicorn logging and avoid printing database logs twice

--- a/poetry.lock
+++ b/poetry.lock
@@ -204,24 +204,6 @@ files = [
 ]
 
 [[package]]
-name = "coloredlogs"
-version = "15.0.1"
-description = "Colored terminal output for Python's logging module"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934"},
-    {file = "coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0"},
-]
-
-[package.dependencies]
-humanfriendly = ">=9.1"
-
-[package.extras]
-cron = ["capturer (>=2.4)"]
-
-[[package]]
 name = "coverage"
 version = "7.0.5"
 description = "Code coverage measurement for Python"
@@ -472,21 +454,6 @@ files = [
 test = ["Cython (>=0.29.24,<0.30.0)"]
 
 [[package]]
-name = "humanfriendly"
-version = "10.0"
-description = "Human friendly output for text interfaces using Python"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-files = [
-    {file = "humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477"},
-    {file = "humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc"},
-]
-
-[package.dependencies]
-pyreadline3 = {version = "*", markers = "sys_platform == \"win32\" and python_version >= \"3.8\""}
-
-[[package]]
 name = "idna"
 version = "3.4"
 description = "Internationalized Domain Names in Applications (IDNA)"
@@ -671,18 +638,6 @@ typing-extensions = ">=4.2.0"
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
 email = ["email-validator (>=1.0.3)"]
-
-[[package]]
-name = "pyreadline3"
-version = "3.4.1"
-description = "A python implementation of GNU readline."
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pyreadline3-3.4.1-py3-none-any.whl", hash = "sha256:b0efb6516fd4fb07b45949053826a62fa4cb353db5be2bbb4a7aa1fdd1e345fb"},
-    {file = "pyreadline3-3.4.1.tar.gz", hash = "sha256:6f3d1f7b8a31ba32b73917cefc1f28cc660562f39aea8646d30bd6eff21f7bae"},
-]
 
 [[package]]
 name = "pytest"
@@ -1217,4 +1172,4 @@ m1 = ["pyd4"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "e5ed36d6eee0e67209fc242797b5f4a5c4ebed0d30994bd757ca60a903be1553"
+content-hash = "dbbf355fae00c5f796aa72f193669c52c8dcc20febbf98939ea94e4a6662a085"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ gunicorn = "^20.1.0"
 uvicorn = {extras = ["standard"], version = "^0.17.5"}
 requests = "^2.28.2"
 pytest-cov = "^4.0.0"
-coloredlogs = "^15.0.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/src/chanjo2/main.py
+++ b/src/chanjo2/main.py
@@ -1,15 +1,14 @@
 import logging
 import os
 
-import coloredlogs
+import uvicorn
 from chanjo2 import __version__
 from chanjo2.dbutil import engine
 from chanjo2.endpoints import intervals, samples
 from chanjo2.models.sql_models import Base
 from fastapi import FastAPI, status
 
-LOG = logging.getLogger(__name__)
-coloredlogs.install(level="INFO")
+LOG = logging.getLogger("uvicorn.access")
 
 
 def create_db_and_tables():
@@ -35,7 +34,16 @@ app.include_router(
 
 @app.on_event("startup")
 async def on_startup():
+    # Configure logging
+    LOG = logging.getLogger("uvicorn.access")
+    console_formatter = uvicorn.logging.ColourizedFormatter(
+        "{levelprefix} {asctime} : {message}", style="{", use_colors=True
+    )
+    LOG.handlers[0].setFormatter(console_formatter)
+
+    # Create database tables
     create_db_and_tables()
+
     if os.getenv("DEMO") or not os.getenv("MYSQL_DATABASE_NAME"):
         LOG.warning("Running a demo instance of Chanjo2")
 


### PR DESCRIPTION
On current main branch the SB logs are printed twice. I haven't understood exactly why, but perhaps because the DB handles has its own logging system that is not configured? 
Anyway I just found out that using the built-in uvicorn log system does the trick. This way we can avoid the dependency of coloredlogs (uvicorn logs are colored as well)


### This PR adds | fixes:
- Fix #42

### How to test:
- Run demo app main branch
- Run demo app this branch

### Expected outcome:
- This branch doesn't print the db logs twice

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
