### PR TITLE
Provide coverage files hosted on a remote HTTP(s) server

### DIFF
--- a/.github/workflows/vulture.yml
+++ b/.github/workflows/vulture.yml
@@ -19,5 +19,5 @@ jobs:
         uses: anaynayak/python-vulture-action@v1.0
         id: vulture
         with:
-          vulture-args: --min-confidence 80 --ignore-names kwargs ${{steps.files.outputs.all}}
+          vulture-args: --min-confidence 80 --ignore-names kwargs cls ${{steps.files.outputs.all}}
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,4 @@
 - Use SQLAlchemy 1.4 Declarative which is now integrated into the ORM to avoid deprecation warning
 - Start SQL engine and sessions using the future tag to prepare migration to SQLAlchemy 2.0
 - Updated a few python dependencies
+- Moved validation of sample's coverage file path to sample's pydantic model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Common test fixtures
 - Some badges on README page
 - Tests for cases and samples endpoints
+- Save samples with coverage files stored on a remote HTTP(s) server
 ### Fixed
 - Bugs preventing the gunicorn app to launch
 - Code to compose DB url to work when app is invoked from docker-compose

--- a/poetry.lock
+++ b/poetry.lock
@@ -785,6 +785,27 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "responses"
+version = "0.22.0"
+description = "A utility library for mocking out the `requests` Python library."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "responses-0.22.0-py3-none-any.whl", hash = "sha256:dcf294d204d14c436fddcc74caefdbc5764795a40ff4e6a7740ed8ddbf3294be"},
+    {file = "responses-0.22.0.tar.gz", hash = "sha256:396acb2a13d25297789a5866b4881cf4e46ffd49cc26c43ab1117f40b973102e"},
+]
+
+[package.dependencies]
+requests = ">=2.22.0,<3.0"
+toml = "*"
+types-toml = "*"
+urllib3 = ">=1.25.10"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "types-requests"]
+
+[[package]]
 name = "setuptools"
 version = "67.2.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -969,6 +990,18 @@ python-versions = ">=3.7"
 files = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.3"
+description = "Typing stubs for toml"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-toml-0.10.8.3.tar.gz", hash = "sha256:f37244eff4cd7eace9cb70d0bac54d3eba77973aa4ef26c271ac3d1c6503a48e"},
+    {file = "types_toml-0.10.8.3-py3-none-any.whl", hash = "sha256:a2286a053aea6ab6ff814659272b1d4a05d86a1dd52b807a87b23511993b46c5"},
 ]
 
 [[package]]
@@ -1172,4 +1205,4 @@ m1 = ["pyd4"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "dbbf355fae00c5f796aa72f193669c52c8dcc20febbf98939ea94e4a6662a085"
+content-hash = "1d3f088f511deaedb0081e6f11b464a30dd6df85fe803a85ca87b6383dd2d320"

--- a/poetry.lock
+++ b/poetry.lock
@@ -271,6 +271,18 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+
+[[package]]
 name = "fastapi"
 version = "0.68.2"
 description = "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
@@ -684,6 +696,24 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.10.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-mock-3.10.0.tar.gz", hash = "sha256:fbbdb085ef7c252a326fd8cdcac0aa3b1333d8811f131bdcc701002e1be7ed4f"},
+    {file = "pytest_mock-3.10.0-py3-none-any.whl", hash = "sha256:f4c973eeae0282963eb293eb173ce91b091a79c1334455acfac9ddee8a1c784b"},
+]
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dotenv"
 version = "0.21.1"
 description = "Read key-value pairs from a .env file and set them as environment variables"
@@ -783,27 +813,6 @@ urllib3 = ">=1.21.1,<1.27"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
-
-[[package]]
-name = "responses"
-version = "0.22.0"
-description = "A utility library for mocking out the `requests` Python library."
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "responses-0.22.0-py3-none-any.whl", hash = "sha256:dcf294d204d14c436fddcc74caefdbc5764795a40ff4e6a7740ed8ddbf3294be"},
-    {file = "responses-0.22.0.tar.gz", hash = "sha256:396acb2a13d25297789a5866b4881cf4e46ffd49cc26c43ab1117f40b973102e"},
-]
-
-[package.dependencies]
-requests = ">=2.22.0,<3.0"
-toml = "*"
-types-toml = "*"
-urllib3 = ">=1.25.10"
-
-[package.extras]
-tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "types-requests"]
 
 [[package]]
 name = "setuptools"
@@ -993,18 +1002,6 @@ files = [
 ]
 
 [[package]]
-name = "types-toml"
-version = "0.10.8.3"
-description = "Typing stubs for toml"
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "types-toml-0.10.8.3.tar.gz", hash = "sha256:f37244eff4cd7eace9cb70d0bac54d3eba77973aa4ef26c271ac3d1c6503a48e"},
-    {file = "types_toml-0.10.8.3-py3-none-any.whl", hash = "sha256:a2286a053aea6ab6ff814659272b1d4a05d86a1dd52b807a87b23511993b46c5"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -1106,6 +1103,23 @@ docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxc
 test = ["Cython (>=0.29.32,<0.30.0)", "aiohttp", "flake8 (>=3.9.2,<3.10.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=22.0.0,<22.1.0)", "pycodestyle (>=2.7.0,<2.8.0)"]
 
 [[package]]
+name = "validators"
+version = "0.20.0"
+description = "Python Data Validation for Humans™."
+category = "main"
+optional = false
+python-versions = ">=3.4"
+files = [
+    {file = "validators-0.20.0.tar.gz", hash = "sha256:24148ce4e64100a2d5e267233e23e7afeb55316b47d30faae7eb6e7292bc226a"},
+]
+
+[package.dependencies]
+decorator = ">=3.4.0"
+
+[package.extras]
+test = ["flake8 (>=2.4.0)", "isort (>=4.2.2)", "pytest (>=2.2.3)"]
+
+[[package]]
 name = "watchgod"
 version = "0.8.2"
 description = "Simple, modern file watching and code reload in python."
@@ -1205,4 +1219,4 @@ m1 = ["pyd4"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "1d3f088f511deaedb0081e6f11b464a30dd6df85fe803a85ca87b6383dd2d320"
+content-hash = "3e91cbcbdcf24f74ced9a16aba8d1ad354b49b38b9330f7ecf0572b7b8894c99"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ gunicorn = "^20.1.0"
 uvicorn = {extras = ["standard"], version = "^0.17.5"}
 requests = "^2.28.2"
 pytest-cov = "^4.0.0"
+responses = "^0.22.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ gunicorn = "^20.1.0"
 uvicorn = {extras = ["standard"], version = "^0.17.5"}
 requests = "^2.28.2"
 pytest-cov = "^4.0.0"
-responses = "^0.22.0"
+validators = "^0.20.0"
+pytest-mock = "^3.10.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/src/chanjo2/endpoints/samples.py
+++ b/src/chanjo2/endpoints/samples.py
@@ -1,16 +1,12 @@
 from typing import List
 
-from chanjo2.crud.samples import (
-    create_sample_in_case,
-    get_case_samples,
-    get_sample,
-    get_samples,
-)
+from chanjo2.crud.samples import create_sample_in_case, get_case_samples, get_sample, get_samples
 from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_d4 import local_resource_exists, remote_resource_exists
 from chanjo2.models.pydantic_models import Sample, SampleCreate
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
+from validators import url
 
 router = APIRouter()
 
@@ -22,7 +18,7 @@ def create_sample_for_case(
 ):
     """Add a sample to a case in the database."""
     d4_file_path = sample.coverage_file_path
-    if d4_file_path.startswith("http"):  # remote resource
+    if url(d4_file_path):
         if not remote_resource_exists(d4_file_path):
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -60,7 +56,5 @@ def read_sample(sample_name: str, db: Session = Depends(get_session)):
     """Return a sample by providing its name"""
     db_sample = get_sample(db, sample_name=sample_name)
     if db_sample is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Sample not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sample not found")
     return db_sample

--- a/src/chanjo2/endpoints/samples.py
+++ b/src/chanjo2/endpoints/samples.py
@@ -8,7 +8,7 @@ from chanjo2.crud.samples import (
     get_samples,
 )
 from chanjo2.dbutil import get_session
-from chanjo2.meta.handle_d4 import local_resource_exists, remote_resource_exists
+from chanjo2.meta.handle_d4 import local_resource_exists
 from chanjo2.models.pydantic_models import Sample, SampleCreate
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session

--- a/src/chanjo2/endpoints/samples.py
+++ b/src/chanjo2/endpoints/samples.py
@@ -22,7 +22,7 @@ def create_sample_for_case(
     db: Session = Depends(get_session),
 ):
     """Add a sample to a case in the database."""
-    d4_file_path = sample.coverage_file_path
+    d4_file_path: str = sample.coverage_file_path
     if not validators.url(d4_file_path) and not local_resource_exists(d4_file_path):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/src/chanjo2/endpoints/samples.py
+++ b/src/chanjo2/endpoints/samples.py
@@ -22,12 +22,13 @@ def create_sample_for_case(
 ):
     """Add a sample to a case in the database."""
     d4_file_path = sample.coverage_file_path
-    if d4_file_path.startswith("http") and not remote_resource_exists(d4_file_path):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Could not find remote resource: {d4_file_path}",
-        )
-    elif not local_resource_exists(d4_file_path):
+    if d4_file_path.startswith("http"):  # remote resource
+        if not remote_resource_exists(d4_file_path):
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Could not find remote resource: {d4_file_path}",
+            )
+    elif not local_resource_exists(d4_file_path):  # local resource
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Could not find local resource: {d4_file_path}",

--- a/src/chanjo2/endpoints/samples.py
+++ b/src/chanjo2/endpoints/samples.py
@@ -1,6 +1,11 @@
 from typing import List
 
-from chanjo2.crud.samples import create_sample_in_case, get_case_samples, get_sample, get_samples
+from chanjo2.crud.samples import (
+    create_sample_in_case,
+    get_case_samples,
+    get_sample,
+    get_samples,
+)
 from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_d4 import local_resource_exists, remote_resource_exists
 from chanjo2.models.pydantic_models import Sample, SampleCreate
@@ -54,5 +59,7 @@ def read_sample(sample_name: str, db: Session = Depends(get_session)):
     """Return a sample by providing its name"""
     db_sample = get_sample(db, sample_name=sample_name)
     if db_sample is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sample not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Sample not found"
+        )
     return db_sample

--- a/src/chanjo2/endpoints/samples.py
+++ b/src/chanjo2/endpoints/samples.py
@@ -1,13 +1,8 @@
-from pathlib import Path
 from typing import List
 
-from chanjo2.crud.samples import (
-    create_sample_in_case,
-    get_case_samples,
-    get_sample,
-    get_samples,
-)
+from chanjo2.crud.samples import create_sample_in_case, get_case_samples, get_sample, get_samples
 from chanjo2.dbutil import get_session
+from chanjo2.meta.handle_d4 import local_resource_exists, remote_resource_exists
 from chanjo2.models.pydantic_models import Sample, SampleCreate
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
@@ -21,12 +16,18 @@ def create_sample_for_case(
     db: Session = Depends(get_session),
 ):
     """Add a sample to a case in the database."""
-    d4_file_path: Path = Path(sample.coverage_file_path)
-    if not d4_file_path.is_file():
+    d4_file_path = sample.coverage_file_path
+    if d4_file_path.startswith("http") and not remote_resource_exists(d4_file_path):
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Could not find file: { d4_file_path}",
+            detail=f"Could not find remote resource: {d4_file_path}",
         )
+    elif not local_resource_exists(d4_file_path):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Could not find local resource: {d4_file_path}",
+        )
+
     db_sample = create_sample_in_case(db=db, sample=sample)
     if db_sample is None:
         raise HTTPException(
@@ -53,7 +54,5 @@ def read_sample(sample_name: str, db: Session = Depends(get_session)):
     """Return a sample by providing its name"""
     db_sample = get_sample(db, sample_name=sample_name)
     if db_sample is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Sample not found"
-        )
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Sample not found")
     return db_sample

--- a/src/chanjo2/endpoints/samples.py
+++ b/src/chanjo2/endpoints/samples.py
@@ -1,6 +1,5 @@
 from typing import List
 
-import validators
 from chanjo2.crud.samples import (
     create_sample_in_case,
     get_case_samples,
@@ -8,7 +7,6 @@ from chanjo2.crud.samples import (
     get_samples,
 )
 from chanjo2.dbutil import get_session
-from chanjo2.meta.handle_d4 import local_resource_exists
 from chanjo2.models.pydantic_models import Sample, SampleCreate
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
@@ -22,12 +20,6 @@ def create_sample_for_case(
     db: Session = Depends(get_session),
 ):
     """Add a sample to a case in the database."""
-    d4_file_path: str = sample.coverage_file_path
-    if not validators.url(d4_file_path) and not local_resource_exists(d4_file_path):
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Could not find resource: {d4_file_path}",
-        )
     db_sample = create_sample_in_case(db=db, sample=sample)
     if db_sample is None:
         raise HTTPException(

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -3,18 +3,6 @@ from pathlib import Path
 import requests
 
 
-def remote_resource_exists(resource_url: str) -> bool:
-    """Checks that a coverage file hosted on a remote server exists.
-    It checks that response has right headers without downloading the coverage file."""
-
-    try:
-        response = requests.head(resource_url)
-        return response.headers["content-type"] == "application/octet-stream"
-
-    except Exception as ex:
-        return False
-
-
 def local_resource_exists(resource_path: str) -> bool:
     """Checks that a coverage file hosted on the local disk exists."""
     return Path(resource_path).is_file()

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -1,6 +1,0 @@
-from pathlib import Path
-
-
-def local_resource_exists(resource_path: str) -> bool:
-    """Checks that a coverage file hosted on the local disk exists."""
-    return Path(resource_path).is_file()

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import requests
+from fastapi import status
+
+
+def remote_resource_exists(resource_url: str) -> bool:
+    """Checks that a coverage file hosted on a remote server exists."""
+    try:
+        response = requests.head(resource_url)
+        return response.status_code == status.HTTP_200_OK
+    except Exception as ex:
+        return False
+
+
+def local_resource_exists(resource_path: str) -> bool:
+    """Checks that a coverage file hosted on the local disk exists."""
+    return Path(resource_path).is_file()

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 
-import requests
-
 
 def local_resource_exists(resource_path: str) -> bool:
     """Checks that a coverage file hosted on the local disk exists."""

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -1,14 +1,12 @@
-import logging
 from pathlib import Path
 
 import requests
-
-LOG = logging.getLogger("uvicorn.access")
 
 
 def remote_resource_exists(resource_url: str) -> bool:
     """Checks that a coverage file hosted on a remote server exists.
     It checks that response has right headers without downloading the coverage file."""
+
     try:
         response = requests.head(resource_url)
         return response.headers["content-type"] == "application/octet-stream"

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -1,14 +1,18 @@
+import logging
 from pathlib import Path
 
 import requests
-from fastapi import status
+
+LOG = logging.getLogger("uvicorn.access")
 
 
 def remote_resource_exists(resource_url: str) -> bool:
-    """Checks that a coverage file hosted on a remote server exists."""
+    """Checks that a coverage file hosted on a remote server exists.
+    It checks that response has right headers without downloading the coverage file."""
     try:
         response = requests.head(resource_url)
-        return response.status_code == status.HTTP_200_OK
+        return response.headers["content-type"] == "application/octet-stream"
+
     except Exception as ex:
         return False
 

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -31,7 +31,7 @@ class SampleBase(BaseModel):
     coverage_file_path: str
 
     @validator("coverage_file_path", pre=True)
-    def validate_src(cls, value: Any) -> Any:
+    def validate_src(cls, value: str) -> Any:
         if not Path(value).is_file() and not validators.url(value):
             raise ValueError(WRONG_COVERAGE_FILE_MSG)
 

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, List, Optional
 
 import validators
-from pydantic import AnyUrl, BaseModel, validator
+from pydantic import BaseModel, validator
 
 WRONG_COVERAGE_FILE_MSG = (
     "coverage_file_path must be either an existing local file path or a URL"

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -31,7 +31,7 @@ class SampleBase(BaseModel):
     coverage_file_path: str
 
     @validator("coverage_file_path", pre=True)
-    def validate_src(cls, value: str) -> Any:
+    def validate_coverage_path(cls, value: str) -> Any:
         if not Path(value).is_file() and not validators.url(value):
             raise ValueError(WRONG_COVERAGE_FILE_MSG)
 

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -1,8 +1,14 @@
 from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from pathlib import Path
+from typing import Any, List, Optional
 
-from pydantic import BaseModel
+import validators
+from pydantic import AnyUrl, BaseModel, validator
+
+WRONG_COVERAGE_FILE_MSG = (
+    "coverage_file_path must be either an existing local file path or a URL"
+)
 
 
 class Builds(str, Enum):
@@ -23,6 +29,13 @@ class SampleBase(BaseModel):
     name: str
     display_name: str
     coverage_file_path: str
+
+    @validator("coverage_file_path", pre=True)
+    def validate_src(cls, value: Any) -> Any:
+        if not Path(value).is_file() and not validators.url(value):
+            raise ValueError(WRONG_COVERAGE_FILE_MSG)
+
+        return value
 
 
 class SampleCreate(SampleBase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,13 +110,13 @@ def db_case(raw_case) -> sql_models.Case:
 
 
 @pytest.fixture(name="db_sample")
-def db_sample(raw_case, raw_sample) -> sql_models.Sample:
+def db_sample(raw_case, raw_sample, coverage_path) -> sql_models.Sample:
     """Returns an object corresponding to a sql_models.Sample."""
     return sql_models.Sample(
         name=raw_sample["name"],
         display_name=raw_sample["display_name"],
         case_id=1,
-        coverage_file_path=COVERAGE_FILE,
+        coverage_file_path=str(coverage_path),
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ SAMPLE_DISPLAY_NAME = "sample_abc"
 CASES_ENDPOINT = "/cases/"
 SAMPLES_ENDPOINT = "/samples/"
 COVERAGE_FILE = "a_file.d4"
+REMOTE_COVERAGE_FILE = "https://a_remote_host/a_file.d4"
 COVERAGE_CONTENT = "content"
 
 engine = create_engine(TEST_DB, connect_args=DEMO_CONNECT_ARGS)
@@ -119,6 +120,12 @@ def db_sample(raw_case, raw_sample) -> sql_models.Sample:
 def coverage_file() -> str:
     """Returns the name of a mock coverage file."""
     return COVERAGE_FILE
+
+
+@pytest.fixture(name="remote_coverage_file")
+def remote_coverage_file() -> str:
+    """Returns the name of a mock coverage file."""
+    return REMOTE_COVERAGE_FILE
 
 
 @pytest.fixture(name="coverage_path")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,9 +94,13 @@ def raw_case() -> Dict[str, str]:
 
 
 @pytest.fixture(name="raw_sample")
-def raw_sample() -> Dict[str, str]:
+def raw_sample(raw_case) -> Dict[str, str]:
     """Returns a dictionary used to create a sample in the database."""
-    return {"name": SAMPLE_NAME, "display_name": SAMPLE_DISPLAY_NAME}
+    return {
+        "name": SAMPLE_NAME,
+        "display_name": SAMPLE_DISPLAY_NAME,
+        "case_name": raw_case["name"],
+    }
 
 
 @pytest.fixture(name="db_case")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,7 @@ def coverage_file() -> str:
 
 @pytest.fixture(name="remote_coverage_file")
 def remote_coverage_file() -> str:
-    """Returns the name of a mock coverage file."""
+    """Returns the URL of a mock coverage file."""
     return REMOTE_COVERAGE_FILE
 
 

--- a/tests/src/chanjo2/endpoints/test_samples.py
+++ b/tests/src/chanjo2/endpoints/test_samples.py
@@ -92,7 +92,6 @@ def test_create_sample_for_case_no_case(
     assert result["detail"] == f"Could not find a case with name: {raw_case['name']}"
 
 
-@responses.activate
 def test_create_sample_for_case_local_coverage_file(
     client: TestClient,
     coverage_path: PosixPath,

--- a/tests/src/chanjo2/endpoints/test_samples.py
+++ b/tests/src/chanjo2/endpoints/test_samples.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import sessionmaker
 
 
-def test_create_sample_for_case_no_coverage_file(
+def test_create_sample_for_case_no_local_coverage_file(
     client: TestClient,
     raw_case: Dict[str, str],
     raw_sample: Dict[str, str],
@@ -33,7 +33,34 @@ def test_create_sample_for_case_no_coverage_file(
     result = response.json()
 
     # WITH a meaningful message
-    assert result["detail"] == f"Could not find file: {coverage_file}"
+    assert result["detail"] == f"Could not find local resource: {coverage_file}"
+
+
+def test_create_sample_for_case_no_remote_coverage_file(
+    client: TestClient,
+    raw_case: Dict[str, str],
+    raw_sample: Dict[str, str],
+    samples_endpoint: str,
+    remote_coverage_file: str,
+):
+    """Test the function that creates a new sample for a case when no coverage file is specified."""
+    # GIVEN a json-like object containing the new sample data that is missing the coverage_file_path key/Value:
+    sample_data = {
+        "name": raw_sample["name"],
+        "display_name": raw_sample["display_name"],
+        "case_name": raw_case["name"],
+        "coverage_file_path": remote_coverage_file,
+    }
+
+    # WHEN the create_sample_for_case endpoint is used to create the case
+    response = client.post(samples_endpoint, json=sample_data)
+
+    # THEN the response should return error
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    result = response.json()
+
+    # WITH a meaningful message
+    assert result["detail"] == f"Could not find remote resource: {remote_coverage_file}"
 
 
 def test_create_sample_for_case_no_case(

--- a/tests/src/chanjo2/endpoints/test_samples.py
+++ b/tests/src/chanjo2/endpoints/test_samples.py
@@ -44,7 +44,7 @@ def test_create_sample_for_case_no_remote_coverage_file(
     samples_endpoint: str,
     remote_coverage_file: str,
 ):
-    """Test the function that creates a new sample for a case when no coverage file is specified."""
+    """Test the function that creates a new sample for a case with remote coverage file not existing."""
     # GIVEN a json-like object containing the new sample data that is missing the coverage_file_path key/Value:
     sample_data = {
         "name": raw_sample["name"],

--- a/tests/src/chanjo2/endpoints/test_samples.py
+++ b/tests/src/chanjo2/endpoints/test_samples.py
@@ -1,8 +1,7 @@
 from pathlib import PosixPath
 from typing import Dict, Type
 
-from chanjo2.endpoints.samples import validators
-from chanjo2.models.pydantic_models import Sample
+from chanjo2.models.pydantic_models import WRONG_COVERAGE_FILE_MSG, Sample, validators
 from chanjo2.models.sql_models import Case as SQLCase
 from chanjo2.models.sql_models import Sample as SQLSample
 from fastapi import status
@@ -35,7 +34,7 @@ def test_create_sample_for_case_no_local_coverage_file(
     result = response.json()
 
     # WITH a meaningful message
-    assert result["detail"] == f"Could not find resource: {coverage_file}"
+    assert result["detail"][0]["msg"] == WRONG_COVERAGE_FILE_MSG
 
 
 def test_create_sample_for_case_no_remote_coverage_file(
@@ -62,7 +61,7 @@ def test_create_sample_for_case_no_remote_coverage_file(
 
     # WITH a meaningful message
     result = response.json()
-    assert result["detail"] == f"Could not find resource: {remote_coverage_file}"
+    assert result["detail"][0]["msg"] == WRONG_COVERAGE_FILE_MSG
 
 
 def test_create_sample_for_case_no_case(

--- a/tests/src/chanjo2/endpoints/test_samples.py
+++ b/tests/src/chanjo2/endpoints/test_samples.py
@@ -19,15 +19,10 @@ def test_create_sample_for_case_no_local_coverage_file(
 ):
     """Test the function that creates a new sample for a case when no coverage file is specified."""
     # GIVEN a json-like object containing the new sample data that is missing the coverage_file_path key/Value:
-    sample_data = {
-        "name": raw_sample["name"],
-        "display_name": raw_sample["display_name"],
-        "case_name": raw_case["name"],
-        "coverage_file_path": coverage_file,
-    }
+    raw_sample["coverage_file_path"] = coverage_file
 
     # WHEN the create_sample_for_case endpoint is used to create the case
-    response = client.post(samples_endpoint, json=sample_data)
+    response = client.post(samples_endpoint, json=raw_sample)
 
     # THEN the response should return error
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -46,15 +41,10 @@ def test_create_sample_for_case_no_remote_coverage_file(
 ):
     """Test the function that creates a new sample for a case with remote coverage file not existing."""
     # GIVEN a json-like object containing the new sample data that is missing the coverage_file_path key/Value:
-    sample_data = {
-        "name": raw_sample["name"],
-        "display_name": raw_sample["display_name"],
-        "case_name": raw_case["name"],
-        "coverage_file_path": remote_coverage_file,
-    }
+    raw_sample["coverage_file_path"] = remote_coverage_file
 
     # WHEN the create_sample_for_case endpoint is used to create the case
-    response = client.post(samples_endpoint, json=sample_data)
+    response = client.post(samples_endpoint, json=raw_sample)
 
     # THEN the response should return error
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -74,15 +64,10 @@ def test_create_sample_for_case_no_case(
     """Test the function that creates a new sample for a case when no case was previously saved in the database."""
 
     # GIVEN a json-like object containing the new sample data:
-    sample_data = {
-        "name": raw_sample["name"],
-        "display_name": raw_sample["display_name"],
-        "case_name": raw_case["name"],
-        "coverage_file_path": str(coverage_path),
-    }
+    raw_sample["coverage_file_path"] = str(coverage_path)
 
     # WHEN the create_sample_for_case endpoint is used to create the case
-    response = client.post(samples_endpoint, json=sample_data)
+    response = client.post(samples_endpoint, json=raw_sample)
 
     # THEN the response should return error
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -106,15 +91,10 @@ def test_create_sample_for_case_local_coverage_file(
     saved_case = client.post(cases_endpoint, json=raw_case).json()
 
     # GIVEN a json-like object containing the new sample data:
-    sample_data = {
-        "name": raw_sample["name"],
-        "display_name": raw_sample["display_name"],
-        "case_name": raw_case["name"],
-        "coverage_file_path": str(coverage_path),
-    }
+    raw_sample["coverage_file_path"] = str(coverage_path)
 
     # WHEN the create_sample_for_case endpoint is used to create the case
-    response = client.post(samples_endpoint, json=sample_data)
+    response = client.post(samples_endpoint, json=raw_sample)
 
     # THEN the response shour return success
     assert response.status_code == status.HTTP_200_OK
@@ -143,15 +123,10 @@ def test_create_sample_for_case_remote_coverage_file(
     saved_case = client.post(cases_endpoint, json=raw_case).json()
 
     # GIVEN a json-like object containing the new sample data:
-    sample_data = {
-        "name": raw_sample["name"],
-        "display_name": raw_sample["display_name"],
-        "case_name": raw_case["name"],
-        "coverage_file_path": remote_coverage_file,
-    }
+    raw_sample["coverage_file_path"] = remote_coverage_file
 
     # WHEN the create_sample_for_case endpoint is used to create the case
-    response = client.post(samples_endpoint, json=sample_data)
+    response = client.post(samples_endpoint, json=raw_sample)
 
     # THEN the response shour return success
     assert response.status_code == status.HTTP_200_OK

--- a/tests/src/chanjo2/endpoints/test_samples.py
+++ b/tests/src/chanjo2/endpoints/test_samples.py
@@ -91,7 +91,7 @@ def test_create_sample_for_case_no_case(
     assert result["detail"] == f"Could not find a case with name: {raw_case['name']}"
 
 
-def test_create_sample_for_case(
+def test_create_sample_for_case_local_coverage_file(
     client: TestClient,
     coverage_path: PosixPath,
     raw_case: Dict[str, str],
@@ -99,7 +99,7 @@ def test_create_sample_for_case(
     cases_endpoint: str,
     samples_endpoint: str,
 ):
-    """Test the function that creates a new sample for a case when provided sample info is complete."""
+    """Test the function that creates a new sample for a case with a local coverage file."""
 
     # GIVEN a case that exists in the database:
     saved_case = client.post(cases_endpoint, json=raw_case).json()


### PR DESCRIPTION
### This PR adds | fixes:
- fix #51 - Coverage files can be also stored on a remote server (cloud) and not just locally. This applies when creating a sample
- Added a tests as well

### How to test:
- Create a case sample with a coverage file which is a URL to a real HTTP-hosted resource (for example this one: https://figshare.com/articles/online_resource/Untitled_Item/22085672)

### Expected outcome:
- [x] The file should be saved successfully

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
