### PR TITLE
Multi-interval coverage endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Demo data (D4 file containing coverage data for a panel of 4 genes)
 - Endpoint for coverage queries over a single interval of a provided D4 file
 - Demo case and demo sample loaded with demo instance startup
+- Endpoint for coverage queries over the intervals of a BED file
 ### Fixed
 - Bugs preventing the gunicorn app to launch
 - Code to compose DB url to work when app is invoked from docker-compose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,3 +36,4 @@
 - Updated a few python dependencies
 - Moved validation of sample's coverage file path to sample's pydantic model
 - Installing the pyd4 module as a requirement of this repository
+- Moved the endpoints contants to a class in test fixtures

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -68,7 +68,7 @@ def read_intervals(coverage_file_path: str, bed_file: bytes = File(...)):
         )
     except:
         raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=WRONG_BED_FILE_MSG,
         )
 

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -2,7 +2,12 @@ from typing import List, Optional, Tuple
 
 from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_bed import parse_bed
-from chanjo2.meta.handle_d4 import interval_coverage, intervals_coverage, set_d4_file, set_interval
+from chanjo2.meta.handle_d4 import (
+    interval_coverage,
+    intervals_coverage,
+    set_d4_file,
+    set_interval,
+)
 from chanjo2.models.pydantic_models import (
     WRONG_BED_FILE_MSG,
     WRONG_COVERAGE_FILE_MSG,

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -55,7 +55,7 @@ def read_intervals(coverage_file_path: str, bed_file: bytes = File(...)):
     """Return coverage on the given intervals for a D4 resource located on the disk or on a remote server."""
 
     try:
-        d4_file: D4File = set_d4_file(coverage_file_path)
+        d4_file: D4File = set_d4_file(coverage_file_path=coverage_file_path)
     except:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -63,7 +63,9 @@ def read_intervals(coverage_file_path: str, bed_file: bytes = File(...)):
         )
 
     try:
-        intervals: List[Tuple[str, Optional[int], Optional[int]]] = parse_bed(bed_file)
+        intervals: List[Tuple[str, Optional[int], Optional[int]]] = parse_bed(
+            bed_file=bed_file
+        )
     except:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -50,7 +50,7 @@ def read_single_interval(
     )
 
 
-@router.post("/intervals/", response_model=List)
+@router.post("/intervals/", response_model=List[CoverageInterval])
 def read_intervals(coverage_file_path: str, bed_file: bytes = File(...)):
     """Return coverage on the given intervals for a D4 resource located on the disk or on a remote server."""
 

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -1,9 +1,14 @@
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 from chanjo2.dbutil import get_session
-from chanjo2.meta.handle_d4 import interval_coverage, set_d4_file, set_interval
-from chanjo2.models.pydantic_models import WRONG_COVERAGE_FILE_MSG, CoverageInterval
-from fastapi import APIRouter, Depends, HTTPException, status
+from chanjo2.meta.handle_bed import parse_bed
+from chanjo2.meta.handle_d4 import interval_coverage, intervals_coverage, set_d4_file, set_interval
+from chanjo2.models.pydantic_models import (
+    WRONG_BED_FILE_MSG,
+    WRONG_COVERAGE_FILE_MSG,
+    CoverageInterval,
+)
+from fastapi import APIRouter, Depends, File, HTTPException, status
 from pyd4 import D4File
 from sqlmodel import Session, select
 
@@ -38,3 +43,26 @@ def read_single_interval(
         interval=interval,
         mean_coverage=interval_coverage(d4_file, interval),
     )
+
+
+@router.post("/intervals/", response_model=List)
+def read_intervals(coverage_file_path: str, bed_file: bytes = File(...)):
+    """Return coverage on the given intervals for a D4 resource located on the disk or on a remote server."""
+
+    try:
+        d4_file: D4File = set_d4_file(coverage_file_path)
+    except:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=WRONG_COVERAGE_FILE_MSG,
+        )
+
+    try:
+        intervals: List[Tuple[str, Optional[int], Optional[int]]] = parse_bed(bed_file)
+    except:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=WRONG_BED_FILE_MSG,
+        )
+
+    return intervals_coverage(d4_file=d4_file, intervals=intervals)

--- a/src/chanjo2/meta/handle_bed.py
+++ b/src/chanjo2/meta/handle_bed.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 
 def parse_bed(bed_file: bytes) -> List[Tuple[str, int, int]]:
     """Parses a bed file containing genomic coordinates."""
-    intervals: List[tuple[str, int, int]] = []
+    intervals: List[Tuple[str, int, int]] = []
     for line_byte in bed_file.rsplit(b"\n"):
         if len(line_byte) > 0 and not line_byte.startswith(b"#"):
             intervals.append(bed_line_to_region(bytes_line=line_byte))
@@ -13,4 +13,4 @@ def parse_bed(bed_file: bytes) -> List[Tuple[str, int, int]]:
 def bed_line_to_region(bytes_line: bytes) -> Tuple[str, int, int]:
     """Returns a single genomic interval corresponding to a bed file line."""
     line_elements: List = bytes_line.decode("utf-8").rsplit("\t")
-    return line_elements[0], int(line_elements[1]), int(line_elements[2])
+    return (line_elements[0], int(line_elements[1]), int(line_elements[2]))

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -1,5 +1,6 @@
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
+from chanjo2.models.pydantic_models import CoverageInterval
 from pyd4 import D4File
 
 
@@ -15,8 +16,26 @@ def set_d4_file(coverage_file_path: str) -> D4File:
     return D4File(coverage_file_path)
 
 
-def interval_coverage(
-    d4_file: D4File, interval: Tuple[str, Optional[int], Optional[int]]
-) -> float:
+def interval_coverage(d4_file: D4File, interval: Tuple[str, Optional[int], Optional[int]]) -> float:
     """Return coverage over a single interval of a D4 file."""
     return d4_file.mean([interval])[0]
+
+
+def intervals_coverage(
+    d4_file: D4File, intervals: List[Tuple[str, int, int]]
+) -> List[CoverageInterval]:
+    """Return coverage over a list of intervals"""
+    intervals_cov: List[CoverageInterval] = []
+    for interval in intervals:
+        intervals_cov.append(
+            CoverageInterval(
+                **{
+                    "chromosome": interval[0],
+                    "start": interval[1],
+                    "end": interval[2],
+                    "mean_coverage": d4_file.mean(interval),
+                }
+            )
+        )
+
+    return intervals_cov

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -16,7 +16,9 @@ def set_d4_file(coverage_file_path: str) -> D4File:
     return D4File(coverage_file_path)
 
 
-def interval_coverage(d4_file: D4File, interval: Tuple[str, Optional[int], Optional[int]]) -> float:
+def interval_coverage(
+    d4_file: D4File, interval: Tuple[str, Optional[int], Optional[int]]
+) -> float:
     """Return coverage over a single interval of a D4 file."""
     return d4_file.mean([interval])[0]
 

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -26,7 +26,7 @@ def interval_coverage(
 def intervals_coverage(
     d4_file: D4File, intervals: List[Tuple[str, int, int]]
 ) -> List[CoverageInterval]:
-    """Return coverage over a list of intervals"""
+    """Return coverage over a list of intervals."""
     intervals_cov: List[CoverageInterval] = []
     for interval in intervals:
         intervals_cov.append(

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -39,5 +39,4 @@ def intervals_coverage(
                 }
             )
         )
-
     return intervals_cov

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -31,12 +31,10 @@ def intervals_coverage(
     for interval in intervals:
         intervals_cov.append(
             CoverageInterval(
-                **{
-                    "chromosome": interval[0],
-                    "start": interval[1],
-                    "end": interval[2],
-                    "mean_coverage": d4_file.mean(interval),
-                }
+                chromosome=interval[0],
+                start=interval[1],
+                end=interval[2],
+                mean_coverage=d4_file.mean(interval),
             )
         )
     return intervals_cov

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -6,7 +6,9 @@ from typing import Any, List, Optional
 import validators
 from pydantic import BaseModel, validator
 
-WRONG_COVERAGE_FILE_MSG = "Coverage_file_path must be either an existing local file path or a URL"
+WRONG_COVERAGE_FILE_MSG = (
+    "Coverage_file_path must be either an existing local file path or a URL"
+)
 WRONG_BED_FILE_MSG = "Provided intervals files is not a valid BED file"
 
 

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, validator
 WRONG_COVERAGE_FILE_MSG = (
     "Coverage_file_path must be either an existing local file path or a URL"
 )
-WRONG_BED_FILE_MSG = "Provided intervals files is not a valid BED file"
+WRONG_BED_FILE_MSG: str = "Provided intervals files is not a valid BED file"
 
 
 class Builds(str, Enum):

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -6,7 +6,7 @@ from typing import Any, List, Optional
 import validators
 from pydantic import BaseModel, validator
 
-WRONG_COVERAGE_FILE_MSG = (
+WRONG_COVERAGE_FILE_MSG: str = (
     "Coverage_file_path must be either an existing local file path or a URL"
 )
 WRONG_BED_FILE_MSG: str = "Provided intervals files is not a valid BED file"

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -6,9 +6,8 @@ from typing import Any, List, Optional
 import validators
 from pydantic import BaseModel, validator
 
-WRONG_COVERAGE_FILE_MSG = (
-    "Coverage_file_path must be either an existing local file path or a URL"
-)
+WRONG_COVERAGE_FILE_MSG = "Coverage_file_path must be either an existing local file path or a URL"
+WRONG_BED_FILE_MSG = "Provided intervals files is not a valid BED file"
 
 
 class Builds(str, Enum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,8 +187,8 @@ def interval_query(bed_interval) -> Dict:
 
 
 @pytest.fixture(name="real_d4_query")
-def real_d4_query(real_coverage_path) -> Dict:
-    """Returns a query dictionary with genomic coordinates."""
+def real_d4_query(real_coverage_path) -> Dict[str, str]:
+    """Returns a query dictionary with the path to an existing D4 coverage file."""
 
     return {
         "coverage_file_path": real_coverage_path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -147,7 +147,7 @@ def coverage_path(tmp_path) -> PosixPath:
 
 @pytest.fixture(name="bed_path")
 def bed_path(tmp_path) -> PosixPath:
-    """Returns malformed bed file."""
+    """Return malformed BED file."""
 
     tf = tmp_path / BED_FILE
     tf.touch()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,21 +142,21 @@ def remote_coverage_file() -> str:
 def coverage_path(tmp_path) -> PosixPath:
     """Returns a mock temp coverage file."""
 
-    tf: PosixPath = tmp_path / COVERAGE_FILE
-    tf.touch()
-    tf.write_text(CONTENT)
-    return tf
+    tmp_coverage_file: PosixPath = tmp_path / COVERAGE_FILE
+    tmp_coverage_file.touch()
+    tmp_coverage_file.write_text(CONTENT)
+    return tmp_coverage_file
 
 
 @pytest.fixture(name="bed_path_malformed")
 def bed_path_malformed(tmp_path) -> PosixPath:
     """Return malformed BED file."""
 
-    tf: PosixPath = tmp_path / BED_FILE
-    tf.touch()
-    tf.write_text(CONTENT)
+    tmp_bed_file: PosixPath = tmp_path / BED_FILE
+    tmp_bed_file.touch()
+    tmp_bed_file.write_text(CONTENT)
 
-    return tf
+    return tmp_bed_file
 
 
 @pytest.fixture(name="real_coverage_path")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,17 +142,17 @@ def remote_coverage_file() -> str:
 def coverage_path(tmp_path) -> PosixPath:
     """Returns a mock temp coverage file."""
 
-    tf = tmp_path / COVERAGE_FILE
+    tf: PosixPath = tmp_path / COVERAGE_FILE
     tf.touch()
     tf.write_text(CONTENT)
     return tf
 
 
-@pytest.fixture(name="bed_path")
-def bed_path(tmp_path) -> PosixPath:
+@pytest.fixture(name="bed_path_malformed")
+def bed_path_malformed(tmp_path) -> PosixPath:
     """Return malformed BED file."""
 
-    tf = tmp_path / BED_FILE
+    tf: PosixPath = tmp_path / BED_FILE
     tf.touch()
     tf.write_text(CONTENT)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,8 +126,8 @@ def db_sample(raw_case, raw_sample, coverage_path) -> sql_models.Sample:
     )
 
 
-@pytest.fixture(name="coverage_file")
-def coverage_file() -> str:
+@pytest.fixture(name="mock_coverage_file")
+def mock_coverage_file() -> str:
     """Returns the name of a mock coverage file."""
     return COVERAGE_FILE
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -73,18 +73,6 @@ def session_fixture() -> sessionmaker:
         db.close()
 
 
-@pytest.fixture(name="samples_endpoint")
-def samples_endpoint() -> str:
-    """Returns samples app endpoint."""
-    return SAMPLES_ENDPOINT
-
-
-@pytest.fixture(name="interval_endpoint")
-def interval_endpoint() -> str:
-    """Returns interval app endpoint."""
-    return INTERVAL_ENDPOINT
-
-
 @pytest.fixture(name="client")
 def client_fixture(session) -> TestClient:
     """Returns a fastapi.testclient.TestClient used to test the app endpoints."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,11 +46,13 @@ class Helpers:
 
 @pytest.fixture
 def endpoints() -> Endpoints:
+    """returns an instance of the class Endpoints"""
     return Endpoints
 
 
 @pytest.fixture
 def helpers() -> Helpers:
+    """returns an instance of the class Helpers"""
     return Helpers
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engin
 
 
 class Endpoints:
-    """Contains all the app endpoints used in testing"""
+    """Contains all the app endpoints used in testing."""
 
     CASES = "/cases/"
     SAMPLES = "/samples/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,7 +142,6 @@ def coverage_path(tmp_path) -> PosixPath:
     tf = tmp_path / COVERAGE_FILE
     tf.touch()
     tf.write_text(CONTENT)
-
     return tf
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from pathlib import PosixPath
 from typing import Dict, Tuple
 
@@ -25,7 +26,7 @@ engine = create_engine(TEST_DB, connect_args=DEMO_CONNECT_ARGS)
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 
-class Endpoints:
+class Endpoints(str, Enum):
     """Contains all the app endpoints used in testing."""
 
     CASES = "/cases/"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,15 +16,21 @@ CASE_NAME = "123"
 CASE_DISPLAY_NAME = "case_123"
 SAMPLE_NAME = "abc"
 SAMPLE_DISPLAY_NAME = "sample_abc"
-CASES_ENDPOINT = "/cases/"
-SAMPLES_ENDPOINT = "/samples/"
-INTERVAL_ENDPOINT = "/intervals/interval/"
 COVERAGE_FILE = "a_file.d4"
 REMOTE_COVERAGE_FILE = "https://a_remote_host/a_file.d4"
 COVERAGE_CONTENT = "content"
 
 engine = create_engine(TEST_DB, connect_args=DEMO_CONNECT_ARGS)
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+class Endpoints:
+    """Contains all the app endpoints used in testing"""
+
+    CASES = "/cases/"
+    SAMPLES = "/samples/"
+    INTERVAL = "/intervals/interval/"
+    INTERVALS = "/intervals/"
 
 
 class Helpers:
@@ -34,6 +40,11 @@ class Helpers:
         session.add(item)
         session.commit()
         session.refresh(item)
+
+
+@pytest.fixture
+def endpoints() -> Endpoints:
+    return Endpoints
 
 
 @pytest.fixture
@@ -60,12 +71,6 @@ def session_fixture() -> sessionmaker:
         yield db
     finally:
         db.close()
-
-
-@pytest.fixture(name="cases_endpoint")
-def cases_endpoint() -> str:
-    """Returns cases app endpoint."""
-    return CASES_ENDPOINT
 
 
 @pytest.fixture(name="samples_endpoint")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ SAMPLE_DISPLAY_NAME = "sample_abc"
 COVERAGE_FILE = "a_file.d4"
 BED_FILE = "a_file.bed"
 REMOTE_COVERAGE_FILE = "https://a_remote_host/a_file.d4"
-CONTENT = "content"
+CONTENT: str = "content"
 
 engine = create_engine(TEST_DB, connect_args=DEMO_CONNECT_ARGS)
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,8 +17,9 @@ CASE_DISPLAY_NAME = "case_123"
 SAMPLE_NAME = "abc"
 SAMPLE_DISPLAY_NAME = "sample_abc"
 COVERAGE_FILE = "a_file.d4"
+BED_FILE = "a_file.bed"
 REMOTE_COVERAGE_FILE = "https://a_remote_host/a_file.d4"
-COVERAGE_CONTENT = "content"
+CONTENT = "content"
 
 engine = create_engine(TEST_DB, connect_args=DEMO_CONNECT_ARGS)
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -140,7 +141,18 @@ def coverage_path(tmp_path) -> PosixPath:
 
     tf = tmp_path / COVERAGE_FILE
     tf.touch()
-    tf.write_text(COVERAGE_CONTENT)
+    tf.write_text(CONTENT)
+
+    return tf
+
+
+@pytest.fixture(name="bed_path")
+def bed_path(tmp_path) -> PosixPath:
+    """Returns malformed bed file."""
+
+    tf = tmp_path / BED_FILE
+    tf.touch()
+    tf.write_text(CONTENT)
 
     return tf
 
@@ -169,4 +181,13 @@ def interval_query(bed_interval) -> Dict:
         "chromosome": bed_interval[0],
         "start": bed_interval[1],
         "end": bed_interval[2],
+    }
+
+
+@pytest.fixture(name="real_d4_query")
+def real_d4_query(real_coverage_path) -> Dict:
+    """Returns a query dictionary with genomic coordinates."""
+
+    return {
+        "coverage_file_path": real_coverage_path,
     }

--- a/tests/src/chanjo2/endpoints/test_cases.py
+++ b/tests/src/chanjo2/endpoints/test_cases.py
@@ -7,13 +7,13 @@ from fastapi.testclient import TestClient
 from sqlalchemy.orm import sessionmaker
 
 
-def test_create_case(client: TestClient, raw_case: Dict[str, str], cases_endpoint: str):
+def test_create_case(client: TestClient, raw_case: Dict[str, str], endpoints: Type):
     """Test the endpoint used to create a new case."""
     # GIVEN a json-like object containing the new case data:
     case_data = raw_case
 
     # WHEN the create_case endpoint is used to create the case
-    response = client.post(cases_endpoint, json=case_data)
+    response = client.post(endpoints.CASES, json=case_data)
 
     # THEN it should return success
     assert response.status_code == status.HTTP_200_OK
@@ -28,7 +28,7 @@ def test_read_cases(
     client: TestClient,
     session: sessionmaker,
     db_case: SQLCase,
-    cases_endpoint: str,
+    endpoints: Type,
     helpers: Type,
 ):
     """Test the endpoint returning all cases found in the database."""
@@ -37,7 +37,7 @@ def test_read_cases(
     helpers.session_commit_item(session, db_case)
 
     # THEN the read_cases endpoint should return the case
-    response = client.get(cases_endpoint)
+    response = client.get(endpoints.CASES)
     assert response.status_code == status.HTTP_200_OK
     result = response.json()
     assert len(result) == 1
@@ -48,7 +48,7 @@ def test_read_case(
     client: TestClient,
     session: sessionmaker,
     db_case: SQLCase,
-    cases_endpoint: str,
+    endpoints: Type,
     helpers: Type,
 ):
     """Test the endpoint that returns a specific case."""
@@ -57,7 +57,7 @@ def test_read_case(
     helpers.session_commit_item(session, db_case)
 
     # WHEN sending a GET request to retrieve the specific case using its name
-    response = client.get(f"{cases_endpoint}{db_case.name}")
+    response = client.get(f"{endpoints.CASES}{db_case.name}")
 
     # THEN it should  return success
     assert response.status_code == status.HTTP_200_OK

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -108,7 +108,7 @@ def test_read_intervals_d4_not_found(
     assert result["detail"] == WRONG_COVERAGE_FILE_MSG
 
 
-def test_read_intervals_wrong_bed_file(
+def test_read_intervals_malformed_bed_file(
     bed_path_malformed: PosixPath,
     real_coverage_path: str,
     client: TestClient,
@@ -125,7 +125,7 @@ def test_read_intervals_wrong_bed_file(
 
     # THEN a request to the endpoint should return 404 error
     response = client.post(endpoints.INTERVALS, params=real_d4_query, files=files)
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # AND show a meaningful message
     result = response.json()

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -1,10 +1,12 @@
+from typing import Type
+
 from chanjo2.models.pydantic_models import WRONG_COVERAGE_FILE_MSG, CoverageInterval
 from fastapi import status
 from fastapi.testclient import TestClient
 
 
 def test_read_single_interval_d4_not_found(
-    client: TestClient, coverage_file: str, interval_endpoint: str, interval_query: dict
+    client: TestClient, coverage_file: str, endpoints: Type, interval_query: dict
 ):
     """Test the function that returns the coverage over an interval of a D4 file.
     Testing with a D4 file not found on disk or on a remote server."""
@@ -13,7 +15,7 @@ def test_read_single_interval_d4_not_found(
     interval_query["coverage_file_path"] = coverage_file
 
     # THEN a request to the read_single_interval should return 404 error
-    response = client.get(interval_endpoint, params=interval_query)
+    response = client.get(endpoints.INTERVAL, params=interval_query)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
     # THEN show a meaningful message
@@ -24,7 +26,7 @@ def test_read_single_interval_d4_not_found(
 def test_read_single_interval(
     client: TestClient,
     real_coverage_path: str,
-    interval_endpoint: str,
+    endpoints: Type,
     interval_query: dict,
 ):
     """Test the function that returns the coverage over an interval of a D4 file."""
@@ -33,7 +35,7 @@ def test_read_single_interval(
     interval_query["coverage_file_path"] = real_coverage_path
 
     # THEN a request to the read_single_interval should be successful
-    response = client.get(interval_endpoint, params=interval_query)
+    response = client.get(endpoints.INTERVAL, params=interval_query)
     assert response.status_code == status.HTTP_200_OK
 
     # THEN the mean coverage over the interval should be returned
@@ -50,7 +52,7 @@ def test_read_single_interval(
 def test_read_single_chromosome(
     client: TestClient,
     real_coverage_path: str,
-    interval_endpoint: str,
+    endpoints: Type,
     interval_query: dict,
 ):
     """Test the function that returns the coverage over an entire chsomosome of a D4 file."""
@@ -63,7 +65,7 @@ def test_read_single_chromosome(
     interval_query["coverage_file_path"] = real_coverage_path
 
     # THEN a request to the read_single_intervalshould be successful
-    response = client.get(interval_endpoint, params=interval_query)
+    response = client.get(endpoints.INTERVAL, params=interval_query)
     assert response.status_code == status.HTTP_200_OK
 
     # AND the mean coverage over the entire chromosome should be present in the result

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -98,7 +98,7 @@ def test_read_intervals_d4_not_found(
     # WHEN using a query for genomic intervals with a D4 not present on disk
     d4_query = {"coverage_file_path": coverage_file}
 
-    # THEN a request to the endpoint should return 404 error (not found)
+    # THEN a request to the endpoint should return 404 error
     response = client.post(endpoints.INTERVALS, params=d4_query, files=files)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -143,7 +143,7 @@ def test_read_intervals(real_coverage_path: str, client: TestClient, endpoints: 
     # WHEN using a query for genomic intervals over an existing d4 file
     d4_query = {"coverage_file_path": real_coverage_path}
 
-    # THEN a request to the endpoint should be successful
+    # THEN a request to the endpoint should return HTTP 200
     response = client.post(endpoints.INTERVALS, params=d4_query, files=files)
     assert response.status_code == status.HTTP_200_OK
 

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -84,7 +84,9 @@ def test_read_single_chromosome(
     assert coverage_data.end is None
 
 
-def test_read_intervals_d4_not_found(coverage_file: str, client: TestClient, endpoints: Type):
+def test_read_intervals_d4_not_found(
+    coverage_file: str, client: TestClient, endpoints: Type
+):
     """Test the function that returns the coverage over multiple intervals of a D4 file.
     Testing with a D4 file not found on disk or on a remote server."""
 

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -109,14 +109,17 @@ def test_read_intervals_d4_not_found(
 
 
 def test_read_intervals_wrong_bed_file(
-    bed_path: PosixPath, real_coverage_path: str, client: TestClient, endpoints: Type
+    bed_path_malformed: PosixPath,
+    real_coverage_path: str,
+    client: TestClient,
+    endpoints: Type,
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file.
     Testing with a BED file that is not correctly formatted."""
 
     # GIVEN a malformed BED file
     files = [
-        ("bed_file", ("a_file.bed", open(bed_path, "rb"))),
+        ("bed_file", ("a_file.bed", open(bed_path_malformed, "rb"))),
     ]
 
     # WHEN using a query for genomic intervals over an existing d4 file

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -122,7 +122,7 @@ def test_read_intervals_wrong_bed_file(
     # WHEN using a query for genomic intervals over an existing d4 file
     d4_query = {"coverage_file_path": real_coverage_path}
 
-    # THEN a request to the endpoint should return 404 error (not found)
+    # THEN a request to the endpoint should return 404 error
     response = client.post(endpoints.INTERVALS, params=d4_query, files=files)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 

--- a/tests/src/chanjo2/endpoints/test_samples.py
+++ b/tests/src/chanjo2/endpoints/test_samples.py
@@ -15,11 +15,11 @@ def test_create_sample_for_case_no_local_coverage_file(
     raw_case: Dict[str, str],
     raw_sample: Dict[str, str],
     endpoints: Type,
-    coverage_file: str,
+    mock_coverage_file: str,
 ):
     """Test the function that creates a new sample for a case when no coverage file is specified."""
     # GIVEN a json-like object containing the new sample data that is missing the coverage_file_path key/Value:
-    raw_sample["coverage_file_path"] = coverage_file
+    raw_sample["coverage_file_path"] = mock_coverage_file
 
     # WHEN the create_sample_for_case endpoint is used to create the case
     response = client.post(endpoints.SAMPLES, json=raw_sample)


### PR DESCRIPTION
### This PR adds | fixes:
- Created an endpoint that accepts a bed file with genomic coordinates and a d4 files
- It returns the mean coverage over all the specified intervals (fix #58 )

### How to test:
Run a demo instance of the app and test the `intervals` endpoint with:
- A .d4 file (can be a real one or the one provided in the demo folder)
- a BED file (use the one provided in demo folder

### Expected outcome:
- [x] The endpoint should calculate and return coverage info

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
