### PR TITLE
Rename 2 intervals endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,4 @@
 - Moved validation of sample's coverage file path to sample's pydantic model
 - Installing the pyd4 module as a requirement of this repository
 - Moved the endpoints contants to a class in test fixtures
+- More explicit names for two endpoints

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -2,7 +2,12 @@ from typing import List, Optional, Tuple
 
 from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_bed import parse_bed
-from chanjo2.meta.handle_d4 import interval_coverage, intervals_coverage, set_d4_file, set_interval
+from chanjo2.meta.handle_d4 import (
+    interval_coverage,
+    intervals_coverage,
+    set_d4_file,
+    set_interval,
+)
 from chanjo2.models.pydantic_models import (
     WRONG_BED_FILE_MSG,
     WRONG_COVERAGE_FILE_MSG,
@@ -45,7 +50,9 @@ def d4_interval_coverage(
     )
 
 
-@router.post("/intervals/coverage/d4/interval_file/", response_model=List[CoverageInterval])
+@router.post(
+    "/intervals/coverage/d4/interval_file/", response_model=List[CoverageInterval]
+)
 def d4_intervals_coverage(coverage_file_path: str, bed_file: bytes = File(...)):
     """Return coverage on the given intervals for a D4 resource located on the disk or on a remote server."""
 
@@ -58,7 +65,9 @@ def d4_intervals_coverage(coverage_file_path: str, bed_file: bytes = File(...)):
         )
 
     try:
-        intervals: List[Tuple[str, Optional[int], Optional[int]]] = parse_bed(bed_file=bed_file)
+        intervals: List[Tuple[str, Optional[int], Optional[int]]] = parse_bed(
+            bed_file=bed_file
+        )
     except:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -2,12 +2,7 @@ from typing import List, Optional, Tuple
 
 from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_bed import parse_bed
-from chanjo2.meta.handle_d4 import (
-    interval_coverage,
-    intervals_coverage,
-    set_d4_file,
-    set_interval,
-)
+from chanjo2.meta.handle_d4 import interval_coverage, intervals_coverage, set_d4_file, set_interval
 from chanjo2.models.pydantic_models import (
     WRONG_BED_FILE_MSG,
     WRONG_COVERAGE_FILE_MSG,
@@ -20,8 +15,8 @@ from sqlmodel import Session, select
 router = APIRouter()
 
 
-@router.get("/intervals/interval/", response_model=CoverageInterval)
-def read_single_interval(
+@router.get("/intervals/coverage/d4/interval/", response_model=CoverageInterval)
+def d4_interval_coverage(
     coverage_file_path: str,
     chromosome: str,
     start: Optional[int] = None,
@@ -50,8 +45,8 @@ def read_single_interval(
     )
 
 
-@router.post("/intervals/", response_model=List[CoverageInterval])
-def read_intervals(coverage_file_path: str, bed_file: bytes = File(...)):
+@router.post("/intervals/coverage/d4/interval_file/", response_model=List[CoverageInterval])
+def d4_intervals_coverage(coverage_file_path: str, bed_file: bytes = File(...)):
     """Return coverage on the given intervals for a D4 resource located on the disk or on a remote server."""
 
     try:
@@ -63,9 +58,7 @@ def read_intervals(coverage_file_path: str, bed_file: bytes = File(...)):
         )
 
     try:
-        intervals: List[Tuple[str, Optional[int], Optional[int]]] = parse_bed(
-            bed_file=bed_file
-        )
+        intervals: List[Tuple[str, Optional[int], Optional[int]]] = parse_bed(bed_file=bed_file)
     except:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,8 @@ class Endpoints(str, Enum):
 
     CASES = "/cases/"
     SAMPLES = "/samples/"
-    INTERVAL = "/intervals/interval/"
-    INTERVALS = "/intervals/"
+    INTERVAL_COVERAGE = "/intervals/coverage/d4/interval/"
+    INTERVALS_FILE_COVERAGE = "/intervals/coverage/d4/interval_file/"
 
 
 class Helpers:

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -11,7 +11,7 @@ from fastapi import status
 from fastapi.testclient import TestClient
 
 
-def test_read_single_interval_d4_not_found(
+def test_d4_interval_coverage_d4_not_found(
     client: TestClient, mock_coverage_file: str, endpoints: Type, interval_query: dict
 ):
     """Test the function that returns the coverage over an interval of a D4 file.
@@ -21,7 +21,7 @@ def test_read_single_interval_d4_not_found(
     interval_query["coverage_file_path"] = mock_coverage_file
 
     # THEN a request to the read_single_interval should return 404 error
-    response = client.get(endpoints.INTERVAL, params=interval_query)
+    response = client.get(endpoints.INTERVAL_COVERAGE, params=interval_query)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
     # THEN show a meaningful message
@@ -29,7 +29,7 @@ def test_read_single_interval_d4_not_found(
     assert result["detail"] == WRONG_COVERAGE_FILE_MSG
 
 
-def test_read_single_interval(
+def test_d4_interval_coverage(
     client: TestClient,
     real_coverage_path: str,
     endpoints: Type,
@@ -41,7 +41,7 @@ def test_read_single_interval(
     interval_query["coverage_file_path"] = real_coverage_path
 
     # THEN a request to the read_single_interval should be successful
-    response = client.get(endpoints.INTERVAL, params=interval_query)
+    response = client.get(endpoints.INTERVAL_COVERAGE, params=interval_query)
     assert response.status_code == status.HTTP_200_OK
 
     # THEN the mean coverage over the interval should be returned
@@ -55,7 +55,7 @@ def test_read_single_interval(
     assert coverage_data.end
 
 
-def test_read_single_chromosome(
+def test_d4_interval_coverage_single_chromosome(
     client: TestClient,
     real_coverage_path: str,
     endpoints: Type,
@@ -71,7 +71,7 @@ def test_read_single_chromosome(
     interval_query["coverage_file_path"] = real_coverage_path
 
     # THEN a request to the read_single_intervalshould be successful
-    response = client.get(endpoints.INTERVAL, params=interval_query)
+    response = client.get(endpoints.INTERVAL_COVERAGE, params=interval_query)
     assert response.status_code == status.HTTP_200_OK
 
     # AND the mean coverage over the entire chromosome should be present in the result
@@ -84,7 +84,7 @@ def test_read_single_chromosome(
     assert coverage_data.end is None
 
 
-def test_read_intervals_d4_not_found(
+def test_d4_intervals_coverage_d4_not_found(
     mock_coverage_file: str, client: TestClient, endpoints: Type
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file.
@@ -99,7 +99,7 @@ def test_read_intervals_d4_not_found(
     d4_query = {"coverage_file_path": mock_coverage_file}
 
     # THEN a request to the endpoint should return 404 error
-    response = client.post(endpoints.INTERVALS, params=d4_query, files=files)
+    response = client.post(endpoints.INTERVALS_FILE_COVERAGE, params=d4_query, files=files)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
     # AND show a meaningful message
@@ -108,7 +108,7 @@ def test_read_intervals_d4_not_found(
     assert result["detail"] == WRONG_COVERAGE_FILE_MSG
 
 
-def test_read_intervals_malformed_bed_file(
+def test_d4_intervals_coverage_malformed_bed_file(
     bed_path_malformed: PosixPath,
     real_coverage_path: str,
     client: TestClient,
@@ -124,7 +124,7 @@ def test_read_intervals_malformed_bed_file(
     ]
 
     # THEN a request to the endpoint should return 404 error
-    response = client.post(endpoints.INTERVALS, params=real_d4_query, files=files)
+    response = client.post(endpoints.INTERVALS_FILE_COVERAGE, params=real_d4_query, files=files)
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # AND show a meaningful message
@@ -133,7 +133,7 @@ def test_read_intervals_malformed_bed_file(
     assert result["detail"] == WRONG_BED_FILE_MSG
 
 
-def test_read_intervals(
+def test_d4_intervals_coverage(
     real_coverage_path: str,
     client: TestClient,
     endpoints: Type,
@@ -147,7 +147,7 @@ def test_read_intervals(
     ]
 
     # THEN a request to the endpoint should return HTTP 200
-    response = client.post(endpoints.INTERVALS, params=real_d4_query, files=files)
+    response = client.post(endpoints.INTERVALS_FILE_COVERAGE, params=real_d4_query, files=files)
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -99,7 +99,9 @@ def test_d4_intervals_coverage_d4_not_found(
     d4_query = {"coverage_file_path": mock_coverage_file}
 
     # THEN a request to the endpoint should return 404 error
-    response = client.post(endpoints.INTERVALS_FILE_COVERAGE, params=d4_query, files=files)
+    response = client.post(
+        endpoints.INTERVALS_FILE_COVERAGE, params=d4_query, files=files
+    )
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
     # AND show a meaningful message
@@ -124,7 +126,9 @@ def test_d4_intervals_coverage_malformed_bed_file(
     ]
 
     # THEN a request to the endpoint should return 404 error
-    response = client.post(endpoints.INTERVALS_FILE_COVERAGE, params=real_d4_query, files=files)
+    response = client.post(
+        endpoints.INTERVALS_FILE_COVERAGE, params=real_d4_query, files=files
+    )
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
     # AND show a meaningful message
@@ -147,7 +151,9 @@ def test_d4_intervals_coverage(
     ]
 
     # THEN a request to the endpoint should return HTTP 200
-    response = client.post(endpoints.INTERVALS_FILE_COVERAGE, params=real_d4_query, files=files)
+    response = client.post(
+        endpoints.INTERVALS_FILE_COVERAGE, params=real_d4_query, files=files
+    )
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data


### PR DESCRIPTION
### This PR adds | fixes:
Changes the name(url) of 2 endpoints:
- `/intervals/interval/ `-> `/intervals/coverage/d4/interval/` (so it's clearer that you have to provide the path to a d4 file)
- `/intervals/` -> `/intervals/coverage/d4/interval_file/` (same, but this also explains that you need to add an interval file)
 
Part from being more clear, it also adds "coverage" to the url, so **we can use the /intervals/ endpoint to return info on the intervals present in the database**.

### How to test:
- Automatic tests

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
