### PR TITLE
Load transcripts endpoint

### DIFF
--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict, List
 
 from schug.load.ensembl import fetch_ensembl_genes, fetch_ensembl_transcripts
 
@@ -12,7 +12,7 @@ ENSEMBL_RESOURCE_CLIENT: dict = {
     "transcripts": fetch_ensembl_transcripts,
 }
 
-GENES_FILE_HEADER: dict = {
+GENES_FILE_HEADER: Dict[str, List[str]] = {
     "GRCh37": [
         "Chromosome Name",
         "Gene Start (bp)",

--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Callable, Dict, List
 
 from schug.load.ensembl import fetch_ensembl_genes, fetch_ensembl_transcripts
 
@@ -7,7 +7,7 @@ WRONG_COVERAGE_FILE_MSG: str = (
 )
 WRONG_BED_FILE_MSG: str = "Provided intervals files is not a valid BED file"
 
-ENSEMBL_RESOURCE_CLIENT: dict = {
+ENSEMBL_RESOURCE_CLIENT: Dict[str, Callable] = {
     "genes": fetch_ensembl_genes,
     "transcripts": fetch_ensembl_transcripts,
 }

--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -1,9 +1,16 @@
 from typing import List
 
+from schug.load.ensembl import fetch_ensembl_genes, fetch_ensembl_transcripts
+
 WRONG_COVERAGE_FILE_MSG: str = (
     "Coverage_file_path must be either an existing local file path or a URL"
 )
 WRONG_BED_FILE_MSG: str = "Provided intervals files is not a valid BED file"
+
+ENSEMBL_RESOURCE_CLIENT: dict = {
+    "genes": fetch_ensembl_genes,
+    "transcripts": fetch_ensembl_transcripts,
+}
 
 GENES_FILE_HEADER: dict = {
     "GRCh37": [
@@ -21,5 +28,30 @@ GENES_FILE_HEADER: dict = {
         "Gene stable ID",
         "HGNC symbol",
         "HGNC ID",
+    ],
+}
+
+TRANSCRIPTS_FILE_HEADER: dict = {
+    "GRCh37": [
+        "Chromosome Name",
+        "Ensembl Gene ID",
+        "Ensembl Transcript ID",
+        "Transcript Start (bp)",
+        "Transcript End (bp)",
+        "RefSeq mRNA [e.g. NM_001195597]",
+        "RefSeq mRNA predicted [e.g. XM_001125684]",
+        "RefSeq ncRNA [e.g. NR_002834]",
+    ],
+    "GRCh38": [
+        "Chromosome/scaffold name",
+        "Gene stable ID",
+        "Transcript stable ID",
+        "Transcript start (bp)",
+        "Transcript end (bp)",
+        "RefSeq mRNA ID",
+        "RefSeq mRNA predicted ID",
+        "RefSeq ncRNA ID",
+        "RefSeq match transcript (MANE Select)",
+        "RefSeq match transcript (MANE Plus Clinical)",
     ],
 }

--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -31,7 +31,7 @@ GENES_FILE_HEADER: dict = {
     ],
 }
 
-TRANSCRIPTS_FILE_HEADER: dict = {
+TRANSCRIPTS_FILE_HEADER: Dict[str, List[str]] = {
     "GRCh37": [
         "Chromosome Name",
         "Ensembl Gene ID",

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -57,9 +57,7 @@ def bulk_insert_genes(db: Session, gene_list: List[Gene]):
 def get_genes(db: Session, build: Builds, limit: int) -> List[Gene]:
     """Returns genes in the given genome build."""
     return (
-        _filter_intervals_by_build(
-            intervals=db.query(SQLGene), interval_type=SQLGene, build=build
-        )
+        _filter_intervals_by_build(intervals=db.query(SQLGene), interval_type=SQLGene, build=build)
         .limit(limit)
         .all()
     )
@@ -69,9 +67,7 @@ def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscri
     """Create a SQL transcript object."""
 
     ensembl_gene = (
-        db.query(SQLGene)
-        .filter(SQLGene.ensembl_id == transcript.ensembl_gene_id)
-        .first()
+        db.query(SQLGene).filter(SQLGene.ensembl_id == transcript.ensembl_gene_id).first()
     )
 
     return SQLTranscript(
@@ -79,7 +75,7 @@ def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscri
         start=transcript.start,
         stop=transcript.stop,
         ensembl_id=transcript.ensembl_id,
-        ensembl_gene_ref=ensembl_gene.id,
+        ensembl_gene_ref=ensembl_gene.id if ensembl_gene else None,
         ensembl_gene_id=transcript.ensembl_gene_id,
         refseq_mrna=transcript.refseq_mrna,
         refseq_mrna_pred=transcript.refseq_mrna_pred,

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -48,9 +48,9 @@ def create_db_gene(gene: GeneBase) -> SQLGene:
     )
 
 
-def bulk_insert_genes(db: Session, gene_list: List[GeneBase]):
+def bulk_insert_genes(db: Session, genes: List[GeneBase]):
     """Bulk insert genes into the database."""
-    db.bulk_save_objects([create_db_gene(gene) for gene in gene_list])
+    db.bulk_save_objects([create_db_gene(gene) for gene in genes])
     db.commit()
 
 

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -97,7 +97,7 @@ def bulk_insert_transcripts(db: Session, transcript_list: List[TranscriptBase]):
 
 
 def get_transcripts(db: Session, build: Builds, limit: int) -> List[SQLTranscript]:
-    """Returns genes in the given genome build."""
+    """Returns transcripts in the given genome build."""
     return (
         _filter_intervals_by_build(
             intervals=db.query(SQLTranscript), interval_type=SQLTranscript, build=build

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -57,7 +57,9 @@ def bulk_insert_genes(db: Session, gene_list: List[Gene]):
 def get_genes(db: Session, build: Builds, limit: int) -> List[Gene]:
     """Returns genes in the given genome build."""
     return (
-        _filter_intervals_by_build(intervals=db.query(SQLGene), interval_type=SQLGene, build=build)
+        _filter_intervals_by_build(
+            intervals=db.query(SQLGene), interval_type=SQLGene, build=build
+        )
         .limit(limit)
         .all()
     )
@@ -67,7 +69,9 @@ def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscri
     """Create a SQL transcript object."""
 
     ensembl_gene = (
-        db.query(SQLGene).filter(SQLGene.ensembl_id == transcript.ensembl_gene_id).first()
+        db.query(SQLGene)
+        .filter(SQLGene.ensembl_id == transcript.ensembl_gene_id)
+        .first()
     )
 
     return SQLTranscript(

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -57,7 +57,9 @@ def bulk_insert_genes(db: Session, gene_list: List[GeneBase]):
 def get_genes(db: Session, build: Builds, limit: int) -> List[SQLGene]:
     """Returns genes in the given genome build."""
     return (
-        _filter_intervals_by_build(intervals=db.query(SQLGene), interval_type=SQLGene, build=build)
+        _filter_intervals_by_build(
+            intervals=db.query(SQLGene), interval_type=SQLGene, build=build
+        )
         .limit(limit)
         .all()
     )
@@ -67,7 +69,9 @@ def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscri
     """Create a SQL transcript object."""
 
     ensembl_gene: SQLGene = (
-        db.query(SQLGene).filter(SQLGene.ensembl_id == transcript.ensembl_gene_id).first()
+        db.query(SQLGene)
+        .filter(SQLGene.ensembl_id == transcript.ensembl_gene_id)
+        .first()
     )
 
     return SQLTranscript(
@@ -88,7 +92,9 @@ def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscri
 
 def bulk_insert_transcripts(db: Session, transcripts: List[TranscriptBase]):
     """Bulk insert transcripts into the database."""
-    db.bulk_save_objects([create_db_transcript(db, transcripts) for transcripts in transcripts])
+    db.bulk_save_objects(
+        [create_db_transcript(db, transcripts) for transcripts in transcripts]
+    )
     db.commit()
 
 

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -1,30 +1,35 @@
+import logging
 from typing import List, Optional, Union
 
-from chanjo2.models.pydantic_models import Builds, Gene, GeneBase
+from chanjo2.models.pydantic_models import Builds, Gene, GeneBase, TranscriptBase
 from chanjo2.models.sql_models import Gene as SQLGene
-from sqlalchemy import delete
+from chanjo2.models.sql_models import Transcript as SQLTranscript
+from sqlalchemy import delete, insert, select
 from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.orm import Session, query
-from sqlalchemy.sql.expression import Delete
+from sqlalchemy.sql.expression import Delete, Select
+
+LOG = logging.getLogger("uvicorn.access")
 
 
 def delete_intervals_for_build(
-    db: Session, interval_type: Union[SQLGene], build: Builds
+    db: Session, interval_type: Union[SQLGene, SQLTranscript], build: Builds
 ) -> None:
     """Delete intervals from a given table by specifying a genome build."""
     statement: Delete = delete(interval_type).where(interval_type.build == build)
+    LOG.warning(f"Executing statement: {statement}")
     db.execute(statement)
 
 
 def count_intervals_for_build(
-    db: Session, interval_type: Union[SQLGene], build: Builds
+    db: Session, interval_type: Union[SQLGene, SQLTranscript], build: Builds
 ) -> int:
     """Count intervals in table by specifying a genome build."""
     return db.query(interval_type).where(interval_type.build == build).count()
 
 
 def _filter_intervals_by_build(
-    intervals: query.Query, interval_type: Union[SQLGene], build: Builds
+    intervals: query.Query, interval_type: Union[SQLGene, SQLTranscript], build: Builds
 ) -> List[Union[SQLGene]]:
     """Filter samples by sample name."""
     return intervals.filter(interval_type.build == build)
@@ -58,3 +63,33 @@ def get_genes(db: Session, build: Builds, limit: int) -> List[Gene]:
         .limit(limit)
         .all()
     )
+
+
+def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscript:
+    """Create a SQL transcript object."""
+
+    gene_id = (
+        db.query(SQLGene.id)
+        .filter(SQLGene.ensembl_id == transcript.ensembl_gene_id)
+        .first()
+    )
+
+    return SQLTranscript(
+        chromosome=transcript.chromosome,
+        start=transcript.start,
+        stop=transcript.stop,
+        ensembl_id=transcript.ensembl_id,
+        ensembl_gene_ref=gene_id,
+        refseq_mrna=transcript.refseq_mrna,
+        refseq_mrna_pred=transcript.refseq_mrna_pred,
+        refseq_ncrna=transcript.refseq_ncrna,
+        refseq_mane_select=transcript.refseq_mane_select,
+        refseq_mane_plus_clinical=transcript.refseq_mane_plus_clinical,
+        build=transcript.build,
+    )
+
+
+def bulk_insert_transcripts(db: Session, transcript_list: List[Gene]):
+    """Bulk insert transcripts into the database."""
+    db.bulk_save_objects([create_db_transcript(db, tx) for tx in transcript_list])
+    db.commit()

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -68,8 +68,8 @@ def get_genes(db: Session, build: Builds, limit: int) -> List[Gene]:
 def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscript:
     """Create a SQL transcript object."""
 
-    gene_id = (
-        db.query(SQLGene.id)
+    ensembl_gene = (
+        db.query(SQLGene)
         .filter(SQLGene.ensembl_id == transcript.ensembl_gene_id)
         .first()
     )
@@ -79,7 +79,7 @@ def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscri
         start=transcript.start,
         stop=transcript.stop,
         ensembl_id=transcript.ensembl_id,
-        ensembl_gene_ref=gene_id,
+        ensembl_gene_ref=ensembl_gene.id,
         ensembl_gene_id=transcript.ensembl_gene_id,
         refseq_mrna=transcript.refseq_mrna,
         refseq_mrna_pred=transcript.refseq_mrna_pred,

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -17,7 +17,7 @@ def delete_intervals_for_build(
 ) -> None:
     """Delete intervals from a given table by specifying a genome build."""
     statement: Delete = delete(interval_type).where(interval_type.build == build)
-    LOG.warning(f"Executing statement: {statement}")
+    LOG.info(f"Executing statement: {statement}")
     db.execute(statement)
 
 

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -94,3 +94,14 @@ def bulk_insert_transcripts(db: Session, transcript_list: List[Gene]):
     """Bulk insert transcripts into the database."""
     db.bulk_save_objects([create_db_transcript(db, tx) for tx in transcript_list])
     db.commit()
+
+
+def get_transcripts(db: Session, build: Builds, limit: int) -> List[Gene]:
+    """Returns genes in the given genome build."""
+    return (
+        _filter_intervals_by_build(
+            intervals=db.query(SQLTranscript), interval_type=SQLTranscript, build=build
+        )
+        .limit(limit)
+        .all()
+    )

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -80,6 +80,7 @@ def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscri
         stop=transcript.stop,
         ensembl_id=transcript.ensembl_id,
         ensembl_gene_ref=gene_id,
+        ensembl_gene_id=transcript.ensembl_gene_id,
         refseq_mrna=transcript.refseq_mrna,
         refseq_mrna_pred=transcript.refseq_mrna_pred,
         refseq_ncrna=transcript.refseq_ncrna,

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -30,8 +30,8 @@ def count_intervals_for_build(
 
 def _filter_intervals_by_build(
     intervals: query.Query, interval_type: Union[SQLGene, SQLTranscript], build: Builds
-) -> List[Union[SQLGene]]:
-    """Filter samples by sample name."""
+) -> List[Union[SQLGene, SQLTranscript]]:
+    """Filter intervals by genome build."""
     return intervals.filter(interval_type.build == build)
 
 
@@ -48,13 +48,13 @@ def create_db_gene(gene: GeneBase) -> SQLGene:
     )
 
 
-def bulk_insert_genes(db: Session, gene_list: List[Gene]):
+def bulk_insert_genes(db: Session, gene_list: List[GeneBase]):
     """Bulk insert genes into the database."""
     db.bulk_save_objects([create_db_gene(gene) for gene in gene_list])
     db.commit()
 
 
-def get_genes(db: Session, build: Builds, limit: int) -> List[Gene]:
+def get_genes(db: Session, build: Builds, limit: int) -> List[SQLGene]:
     """Returns genes in the given genome build."""
     return (
         _filter_intervals_by_build(
@@ -90,13 +90,13 @@ def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscri
     )
 
 
-def bulk_insert_transcripts(db: Session, transcript_list: List[Gene]):
+def bulk_insert_transcripts(db: Session, transcript_list: List[TranscriptBase]):
     """Bulk insert transcripts into the database."""
     db.bulk_save_objects([create_db_transcript(db, tx) for tx in transcript_list])
     db.commit()
 
 
-def get_transcripts(db: Session, build: Builds, limit: int) -> List[Gene]:
+def get_transcripts(db: Session, build: Builds, limit: int) -> List[SQLTranscript]:
     """Returns genes in the given genome build."""
     return (
         _filter_intervals_by_build(

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -57,9 +57,7 @@ def bulk_insert_genes(db: Session, gene_list: List[GeneBase]):
 def get_genes(db: Session, build: Builds, limit: int) -> List[SQLGene]:
     """Returns genes in the given genome build."""
     return (
-        _filter_intervals_by_build(
-            intervals=db.query(SQLGene), interval_type=SQLGene, build=build
-        )
+        _filter_intervals_by_build(intervals=db.query(SQLGene), interval_type=SQLGene, build=build)
         .limit(limit)
         .all()
     )
@@ -68,10 +66,8 @@ def get_genes(db: Session, build: Builds, limit: int) -> List[SQLGene]:
 def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscript:
     """Create a SQL transcript object."""
 
-    ensembl_gene = (
-        db.query(SQLGene)
-        .filter(SQLGene.ensembl_id == transcript.ensembl_gene_id)
-        .first()
+    ensembl_gene: SQLGene = (
+        db.query(SQLGene).filter(SQLGene.ensembl_id == transcript.ensembl_gene_id).first()
     )
 
     return SQLTranscript(
@@ -90,9 +86,9 @@ def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscri
     )
 
 
-def bulk_insert_transcripts(db: Session, transcript_list: List[TranscriptBase]):
+def bulk_insert_transcripts(db: Session, transcripts: List[TranscriptBase]):
     """Bulk insert transcripts into the database."""
-    db.bulk_save_objects([create_db_transcript(db, tx) for tx in transcript_list])
+    db.bulk_save_objects([create_db_transcript(db, transcripts) for transcripts in transcripts])
     db.commit()
 
 

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -10,7 +10,7 @@ from chanjo2.meta.handle_d4 import (
     set_d4_file,
     set_interval,
 )
-from chanjo2.meta.handle_load_intervals import update_genes
+from chanjo2.meta.handle_load_intervals import update_genes, update_transcripts
 from chanjo2.models.pydantic_models import Builds, CoverageInterval, Gene, Interval
 from fastapi import APIRouter, Depends, File, HTTPException, Response, status
 from fastapi.responses import JSONResponse
@@ -102,3 +102,24 @@ async def genes(
 ) -> List[Gene]:
     """Return genes in the given genome build."""
     return get_genes(db=session, build=build, limit=limit)
+
+
+@router.post("/intervals/load/transcripts/{build}")
+async def load_transcripts(
+    build: Builds, session: Session = Depends(get_session)
+) -> Union[Response, HTTPException]:
+    """Load transcripts in the given genome build."""
+
+    try:
+        nr_loaded_transcripts: int = await update_transcripts(build, session)
+        return JSONResponse(
+            content={
+                "detail": f"{nr_loaded_transcripts} transcripts loaded into the database"
+            }
+        )
+
+    except Exception as ex:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=ex.args,
+        )

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Tuple, Union
 
 from chanjo2.constants import WRONG_BED_FILE_MSG, WRONG_COVERAGE_FILE_MSG
-from chanjo2.crud.intervals import get_genes
+from chanjo2.crud.intervals import get_genes, get_transcripts
 from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_bed import parse_bed
 from chanjo2.meta.handle_d4 import (
@@ -11,7 +11,13 @@ from chanjo2.meta.handle_d4 import (
     set_interval,
 )
 from chanjo2.meta.handle_load_intervals import update_genes, update_transcripts
-from chanjo2.models.pydantic_models import Builds, CoverageInterval, Gene, Interval
+from chanjo2.models.pydantic_models import (
+    Builds,
+    CoverageInterval,
+    Gene,
+    Interval,
+    Transcript,
+)
 from fastapi import APIRouter, Depends, File, HTTPException, Response, status
 from fastapi.responses import JSONResponse
 from pyd4 import D4File
@@ -123,3 +129,11 @@ async def load_transcripts(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=ex.args,
         )
+
+
+@router.get("/intervals/transcripts/{build}")
+async def transcripts(
+    build: Builds, session: Session = Depends(get_session), limit: int = 100
+) -> List[Transcript]:
+    """Return transcripts in the given genome build."""
+    return get_transcripts(db=session, build=build, limit=limit)

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -42,14 +42,14 @@ def _get_ensembl_resource_url(build: Builds, resource_type: str) -> str:
     return shug_client.build_url(xml=shug_client.xml)
 
 
-def _replace_empty_cols(string_line: str, n_expected_cols: int) -> List:
+def _replace_empty_cols(string_line: str, nr_expected_cols: int) -> List:
     """Split gene line into columns, replacing empty columns with None values."""
     cols = [
         None if col == "" else col.replace("HGNC:", "")
         for col in string_line.split("\t")
     ]
     # Make sure that expected nr of cols are returned if last cols are blank
-    cols += [None] * (n_expected_cols - len(cols))
+    cols += [None] * (nr_expected_cols - len(cols))
     return cols
 
 
@@ -67,7 +67,7 @@ async def update_genes(build: Builds, session: Session) -> int:
 
     gene_list: List[SQLGene] = []
     for line in lines:
-        items = _replace_empty_cols(string_line=line, n_expected_cols=len(header))
+        items = _replace_empty_cols(string_line=line, nr_expected_cols=len(header))
 
         # Load gene interval into the database
         gene: GeneBase = GeneBase(
@@ -104,7 +104,7 @@ async def update_transcripts(build: Builds, session: Session) -> int:
 
     transcript_list: List[TranscriptBase] = []
     for line in lines:
-        items = _replace_empty_cols(string_line=line, n_expected_cols=len(header))
+        items = _replace_empty_cols(string_line=line, nr_expected_cols=len(header))
 
         # Load transcript interval into the database
         tx = TranscriptBase(

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -46,7 +46,7 @@ def _replace_empty_cols(line: str, nr_expected_columns: int) -> List:
     """Split gene line into columns, replacing empty columns with None values."""
     cols = [None if col == "" else col.replace("HGNC:", "") for col in line.split("\t")]
     # Make sure that expected nr of cols are returned if last cols are blank
-    cols += [None] * (nr_expected_cols - len(cols))
+    cols += [None] * (nr_expected_columns - len(cols))
     return cols
 
 

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -1,16 +1,21 @@
 import logging
 from typing import List, Tuple
 
-from chanjo2.constants import GENES_FILE_HEADER
+from chanjo2.constants import (
+    ENSEMBL_RESOURCE_CLIENT,
+    GENES_FILE_HEADER,
+    TRANSCRIPTS_FILE_HEADER,
+)
 from chanjo2.crud.intervals import (
     bulk_insert_genes,
+    bulk_insert_transcripts,
     count_intervals_for_build,
     delete_intervals_for_build,
 )
-from chanjo2.models.pydantic_models import Builds, GeneBase
+from chanjo2.models.pydantic_models import Builds, GeneBase, TranscriptBase
 from chanjo2.models.sql_models import Gene as SQLGene
+from chanjo2.models.sql_models import Transcript as SQLTranscript
 from schug.load.biomart import EnsemblBiomartClient
-from schug.load.ensembl import fetch_ensembl_genes
 from schug.load.fetch_resource import stream_resource
 from schug.models.common import Build as SchugBuild
 from sqlmodel import Session
@@ -29,26 +34,30 @@ async def parse_resource_lines(url) -> Tuple[List[List[str]], List[str]]:
     return resource_header.split("\t"), resource_lines
 
 
-def _get_ensembl_genes_url(build: Builds) -> str:
+def _get_ensembl_resource_url(build: Builds, resource_type: str) -> str:
     """Return the URL to download genes using the Ensembl Biomart."""
-    shug_client: EnsemblBiomartClient = fetch_ensembl_genes(
+    shug_client: EnsemblBiomartClient = ENSEMBL_RESOURCE_CLIENT[resource_type](
         build=SchugBuild(build)
-    )  # Schug converts 'GRCh38' to '38'
+    )
     return shug_client.build_url(xml=shug_client.xml)
+
+
+def _replace_empty_cols(string_line: str, n_expected_cols: int) -> List:
+    """Split gene line into columns, replacing empty columns with None values."""
+    cols = [
+        None if col == "" else col.replace("HGNC:", "")
+        for col in string_line.split("\t")
+    ]
+    # Make sure that expected nr of cols are returned if last cols are blank
+    cols += [None] * (n_expected_cols - len(cols))
+    return cols
 
 
 async def update_genes(build: Builds, session: Session) -> int:
     """Loads genes into the database."""
 
-    def _format_gene_line_cols(string_line: str) -> List:
-        """Split gene line into columns, replacing empty columns with None values."""
-        return [
-            None if col == "" else col.replace("HGNC:", "")
-            for col in string_line.split("\t")
-        ]
-
     LOG.info(f"Loading gene intervals. Genome build --> {build}")
-    url: str = _get_ensembl_genes_url(build)
+    url: str = _get_ensembl_resource_url(build=build, resource_type="genes")
     header, lines = await parse_resource_lines(url)
 
     if header != GENES_FILE_HEADER[build]:
@@ -56,12 +65,12 @@ async def update_genes(build: Builds, session: Session) -> int:
             f"Ensembl genes file has an unexpected format:{header}. Expected format: {GENES_FILE_HEADER[build]}"
         )
 
-    db_genes: List[SQLGene] = []
+    gene_list: List[SQLGene] = []
     for line in lines:
-        items = _format_gene_line_cols(line)
+        items = _replace_empty_cols(string_line=line, n_expected_cols=len(header))
 
         # Load gene interval into the database
-        gene: SQLGene = GeneBase(
+        gene: GeneBase = GeneBase(
             build=build,
             chromosome=items[0],
             start=int(items[1]),
@@ -70,12 +79,54 @@ async def update_genes(build: Builds, session: Session) -> int:
             hgnc_symbol=items[4],
             hgnc_id=items[5],
         )
-        db_genes.append(gene)
+        gene_list.append(gene)
 
     delete_intervals_for_build(db=session, interval_type=SQLGene, build=build)
-    bulk_insert_genes(db=session, gene_list=db_genes)
+    bulk_insert_genes(db=session, gene_list=gene_list)
     nr_loaded_genes: int = count_intervals_for_build(
         db=session, interval_type=SQLGene, build=build
     )
     LOG.info(f"{nr_loaded_genes} genes loaded into the database.")
     return nr_loaded_genes
+
+
+async def update_transcripts(build: Builds, session: Session) -> int:
+    """Loads transcripts into the database."""
+
+    LOG.info(f"Loading transcript intervals. Genome build --> {build}")
+    url: str = _get_ensembl_resource_url(build=build, resource_type="transcripts")
+    header, lines = await parse_resource_lines(url)
+
+    if header != TRANSCRIPTS_FILE_HEADER[build]:
+        raise ValueError(
+            f"Ensembl transcripts file has an unexpected format:{header}. Expected format: {TRANSCRIPTS_FILE_HEADER[build]}"
+        )
+
+    transcript_list: List[TranscriptBase] = []
+    for line in lines:
+        items = _replace_empty_cols(string_line=line, n_expected_cols=len(header))
+
+        # Load transcript interval into the database
+        tx = TranscriptBase(
+            chromosome=items[0],
+            ensembl_gene_id=items[1],
+            ensembl_id=items[2],
+            start=int(items[3]),
+            stop=int(items[4]),
+            refseq_mrna=items[5],
+            refseq_mrna_pred=items[6],
+            refseq_ncrna=items[7],
+            refseq_mane_select=items[8] if build == "GRCh38" else None,
+            refseq_mane_plus_clinical=items[9] if build == "GRCh38" else None,
+            build=build,
+        )
+        transcript_list.append(tx)
+
+    delete_intervals_for_build(db=session, interval_type=SQLTranscript, build=build)
+    bulk_insert_transcripts(db=session, transcript_list=transcript_list)
+
+    nr_loaded_transcripts: int = count_intervals_for_build(
+        db=session, interval_type=SQLTranscript, build=build
+    )
+    LOG.info(f"{nr_loaded_transcripts} transcripts loaded into the database.")
+    return nr_loaded_transcripts

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -62,7 +62,7 @@ async def update_genes(build: Builds, session: Session) -> int:
             f"Ensembl genes file has an unexpected format:{header}. Expected format: {GENES_FILE_HEADER[build]}"
         )
 
-    gene_list: List[SQLGene] = []
+    genes: List[SQLGene] = []
     for line in lines:
         items: List = _replace_empty_cols(line=line, nr_expected_columns=len(header))
 
@@ -76,10 +76,10 @@ async def update_genes(build: Builds, session: Session) -> int:
             hgnc_symbol=items[4],
             hgnc_id=items[5],
         )
-        gene_list.append(gene)
+        genes.append(gene)
 
     delete_intervals_for_build(db=session, interval_type=SQLGene, build=build)
-    bulk_insert_genes(db=session, genes=gene_list)
+    bulk_insert_genes(db=session, genes=genes)
     nr_loaded_genes: int = count_intervals_for_build(
         db=session, interval_type=SQLGene, build=build
     )
@@ -117,10 +117,10 @@ async def update_transcripts(build: Builds, session: Session) -> int:
             refseq_mane_plus_clinical=items[9] if build == "GRCh38" else None,
             build=build,
         )
-        transcript_list.append(transcript)
+        transcripts.append(transcript)
 
     delete_intervals_for_build(db=session, interval_type=SQLTranscript, build=build)
-    bulk_insert_transcripts(db=session, transcripts=transcript_list)
+    bulk_insert_transcripts(db=session, transcripts=transcripts)
 
     nr_loaded_transcripts: int = count_intervals_for_build(
         db=session, interval_type=SQLTranscript, build=build

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -64,7 +64,7 @@ async def update_genes(build: Builds, session: Session) -> int:
 
     gene_list: List[SQLGene] = []
     for line in lines:
-        items = _replace_empty_cols(line=line, nr_expected_columns=len(header))
+        items: List = _replace_empty_cols(line=line, nr_expected_columns=len(header))
 
         # Load gene interval into the database
         gene: GeneBase = GeneBase(
@@ -101,7 +101,7 @@ async def update_transcripts(build: Builds, session: Session) -> int:
 
     transcript_list: List[TranscriptBase] = []
     for line in lines:
-        items = _replace_empty_cols(line=line, nr_expected_columns=len(header))
+        items: List = _replace_empty_cols(line=line, nr_expected_columns=len(header))
 
         # Load transcript interval into the database
         transcript = TranscriptBase(

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -97,8 +97,7 @@ class TranscriptBase(IntervalBase):
 
 class Transcript(TranscriptBase):
     id: int
-    ensembl_gene_ref: int
-    hgnc_gene_ref: Optional[int]
+    ensembl_gene_ref: Optional[int]
 
 
 class CoverageInterval(BaseModel):

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -84,6 +84,23 @@ class Gene(IntervalBase):
     id: int
 
 
+class TranscriptBase(IntervalBase):
+    ensembl_gene_id: str
+    ensembl_id: str
+    refseq_mrna: Optional[str]
+    refseq_mrna_pred: Optional[str]
+    refseq_ncrna: Optional[str]
+    refseq_mane_select: Optional[str]
+    refseq_mane_plus_clinical: Optional[str]
+    build: Builds
+
+
+class Transcript(TranscriptBase):
+    id: int
+    ensembl_gene_ref: int
+    hgnc_gene_ref: Optional[int]
+
+
 class CoverageInterval(BaseModel):
     chromosome: str
     start: Optional[int]

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -15,7 +15,7 @@ class Builds(str, Enum):
 
 class IntervalType(str, Enum):
     GENES = "genes"
-    TRANCRIPTS = "transcripts"
+    TRANSCRIPTS = "transcripts"
     EXONS = "exons"
     CUSTOM = "custom_intervals"
 

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -55,3 +55,23 @@ class Gene(Base):
     hgnc_id = Column(Integer, nullable=True, index=True)
     hgnc_symbol = Column(String(24), nullable=True, index=True)
     build = Column(Enum(Builds), index=True)
+
+
+class Transcript(Base):
+    """Used to define a transcript entity."""
+
+    __tablename__ = "transcripts"
+    id = Column(Integer, primary_key=True, index=True)
+    chromosome = Column(String(6), nullable=False)
+    start = Column(Integer, nullable=False)
+    stop = Column(Integer, nullable=False)
+    ensembl_id = Column(String(24), nullable=False, index=True)
+    refseq_mrna = Column(String(24), nullable=True, index=True)
+    refseq_mrna_pred = Column(String(24), nullable=True, index=False)
+    refseq_ncrna = Column(String(24), nullable=True, index=False)
+    refseq_mane_select = Column(String(24), nullable=True, index=True)
+    refseq_mane_plus_clinical = Column(String(24), nullable=True, index=True)
+    ensembl_gene_ref = Column(
+        Integer, ForeignKey("genes.id"), nullable=True, index=True
+    )
+    build = Column(Enum(Builds), index=True)

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -74,4 +74,5 @@ class Transcript(Base):
     ensembl_gene_ref = Column(
         Integer, ForeignKey("genes.id"), nullable=True, index=True
     )
+    ensembl_gene_id = Column(String(24), nullable=False, index=True)
     build = Column(Enum(Builds), index=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ class Endpoints(str, Enum):
     LOAD_GENES = "/intervals/load/genes/"
     GENES = "/intervals/genes/"
     LOAD_TRANSCRIPTS = "/intervals/load/transcripts/"
+    TRANSCRIPTS = "/intervals/transcripts/"
     INTERVAL_COVERAGE = "/intervals/coverage/d4/interval/"
     INTERVALS_FILE_COVERAGE = "/intervals/coverage/d4/interval_file/"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ class Endpoints(str, Enum):
     INTERVALS = "/intervals/"
     LOAD_GENES = "/intervals/load/genes/"
     GENES = "/intervals/genes/"
+    LOAD_TRANSCRIPTS = "/intervals/load/transcripts/"
     INTERVAL_COVERAGE = "/intervals/coverage/d4/interval/"
     INTERVALS_FILE_COVERAGE = "/intervals/coverage/d4/interval_file/"
 

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -9,11 +9,21 @@ from chanjo2.models.pydantic_models import Builds, CoverageInterval, Gene
 from fastapi import status
 from fastapi.testclient import TestClient
 from pytest_mock.plugin import MockerFixture
-from schug.demo import GENES_37_FILE_PATH, GENES_38_FILE_PATH
+from schug.demo import (
+    GENES_37_FILE_PATH,
+    GENES_38_FILE_PATH,
+    TRANSCRIPTS_37_FILE_PATH,
+    TRANSCRIPTS_38_FILE_PATH,
+)
 
 BUILD_GENES_RESOURCE: List[Tuple[Builds, str]] = [
     (Builds.build_37, GENES_37_FILE_PATH),
-    (Builds.build_38, GENES_38_FILE_PATH),
+    # (Builds.build_38, GENES_38_FILE_PATH),
+]
+
+BUILD_TRANSCRIPTS_RESOURCE: List[Tuple[Builds, str]] = [
+    (Builds.build_37, TRANSCRIPTS_37_FILE_PATH),
+    (Builds.build_38, TRANSCRIPTS_38_FILE_PATH),
 ]
 
 
@@ -186,7 +196,7 @@ def test_load_genes(
         return_value=gene_lines,
     )
 
-    # GIVEN a number of genes contained in the genes file
+    # GIVEN a number of genes contained in the demo file
     nr_genes = len(gene_lines[1])
     # WHEN sending a request to the load_genes with genome build
     response: Response = client.post(f"{endpoints.LOAD_GENES}{build}")
@@ -203,3 +213,45 @@ def test_load_genes(
     assert len(result) == nr_genes
     # AND the should have the right format
     assert Gene(**result[0])
+
+
+@pytest.mark.parametrize("build, path", BUILD_TRANSCRIPTS_RESOURCE)
+def test_load_transcripts(
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
+    file_handler: Callable,
+):
+    """Test the endpoint that adds genes to the database in a given genome build."""
+
+    # GIVEN a patched response from Ensembl Biomart, via schug
+    transcript_lines: TextIOWrapper = file_handler(path)
+    mocker.patch(
+        "chanjo2.meta.handle_load_intervals.parse_resource_lines",
+        return_value=transcript_lines,
+    )
+
+    # GIVEN a number of transcripts contained in the demo file
+    nr_transcripts = len(transcript_lines[1])
+
+    # WHEN sending a request to the load_genes with genome build
+    response: Response = client.post(f"{endpoints.LOAD_TRANSCRIPTS}{build}")
+    # THEN it should return success
+    # assert response.status_code == status.HTTP_200_OK
+    # THEN all the genes should be loaded
+    assert (
+        response.json()["detail"]
+        == f"{nr_transcripts} transcripts loaded into the database"
+    )
+    """
+    # WHEN sending a request to the "genes" endpoint
+    response: Response = client.get(f"{endpoints.GENES}{build}")
+    assert response.status_code == status.HTTP_200_OK
+    result = response.json()
+    # THEN the expected number of genes should be returned
+    assert len(result) == nr_genes
+    # AND the should have the right format
+    assert Gene(**result[0])
+    """

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -239,7 +239,7 @@ def test_load_transcripts(
     # WHEN sending a request to the load_genes with genome build
     response: Response = client.post(f"{endpoints.LOAD_TRANSCRIPTS}{build}")
     # THEN it should return success
-    # assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == status.HTTP_200_OK
     # THEN all the genes should be loaded
     assert (
         response.json()["detail"]

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -18,7 +18,7 @@ from schug.demo import (
 
 BUILD_GENES_RESOURCE: List[Tuple[Builds, str]] = [
     (Builds.build_37, GENES_37_FILE_PATH),
-    # (Builds.build_38, GENES_38_FILE_PATH),
+    (Builds.build_38, GENES_38_FILE_PATH),
 ]
 
 BUILD_TRANSCRIPTS_RESOURCE: List[Tuple[Builds, str]] = [

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -5,7 +5,7 @@ import pytest
 from _io import TextIOWrapper
 from chanjo2.constants import WRONG_BED_FILE_MSG, WRONG_COVERAGE_FILE_MSG
 from chanjo2.demo import gene_panel_file, gene_panel_path
-from chanjo2.models.pydantic_models import Builds, CoverageInterval, Gene
+from chanjo2.models.pydantic_models import Builds, CoverageInterval, Gene, Transcript
 from fastapi import status
 from fastapi.testclient import TestClient
 from pytest_mock.plugin import MockerFixture
@@ -211,7 +211,7 @@ def test_load_genes(
     result = response.json()
     # THEN the expected number of genes should be returned
     assert len(result) == nr_genes
-    # AND the should have the right format
+    # AND the gene should have the right format
     assert Gene(**result[0])
 
 
@@ -240,18 +240,16 @@ def test_load_transcripts(
     response: Response = client.post(f"{endpoints.LOAD_TRANSCRIPTS}{build}")
     # THEN it should return success
     assert response.status_code == status.HTTP_200_OK
-    # THEN all the genes should be loaded
+    # THEN all transcripts should be loaded
     assert (
         response.json()["detail"]
         == f"{nr_transcripts} transcripts loaded into the database"
     )
-    """
-    # WHEN sending a request to the "genes" endpoint
-    response: Response = client.get(f"{endpoints.GENES}{build}")
+    # WHEN sending a request to the "transcripts" endpoint
+    response: Response = client.get(f"{endpoints.TRANSCRIPTS}{build}")
     assert response.status_code == status.HTTP_200_OK
     result = response.json()
-    # THEN the expected number of genes should be returned
-    assert len(result) == nr_genes
-    # AND the should have the right format
-    assert Gene(**result[0])
-    """
+    # THEN the expected number of transcripts should be returned
+    assert len(result) == nr_transcripts
+    # AND the transcript should have the right format
+    assert Transcript(**result[0])


### PR DESCRIPTION
### This PR adds | fixes:
- Load transcripts in both genome builds using a dedicated API endpoint

### How to test:
- Launch a local server: `uvicorn src.chanjo2.main:app --reload`
- Load genes in both genome builds
- Use the dedicated endpoints (`load_transcripts`) to load transcripts in both genome builds.
- Retrieve a number of transcripts of both genome builds using the new dedicated endpoint (`transcripts`)

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
