### PR TITLE
Add VARCHAR length to sample.coverage_file_path SQL field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Bugs preventing the gunicorn app to launch
 - Code to compose DB url to work when app is invoked from docker-compose
 - Dockerfile building error due to missing d4tools lib
+- Add VARCHAR length to sample.coverage_file_path SQL field 
 ### Changed
 - Renamed root endpoint to heartbeat
 - Use a multi-stage build in Dockerfile to reduce its size

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -26,7 +26,7 @@ class Sample(Base):
     name = Column(String(64), nullable=False, unique=True, index=True)
     display_name = Column(String(64), nullable=True, unique=False)
     case_id = Column(Integer, ForeignKey("cases.id"), nullable=False)
-    coverage_file_path = Column(String, nullable=False)
+    coverage_file_path = Column(String(512), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     case = relationship("Case", back_populates="samples")


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #71 

### How to test:
- Using a local MySQL database, after setting the required connection ENV variables, start the server

### Expected outcome:
- The server won't start using main branch
- The server will start when using THIS branch

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
