### PR TITLE
Filter genes by Ensembl ID, HGNC ID or HGNC symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Demo case and demo sample loaded with demo instance startup
 - Endpoint for coverage queries over the intervals of a BED file
 - Include a default .env file loaded on app startup
+- Filter genes by Ensemble id, HGNC id, HGNC symbol
 
 ### Fixed
 

--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -7,6 +7,9 @@ WRONG_COVERAGE_FILE_MSG: str = (
     "Coverage_file_path must be either an existing local file path or a URL"
 )
 WRONG_BED_FILE_MSG: str = "Provided intervals files is not a valid BED file"
+MULTIPLE_PARAMS_NOT_SUPPORTED_MSG = (
+    "Please provide Ensembl IDs OR HGNC IDs OR HGNC symbols"
+)
 
 ENSEMBL_RESOURCE_CLIENT: Dict[str, Callable] = {
     "genes": fetch_ensembl_genes,
@@ -64,7 +67,6 @@ TRANSCRIPTS_FILE_HEADER: Dict[str, List[str]] = {
         "RefSeq match transcript (MANE Plus Clinical)",
     ],
 }
-
 
 EXONS_FILE_HEADER: Dict[str, List[str]] = {
     BUILD_37: [

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -33,9 +33,20 @@ def count_intervals_for_build(
     return db.query(interval_type).where(interval_type.build == build).count()
 
 
+def _filter_intervals_by_ensembl_id(
+    intervals: query.Query,
+    interval_type: Union[SQLGene, SQLTranscript, SQLExon],
+    id: str,
+) -> List[Union[SQLGene, SQLTranscript, SQLExon]]:
+    """Filter intervals by Ensembl ID"""
+    return intervals.filter(interval_type.ensembl_id == id)
+
+
 def _filter_intervals_by_build(
-    intervals: query.Query, interval_type: Union[SQLGene, SQLTranscript], build: Builds
-) -> List[Union[SQLGene, SQLTranscript]]:
+    intervals: query.Query,
+    interval_type: Union[SQLGene, SQLTranscript, SQLExon],
+    build: Builds,
+) -> List[Union[SQLGene, SQLTranscript, SQLExon]]:
     """Filter intervals by genome build."""
     return intervals.filter(interval_type.build == build)
 
@@ -62,9 +73,9 @@ def bulk_insert_genes(db: Session, genes: List[GeneBase]):
 def get_genes(
     db: Session,
     build: Builds,
-    ensembl_id: Optional[str],
-    hgnc_id: Optional[int],
-    hgnc_symbol: Optional[str],
+    ensembl_ids: Optional[List[str]],
+    hgnc_ids: Optional[List[int]],
+    hgnc_symbols: Optional[List[str]],
     limit: int,
 ) -> List[SQLGene]:
     """Returns genes in the given genome build."""

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -4,17 +4,15 @@ from typing import List, Optional, Union
 from chanjo2.models.pydantic_models import (
     Builds,
     ExonBase,
-    Gene,
     GeneBase,
     TranscriptBase,
 )
 from chanjo2.models.sql_models import Exon as SQLExon
 from chanjo2.models.sql_models import Gene as SQLGene
 from chanjo2.models.sql_models import Transcript as SQLTranscript
-from sqlalchemy import delete, insert, select
-from sqlalchemy.engine.cursor import CursorResult
+from sqlalchemy import delete
 from sqlalchemy.orm import Session, query
-from sqlalchemy.sql.expression import Delete, Select
+from sqlalchemy.sql.expression import Delete
 
 LOG = logging.getLogger("uvicorn.access")
 
@@ -61,7 +59,14 @@ def bulk_insert_genes(db: Session, genes: List[GeneBase]):
     db.commit()
 
 
-def get_genes(db: Session, build: Builds, limit: int) -> List[SQLGene]:
+def get_genes(
+    db: Session,
+    build: Builds,
+    ensembl_id: Optional[str],
+    hgnc_id: Optional[int],
+    hgnc_symbol: Optional[str],
+    limit: int,
+) -> List[SQLGene]:
     """Returns genes in the given genome build."""
     return (
         _filter_intervals_by_build(

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -117,10 +117,13 @@ async def genes(
     hgnc_ids: List[int] = Query(None),
     hgnc_symbols: List[str] = Query(None),
     session: Session = Depends(get_session),
-    limit: int = 100,
+    limit: Optional[int] = 100,
 ) -> List[Gene]:
     """Return genes according to query parameters."""
-    if sum(param is not None for param in [ensembl_ids, hgnc_ids, hgnc_symbols]) > 1:
+    nr_filters = sum(
+        param is not None for param in [ensembl_ids, hgnc_ids, hgnc_symbols]
+    )
+    if nr_filters > 1:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=MULTIPLE_PARAMS_NOT_SUPPORTED_MSG,
@@ -132,7 +135,7 @@ async def genes(
         ensembl_ids=ensembl_ids,
         hgnc_ids=hgnc_ids,
         hgnc_symbols=hgnc_symbols,
-        limit=limit,
+        limit=limit if nr_filters == 0 else None,
     )
 
 

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -20,24 +20,23 @@ from chanjo2.models.pydantic_models import (
     CoverageInterval,
     Exon,
     Gene,
-    Interval,
     Transcript,
 )
 from fastapi import APIRouter, Depends, File, HTTPException, Response, status
 from fastapi.responses import JSONResponse
 from pyd4 import D4File
-from sqlmodel import Session, select
+from sqlmodel import Session
 
 router = APIRouter()
 
 
 @router.get("/intervals/coverage/d4/interval/", response_model=CoverageInterval)
 def d4_interval_coverage(
-    coverage_file_path: str,
-    chromosome: str,
-    start: Optional[int] = None,
-    end: Optional[int] = None,
-    session: Session = Depends(get_session),
+        coverage_file_path: str,
+        chromosome: str,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
+        session: Session = Depends(get_session),
 ):
     """Return coverage on the given interval for a D4 resource located on the disk or on a remote server."""
 
@@ -90,7 +89,7 @@ def d4_intervals_coverage(coverage_file_path: str, bed_file: bytes = File(...)):
 
 @router.post("/intervals/load/genes/{build}")
 async def load_genes(
-    build: Builds, session: Session = Depends(get_session)
+        build: Builds, session: Session = Depends(get_session)
 ) -> Union[Response, HTTPException]:
     """Load genes in the given genome build."""
 
@@ -107,9 +106,9 @@ async def load_genes(
         )
 
 
-@router.get("/intervals/genes/{build}")
+@router.get("/intervals/genes")
 async def genes(
-    build: Builds, session: Session = Depends(get_session), limit: int = 100
+        build: Builds, session: Session = Depends(get_session), limit: int = 100
 ) -> List[Gene]:
     """Return genes in the given genome build."""
     return get_genes(db=session, build=build, limit=limit)
@@ -117,7 +116,7 @@ async def genes(
 
 @router.post("/intervals/load/transcripts/{build}")
 async def load_transcripts(
-    build: Builds, session: Session = Depends(get_session)
+        build: Builds, session: Session = Depends(get_session)
 ) -> Union[Response, HTTPException]:
     """Load transcripts in the given genome build."""
 
@@ -138,7 +137,7 @@ async def load_transcripts(
 
 @router.get("/intervals/transcripts/{build}")
 async def transcripts(
-    build: Builds, session: Session = Depends(get_session), limit: int = 100
+        build: Builds, session: Session = Depends(get_session), limit: int = 100
 ) -> List[Transcript]:
     """Return transcripts in the given genome build."""
     return get_transcripts(db=session, build=build, limit=limit)
@@ -146,7 +145,7 @@ async def transcripts(
 
 @router.post("/intervals/load/exons/{build}")
 async def load_exons(
-    build: Builds, session: Session = Depends(get_session)
+        build: Builds, session: Session = Depends(get_session)
 ) -> Union[Response, HTTPException]:
     """Load exons in the given genome build."""
 
@@ -165,7 +164,7 @@ async def load_exons(
 
 @router.get("/intervals/exons/{build}")
 async def exons(
-    build: Builds, session: Session = Depends(get_session), limit: int = 100
+        build: Builds, session: Session = Depends(get_session), limit: int = 100
 ) -> List[Exon]:
     """Return exons in the given genome build."""
     return get_exons(db=session, build=build, limit=limit)

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -32,11 +32,11 @@ router = APIRouter()
 
 @router.get("/intervals/coverage/d4/interval/", response_model=CoverageInterval)
 def d4_interval_coverage(
-        coverage_file_path: str,
-        chromosome: str,
-        start: Optional[int] = None,
-        end: Optional[int] = None,
-        session: Session = Depends(get_session),
+    coverage_file_path: str,
+    chromosome: str,
+    start: Optional[int] = None,
+    end: Optional[int] = None,
+    session: Session = Depends(get_session),
 ):
     """Return coverage on the given interval for a D4 resource located on the disk or on a remote server."""
 
@@ -89,7 +89,7 @@ def d4_intervals_coverage(coverage_file_path: str, bed_file: bytes = File(...)):
 
 @router.post("/intervals/load/genes/{build}")
 async def load_genes(
-        build: Builds, session: Session = Depends(get_session)
+    build: Builds, session: Session = Depends(get_session)
 ) -> Union[Response, HTTPException]:
     """Load genes in the given genome build."""
 
@@ -108,7 +108,7 @@ async def load_genes(
 
 @router.get("/intervals/genes")
 async def genes(
-        build: Builds, session: Session = Depends(get_session), limit: int = 100
+    build: Builds, session: Session = Depends(get_session), limit: int = 100
 ) -> List[Gene]:
     """Return genes in the given genome build."""
     return get_genes(db=session, build=build, limit=limit)
@@ -116,7 +116,7 @@ async def genes(
 
 @router.post("/intervals/load/transcripts/{build}")
 async def load_transcripts(
-        build: Builds, session: Session = Depends(get_session)
+    build: Builds, session: Session = Depends(get_session)
 ) -> Union[Response, HTTPException]:
     """Load transcripts in the given genome build."""
 
@@ -137,7 +137,7 @@ async def load_transcripts(
 
 @router.get("/intervals/transcripts/{build}")
 async def transcripts(
-        build: Builds, session: Session = Depends(get_session), limit: int = 100
+    build: Builds, session: Session = Depends(get_session), limit: int = 100
 ) -> List[Transcript]:
     """Return transcripts in the given genome build."""
     return get_transcripts(db=session, build=build, limit=limit)
@@ -145,7 +145,7 @@ async def transcripts(
 
 @router.post("/intervals/load/exons/{build}")
 async def load_exons(
-        build: Builds, session: Session = Depends(get_session)
+    build: Builds, session: Session = Depends(get_session)
 ) -> Union[Response, HTTPException]:
     """Load exons in the given genome build."""
 
@@ -164,7 +164,7 @@ async def load_exons(
 
 @router.get("/intervals/exons/{build}")
 async def exons(
-        build: Builds, session: Session = Depends(get_session), limit: int = 100
+    build: Builds, session: Session = Depends(get_session), limit: int = 100
 ) -> List[Exon]:
     """Return exons in the given genome build."""
     return get_exons(db=session, build=build, limit=limit)

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -108,10 +108,22 @@ async def load_genes(
 
 @router.get("/intervals/genes")
 async def genes(
-    build: Builds, session: Session = Depends(get_session), limit: int = 100
+    build: Builds,
+    ensembl_id: Optional[str] = None,
+    hgnc_id: Optional[int] = None,
+    hgnc_symbol: Optional[str] = None,
+    session: Session = Depends(get_session),
+    limit: int = 100,
 ) -> List[Gene]:
-    """Return genes in the given genome build."""
-    return get_genes(db=session, build=build, limit=limit)
+    """Return genes according to query parameters."""
+    return get_genes(
+        db=session,
+        build=build,
+        ensembl_id=ensembl_id,
+        hgnc_id=hgnc_id,
+        hgnc_symbol=hgnc_symbol,
+        limit=limit,
+    )
 
 
 @router.post("/intervals/load/transcripts/{build}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from pathlib import PosixPath
 from typing import Dict, Iterator, List, Tuple
 
 import pytest
+from chanjo2.constants import BUILD_38, BUILD_37
 from chanjo2.dbutil import DEMO_CONNECT_ARGS, get_session
 from chanjo2.demo import d4_demo_path, gene_panel_path
 from chanjo2.main import Base, app, engine
@@ -22,6 +23,16 @@ COVERAGE_FILE = "a_file.d4"
 BED_FILE = "a_file.bed"
 REMOTE_COVERAGE_FILE = "https://a_remote_host/a_file.d4"
 CONTENT: str = "content"
+GENE_LISTS_37 = {
+    "ensembl_ids": ["ENSG00000233440", "ENSG00000207157", "ENSG00000196593"],
+    "hgnc_ids": [19121, 42488, 42737],
+    "hgnc_symbols": ["HMGA1P6", "RNY3P4", "ANKRD20A19P"],
+}
+GENE_LISTS_38 = {
+    "ensembl_ids": ["ENSG00000160072", "ENSG00000142611", "ENSG00000171729"],
+    "hgnc_ids": [24007, 14000, 25488],
+    "hgnc_symbols": ["ATAD3B", "PRDM16", "TMEM51"],
+}
 
 engine = create_engine(TEST_DB, connect_args=DEMO_CONNECT_ARGS)
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -215,3 +226,9 @@ def file_handler() -> TextIOWrapper:
         return iter(lines)
 
     return _resource_data
+
+
+@pytest.fixture(name="gene_lists")
+def gene_lists() -> Dict[str, List]:
+    """Return lists with test genes in different formats"""
+    return {BUILD_37: GENE_LISTS_37, BUILD_38: GENE_LISTS_38}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
+from _io import TextIOWrapper
 from enum import Enum
 from pathlib import PosixPath
 from typing import Dict, Iterator, List, Tuple
 
 import pytest
-from _io import TextIOWrapper
 from chanjo2.dbutil import DEMO_CONNECT_ARGS, get_session
 from chanjo2.demo import d4_demo_path, gene_panel_path
 from chanjo2.main import Base, app, engine
@@ -35,7 +35,7 @@ class Endpoints(str, Enum):
     INTERVAL = "/intervals/interval/"
     INTERVALS = "/intervals/"
     LOAD_GENES = "/intervals/load/genes/"
-    GENES = "/intervals/genes/"
+    GENES = "/intervals/genes"
     LOAD_TRANSCRIPTS = "/intervals/load/transcripts/"
     TRANSCRIPTS = "/intervals/transcripts/"
     INTERVAL_COVERAGE = "/intervals/coverage/d4/interval/"

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -43,7 +43,7 @@ MOCKED_FILE_PARSER = "chanjo2.meta.handle_load_intervals.read_resource_lines"
 
 
 def test_d4_interval_coverage_d4_not_found(
-        client: TestClient, mock_coverage_file: str, endpoints: Type, interval_query: dict
+    client: TestClient, mock_coverage_file: str, endpoints: Type, interval_query: dict
 ):
     """Test the function that returns the coverage over an interval of a D4 file.
     Testing with a D4 file not found on disk or on a remote server."""
@@ -61,10 +61,10 @@ def test_d4_interval_coverage_d4_not_found(
 
 
 def test_d4_interval_coverage(
-        client: TestClient,
-        real_coverage_path: str,
-        endpoints: Type,
-        interval_query: dict,
+    client: TestClient,
+    real_coverage_path: str,
+    endpoints: Type,
+    interval_query: dict,
 ):
     """Test the function that returns the coverage over an interval of a D4 file."""
 
@@ -87,10 +87,10 @@ def test_d4_interval_coverage(
 
 
 def test_d4_interval_coverage_single_chromosome(
-        client: TestClient,
-        real_coverage_path: str,
-        endpoints: Type,
-        interval_query: dict,
+    client: TestClient,
+    real_coverage_path: str,
+    endpoints: Type,
+    interval_query: dict,
 ):
     """Test the function that returns the coverage over an entire chsomosome of a D4 file."""
 
@@ -116,7 +116,7 @@ def test_d4_interval_coverage_single_chromosome(
 
 
 def test_d4_intervals_coverage_d4_not_found(
-        mock_coverage_file: str, client: TestClient, endpoints: Type
+    mock_coverage_file: str, client: TestClient, endpoints: Type
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file.
     Testing with a D4 file not found on disk or on a remote server."""
@@ -142,11 +142,11 @@ def test_d4_intervals_coverage_d4_not_found(
 
 
 def test_d4_intervals_coverage_malformed_bed_file(
-        bed_path_malformed: PosixPath,
-        real_coverage_path: str,
-        client: TestClient,
-        endpoints: Type,
-        real_d4_query: Dict[str, str],
+    bed_path_malformed: PosixPath,
+    real_coverage_path: str,
+    client: TestClient,
+    endpoints: Type,
+    real_d4_query: Dict[str, str],
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file.
     Testing with a BED file that is not correctly formatted."""
@@ -169,10 +169,10 @@ def test_d4_intervals_coverage_malformed_bed_file(
 
 
 def test_d4_intervals_coverage(
-        real_coverage_path: str,
-        client: TestClient,
-        endpoints: Type,
-        real_d4_query: Dict[str, str],
+    real_coverage_path: str,
+    client: TestClient,
+    endpoints: Type,
+    real_d4_query: Dict[str, str],
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file."""
 
@@ -195,12 +195,12 @@ def test_d4_intervals_coverage(
 
 @pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
 def test_load_genes(
-        build: str,
-        path: str,
-        client: TestClient,
-        endpoints: Type,
-        mocker: MockerFixture,
-        file_handler: Callable,
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
+    file_handler: Callable,
 ):
     """Test the endpoint that adds genes to the database in a given genome build."""
 
@@ -234,12 +234,12 @@ def test_load_genes(
 
 @pytest.mark.parametrize("build, path", BUILD_TRANSCRIPTS_RESOURCE)
 def test_load_transcripts(
-        build: str,
-        path: str,
-        client: TestClient,
-        endpoints: Type,
-        mocker: MockerFixture,
-        file_handler: Callable,
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
+    file_handler: Callable,
 ):
     """Test the endpoint that adds genes to the database in a given genome build."""
 
@@ -259,8 +259,8 @@ def test_load_transcripts(
     assert response.status_code == status.HTTP_200_OK
     # THEN all transcripts should be loaded
     assert (
-            response.json()["detail"]
-            == f"{nr_transcripts} transcripts loaded into the database"
+        response.json()["detail"]
+        == f"{nr_transcripts} transcripts loaded into the database"
     )
     # WHEN sending a request to the "transcripts" endpoint
     response: Response = client.get(f"{endpoints.TRANSCRIPTS}{build}")
@@ -274,12 +274,12 @@ def test_load_transcripts(
 
 @pytest.mark.parametrize("build, path", BUILD_EXONS_RESOURCE)
 def test_load_exons(
-        build: str,
-        path: str,
-        client: TestClient,
-        endpoints: Type,
-        mocker: MockerFixture,
-        file_handler: Callable,
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
+    file_handler: Callable,
 ):
     """Test the endpoint that adds exons to the database in a given genome build."""
 

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -1,8 +1,8 @@
+from _io import TextIOWrapper
 from pathlib import PosixPath
 from typing import Callable, Dict, Iterator, List, Tuple, Type
 
 import pytest
-from _io import TextIOWrapper
 from chanjo2.constants import WRONG_BED_FILE_MSG, WRONG_COVERAGE_FILE_MSG
 from chanjo2.demo import gene_panel_file, gene_panel_path
 from chanjo2.models.pydantic_models import (
@@ -43,7 +43,7 @@ MOCKED_FILE_PARSER = "chanjo2.meta.handle_load_intervals.read_resource_lines"
 
 
 def test_d4_interval_coverage_d4_not_found(
-    client: TestClient, mock_coverage_file: str, endpoints: Type, interval_query: dict
+        client: TestClient, mock_coverage_file: str, endpoints: Type, interval_query: dict
 ):
     """Test the function that returns the coverage over an interval of a D4 file.
     Testing with a D4 file not found on disk or on a remote server."""
@@ -61,10 +61,10 @@ def test_d4_interval_coverage_d4_not_found(
 
 
 def test_d4_interval_coverage(
-    client: TestClient,
-    real_coverage_path: str,
-    endpoints: Type,
-    interval_query: dict,
+        client: TestClient,
+        real_coverage_path: str,
+        endpoints: Type,
+        interval_query: dict,
 ):
     """Test the function that returns the coverage over an interval of a D4 file."""
 
@@ -87,10 +87,10 @@ def test_d4_interval_coverage(
 
 
 def test_d4_interval_coverage_single_chromosome(
-    client: TestClient,
-    real_coverage_path: str,
-    endpoints: Type,
-    interval_query: dict,
+        client: TestClient,
+        real_coverage_path: str,
+        endpoints: Type,
+        interval_query: dict,
 ):
     """Test the function that returns the coverage over an entire chsomosome of a D4 file."""
 
@@ -116,7 +116,7 @@ def test_d4_interval_coverage_single_chromosome(
 
 
 def test_d4_intervals_coverage_d4_not_found(
-    mock_coverage_file: str, client: TestClient, endpoints: Type
+        mock_coverage_file: str, client: TestClient, endpoints: Type
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file.
     Testing with a D4 file not found on disk or on a remote server."""
@@ -142,11 +142,11 @@ def test_d4_intervals_coverage_d4_not_found(
 
 
 def test_d4_intervals_coverage_malformed_bed_file(
-    bed_path_malformed: PosixPath,
-    real_coverage_path: str,
-    client: TestClient,
-    endpoints: Type,
-    real_d4_query: Dict[str, str],
+        bed_path_malformed: PosixPath,
+        real_coverage_path: str,
+        client: TestClient,
+        endpoints: Type,
+        real_d4_query: Dict[str, str],
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file.
     Testing with a BED file that is not correctly formatted."""
@@ -169,10 +169,10 @@ def test_d4_intervals_coverage_malformed_bed_file(
 
 
 def test_d4_intervals_coverage(
-    real_coverage_path: str,
-    client: TestClient,
-    endpoints: Type,
-    real_d4_query: Dict[str, str],
+        real_coverage_path: str,
+        client: TestClient,
+        endpoints: Type,
+        real_d4_query: Dict[str, str],
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file."""
 
@@ -195,12 +195,12 @@ def test_d4_intervals_coverage(
 
 @pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
 def test_load_genes(
-    build: str,
-    path: str,
-    client: TestClient,
-    endpoints: Type,
-    mocker: MockerFixture,
-    file_handler: Callable,
+        build: str,
+        path: str,
+        client: TestClient,
+        endpoints: Type,
+        mocker: MockerFixture,
+        file_handler: Callable,
 ):
     """Test the endpoint that adds genes to the database in a given genome build."""
 
@@ -223,7 +223,7 @@ def test_load_genes(
     assert response.json()["detail"] == f"{nr_genes} genes loaded into the database"
 
     # WHEN sending a request to the "genes" endpoint
-    response: Response = client.get(f"{endpoints.GENES}{build}")
+    response: Response = client.get(endpoints.GENES, params={"build": build})
     assert response.status_code == status.HTTP_200_OK
     result = response.json()
     # THEN the expected number of genes should be returned
@@ -234,12 +234,12 @@ def test_load_genes(
 
 @pytest.mark.parametrize("build, path", BUILD_TRANSCRIPTS_RESOURCE)
 def test_load_transcripts(
-    build: str,
-    path: str,
-    client: TestClient,
-    endpoints: Type,
-    mocker: MockerFixture,
-    file_handler: Callable,
+        build: str,
+        path: str,
+        client: TestClient,
+        endpoints: Type,
+        mocker: MockerFixture,
+        file_handler: Callable,
 ):
     """Test the endpoint that adds genes to the database in a given genome build."""
 
@@ -259,8 +259,8 @@ def test_load_transcripts(
     assert response.status_code == status.HTTP_200_OK
     # THEN all transcripts should be loaded
     assert (
-        response.json()["detail"]
-        == f"{nr_transcripts} transcripts loaded into the database"
+            response.json()["detail"]
+            == f"{nr_transcripts} transcripts loaded into the database"
     )
     # WHEN sending a request to the "transcripts" endpoint
     response: Response = client.get(f"{endpoints.TRANSCRIPTS}{build}")
@@ -274,12 +274,12 @@ def test_load_transcripts(
 
 @pytest.mark.parametrize("build, path", BUILD_EXONS_RESOURCE)
 def test_load_exons(
-    build: str,
-    path: str,
-    client: TestClient,
-    endpoints: Type,
-    mocker: MockerFixture,
-    file_handler: Callable,
+        build: str,
+        path: str,
+        client: TestClient,
+        endpoints: Type,
+        mocker: MockerFixture,
+        file_handler: Callable,
 ):
     """Test the endpoint that adds exons to the database in a given genome build."""
 


### PR DESCRIPTION
### This PR adds | fixes:
- Filter genes by Ensembl ID, HGNC ID or HGNC symbol

### How to test:
- On a local instance containing genes in a given genome build, query for genes using the 3 different items

### Expected outcome:
- [ ] When specifying one or more IDs, genes should be returned
- [ ] Without any gene ID, 100 randon genes in the given build should be returned

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
