### PR TITLE
Add demo intervals (genes, transcripts, exons) when launching the demo instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Endpoint for coverage queries over the intervals of a BED file
 - Include a default .env file loaded on app startup
 - Filter genes by Ensemble id, HGNC id, HGNC symbol
+- Demo genes, transcripts and exons loaded on demo instance startup
 
 ### Fixed
 

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -99,7 +99,7 @@ async def load_genes(
     """Load genes in the given genome build."""
 
     try:
-        nr_loaded_genes: int = await update_genes(build, session)
+        nr_loaded_genes: int = await update_genes(build=build, session=session)
         return JSONResponse(
             content={"detail": f"{nr_loaded_genes} genes loaded into the database"}
         )
@@ -143,7 +143,9 @@ async def load_transcripts(
     """Load transcripts in the given genome build."""
 
     try:
-        nr_loaded_transcripts: int = await update_transcripts(build, session)
+        nr_loaded_transcripts: int = await update_transcripts(
+            build=build, session=session
+        )
         return JSONResponse(
             content={
                 "detail": f"{nr_loaded_transcripts} transcripts loaded into the database"

--- a/src/chanjo2/main.py
+++ b/src/chanjo2/main.py
@@ -53,7 +53,7 @@ async def on_startup():
 
     if os.getenv("DEMO") or not os.getenv("MYSQL_DATABASE_NAME"):
         LOG.warning("Running a demo instance of Chanjo2")
-        if load_demo_data():
+        if await load_demo_data():
             LOG.info("Demo data loaded into database")
 
 

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Iterator, List, Tuple, Union
+from typing import Iterator, List, Union, Optional
 
 import requests
 from chanjo2.constants import (
@@ -26,7 +26,6 @@ from chanjo2.models.sql_models import Exon as SQLExon
 from chanjo2.models.sql_models import Gene as SQLGene
 from chanjo2.models.sql_models import Transcript as SQLTranscript
 from schug.load.biomart import EnsemblBiomartClient
-from schug.load.fetch_resource import stream_resource
 from schug.models.common import Build as SchugBuild
 from sqlmodel import Session
 
@@ -58,13 +57,17 @@ def _replace_empty_cols(line: str, nr_expected_columns: int) -> List[Union[str, 
     return cols
 
 
-async def update_genes(build: Builds, session: Session) -> int:
+async def update_genes(
+    build: Builds, session: Session, lines: Optional[Iterator] = None
+) -> int:
     """Loads genes into the database."""
 
     LOG.info(f"Loading gene intervals. Genome build --> {build}")
-    url: str = _get_ensembl_resource_url(build=build, interval_type=IntervalType.GENES)
-
-    lines: Iterator[str] = read_resource_lines(url=url)
+    if lines is None:
+        url: str = _get_ensembl_resource_url(
+            build=build, interval_type=IntervalType.GENES
+        )
+        lines: Iterator[str] = read_resource_lines(url=url)
 
     header = next(lines).split("\t")
     if header != GENES_FILE_HEADER[build]:
@@ -107,15 +110,18 @@ async def update_genes(build: Builds, session: Session) -> int:
     return nr_loaded_genes
 
 
-async def update_transcripts(build: Builds, session: Session) -> int:
+async def update_transcripts(
+    build: Builds, session: Session, lines: Optional[Iterator] = None
+) -> int:
     """Loads transcripts into the database."""
 
     LOG.info(f"Loading transcript intervals. Genome build --> {build}")
-    url: str = _get_ensembl_resource_url(
-        build=build, interval_type=IntervalType.TRANSCRIPTS
-    )
 
-    lines: Iterator[str] = read_resource_lines(url=url)
+    if lines is None:
+        url: str = _get_ensembl_resource_url(
+            build=build, interval_type=IntervalType.TRANSCRIPTS
+        )
+        lines: Iterator[str] = read_resource_lines(url=url)
 
     header = next(lines).split("\t")
     if header != TRANSCRIPTS_FILE_HEADER[build]:
@@ -166,13 +172,18 @@ async def update_transcripts(build: Builds, session: Session) -> int:
     return nr_loaded_transcripts
 
 
-async def update_exons(build: Builds, session: Session) -> int:
+async def update_exons(
+    build: Builds, session: Session, lines: Optional[Iterator] = None
+) -> int:
     """Loads exons into the database."""
 
     LOG.info(f"Loading exon intervals. Genome build --> {build}")
-    url: str = _get_ensembl_resource_url(build=build, interval_type=IntervalType.EXONS)
 
-    lines: Iterator[str] = read_resource_lines(url=url)
+    if lines is None:
+        url: str = _get_ensembl_resource_url(
+            build=build, interval_type=IntervalType.EXONS
+        )
+        lines: Iterator[str] = read_resource_lines(url=url)
 
     header = next(lines).split("\t")
     if header != EXONS_FILE_HEADER[build]:

--- a/src/chanjo2/populate_demo.py
+++ b/src/chanjo2/populate_demo.py
@@ -4,7 +4,11 @@ from chanjo2.crud.cases import create_db_case
 from chanjo2.crud.samples import create_sample_in_case
 from chanjo2.dbutil import get_session
 from chanjo2.demo import d4_demo_path
-from chanjo2.meta.handle_load_intervals import update_genes, update_transcripts
+from chanjo2.meta.handle_load_intervals import (
+    update_genes,
+    update_transcripts,
+    update_exons,
+)
 from chanjo2.models.pydantic_models import CaseCreate, SampleCreate, Builds
 from schug.demo import (
     EXONS_37_FILE_PATH,
@@ -46,13 +50,13 @@ def resource_lines(file_path: str) -> Iterator[str]:
     return iter(lines)
 
 
-def load_demo_data() -> None:
+async def load_demo_data() -> None:
     """Loads demo data into the database of a demo instance of Chanjo2."""
     load_demo_case()
     load_demo_sample()
-    load_demo_genes()
-    load_demo_transcripts()
-    load_demo_exons()
+    await load_demo_genes()
+    await load_demo_transcripts()
+    await load_demo_exons()
 
 
 def load_demo_case() -> None:
@@ -67,25 +71,25 @@ def load_demo_sample() -> None:
     create_sample_in_case(db=db, sample=sample)
 
 
-def load_demo_genes() -> None:
+async def load_demo_genes() -> None:
     """Load 50 test genes into the database"""
 
     for build, path in BUILD_GENES_RESOURCE:
         gene_lines: Iterator = resource_lines(path)
-        update_genes(build=build, session=db, lines=gene_lines)
+        await update_genes(build=build, session=db, lines=gene_lines)
 
 
-def load_demo_transcripts() -> None:
+async def load_demo_transcripts() -> None:
     """Load 50 test transcripts into the database"""
 
     for build, path in BUILD_TRANSCRIPTS_RESOURCE:
         transcript_lines: Iterator = resource_lines(path)
-        update_transcripts(build=build, session=db, lines=transcript_lines)
+        await update_transcripts(build=build, session=db, lines=transcript_lines)
 
 
-def load_demo_exons() -> None:
+async def load_demo_exons() -> None:
     """Load 50 test genes into the database"""
 
     for build, path in BUILD_EXONS_RESOURCE:
         exon_lines: Iterator = resource_lines(path)
-        update_transcripts(build=build, session=db, lines=exon_lines)
+        await update_exons(build=build, session=db, lines=exon_lines)

--- a/src/chanjo2/populate_demo.py
+++ b/src/chanjo2/populate_demo.py
@@ -4,6 +4,7 @@ from chanjo2.crud.cases import create_db_case
 from chanjo2.crud.samples import create_sample_in_case
 from chanjo2.dbutil import get_session
 from chanjo2.demo import d4_demo_path
+from chanjo2.meta.handle_load_intervals import update_genes, update_transcripts
 from chanjo2.models.pydantic_models import CaseCreate, SampleCreate, Builds
 from schug.demo import (
     EXONS_37_FILE_PATH,
@@ -50,6 +51,8 @@ def load_demo_data() -> None:
     load_demo_case()
     load_demo_sample()
     load_demo_genes()
+    load_demo_transcripts()
+    load_demo_exons()
 
 
 def load_demo_case() -> None:
@@ -69,3 +72,20 @@ def load_demo_genes() -> None:
 
     for build, path in BUILD_GENES_RESOURCE:
         gene_lines: Iterator = resource_lines(path)
+        update_genes(build=build, session=db, lines=gene_lines)
+
+
+def load_demo_transcripts() -> None:
+    """Load 50 test transcripts into the database"""
+
+    for build, path in BUILD_TRANSCRIPTS_RESOURCE:
+        transcript_lines: Iterator = resource_lines(path)
+        update_transcripts(build=build, session=db, lines=transcript_lines)
+
+
+def load_demo_exons() -> None:
+    """Load 50 test genes into the database"""
+
+    for build, path in BUILD_EXONS_RESOURCE:
+        exon_lines: Iterator = resource_lines(path)
+        update_transcripts(build=build, session=db, lines=exon_lines)

--- a/src/chanjo2/populate_demo.py
+++ b/src/chanjo2/populate_demo.py
@@ -80,7 +80,7 @@ async def load_demo_genes() -> None:
 
 
 async def load_demo_transcripts() -> None:
-    """Load 50 test transcripts into the database"""
+    """Load test transcripts into the database."""
 
     for build, path in BUILD_TRANSCRIPTS_RESOURCE:
         transcript_lines: Iterator = resource_lines(path)

--- a/src/chanjo2/populate_demo.py
+++ b/src/chanjo2/populate_demo.py
@@ -72,7 +72,7 @@ def load_demo_sample() -> None:
 
 
 async def load_demo_genes() -> None:
-    """Load 50 test genes into the database"""
+    """Load test genes into the database."""
 
     for build, path in BUILD_GENES_RESOURCE:
         gene_lines: Iterator = resource_lines(path)

--- a/src/chanjo2/populate_demo.py
+++ b/src/chanjo2/populate_demo.py
@@ -1,11 +1,18 @@
-from typing import Dict
+from typing import Dict, List, Tuple, Iterator
 
-from chanjo2.crud.cases import create_db_case, get_case
+from chanjo2.crud.cases import create_db_case
 from chanjo2.crud.samples import create_sample_in_case
 from chanjo2.dbutil import get_session
 from chanjo2.demo import d4_demo_path
-from chanjo2.models.pydantic_models import CaseCreate, SampleCreate
-from chanjo2.models.sql_models import Case
+from chanjo2.models.pydantic_models import CaseCreate, SampleCreate, Builds
+from schug.demo import (
+    EXONS_37_FILE_PATH,
+    EXONS_38_FILE_PATH,
+    GENES_37_FILE_PATH,
+    GENES_38_FILE_PATH,
+    TRANSCRIPTS_37_FILE_PATH,
+    TRANSCRIPTS_38_FILE_PATH,
+)
 from sqlalchemy.orm import sessionmaker
 
 db: sessionmaker = next(get_session())
@@ -17,13 +24,32 @@ DEMO_SAMPLE: Dict[str, str] = {
     "case_name": DEMO_CASE["name"],
     "coverage_file_path": d4_demo_path,
 }
+BUILD_GENES_RESOURCE: List[Tuple[Builds, str]] = [
+    (Builds.build_37, GENES_37_FILE_PATH),
+    (Builds.build_38, GENES_38_FILE_PATH),
+]
+BUILD_TRANSCRIPTS_RESOURCE: List[Tuple[Builds, str]] = [
+    (Builds.build_37, TRANSCRIPTS_37_FILE_PATH),
+    (Builds.build_38, TRANSCRIPTS_38_FILE_PATH),
+]
+BUILD_EXONS_RESOURCE: List[Tuple[Builds, str]] = [
+    (Builds.build_37, EXONS_37_FILE_PATH),
+    (Builds.build_38, EXONS_38_FILE_PATH),
+]
 
 
-def load_demo_data() -> Case:
+def resource_lines(file_path: str) -> Iterator[str]:
+    resource = open(file_path, "r", encoding="utf-8")
+    lines: List = resource.readlines()
+    lines: List = [line.rstrip("\n") for line in lines]
+    return iter(lines)
+
+
+def load_demo_data() -> None:
     """Loads demo data into the database of a demo instance of Chanjo2."""
     load_demo_case()
     load_demo_sample()
-    return get_case(db=db, case_name=DEMO_CASE["name"])
+    load_demo_genes()
 
 
 def load_demo_case() -> None:
@@ -36,3 +62,10 @@ def load_demo_sample() -> None:
     """Add a sample to a demo case."""
     sample: SampleCreate = SampleCreate(**DEMO_SAMPLE)
     create_sample_in_case(db=db, sample=sample)
+
+
+def load_demo_genes() -> None:
+    """Load 50 test genes into the database"""
+
+    for build, path in BUILD_GENES_RESOURCE:
+        gene_lines: Iterator = resource_lines(path)

--- a/src/chanjo2/populate_demo.py
+++ b/src/chanjo2/populate_demo.py
@@ -88,7 +88,7 @@ async def load_demo_transcripts() -> None:
 
 
 async def load_demo_exons() -> None:
-    """Load 50 test genes into the database"""
+    """Load test exons into the database."""
 
     for build, path in BUILD_EXONS_RESOURCE:
         exon_lines: Iterator = resource_lines(path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
-from _io import TextIOWrapper
+from enum import Enum
 from enum import Enum
 from pathlib import PosixPath
-from typing import Dict, Iterator, List, Tuple
+from typing import Dict, List, Tuple
 
 import pytest
 from chanjo2.constants import BUILD_38, BUILD_37
@@ -213,19 +213,6 @@ def real_d4_query(real_coverage_path) -> Dict[str, str]:
     return {
         "coverage_file_path": real_coverage_path,
     }
-
-
-@pytest.fixture(name="file_handler")
-def file_handler() -> TextIOWrapper:
-    """Get a file handler to a resource file."""
-
-    def _resource_data(file_path: str) -> Iterator[str]:
-        resource = open(file_path, "r", encoding="utf-8")
-        lines: List = resource.readlines()
-        lines: List = [line.rstrip("\n") for line in lines]
-        return iter(lines)
-
-    return _resource_data
 
 
 @pytest.fixture(name="genes_per_build")

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -358,7 +358,7 @@ def test_load_transcripts(
     )
 
     # GIVEN a number of transcripts contained in the demo file
-    nr_transcripts = len(list(resource_lines(path))) - 1
+    nr_transcripts: int = len(list(resource_lines(path))) - 1
 
     # WHEN sending a request to the load_genes with genome build
     response: Response = client.post(f"{endpoints.LOAD_TRANSCRIPTS}{build}")

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -1,6 +1,6 @@
 from _io import TextIOWrapper
 from pathlib import PosixPath
-from typing import Callable, Dict, Iterator, List, Tuple, Type
+from typing import Dict, Iterator, List, Type
 
 import pytest
 from chanjo2.constants import (
@@ -16,38 +16,17 @@ from chanjo2.models.pydantic_models import (
     Gene,
     Transcript,
 )
+from chanjo2.populate_demo import BUILD_GENES_RESOURCE, BUILD_TRANSCRIPTS_RESOURCE, BUILD_EXONS_RESOURCE
+from chanjo2.populate_demo import resource_lines
 from fastapi import status
 from fastapi.testclient import TestClient
 from pytest_mock.plugin import MockerFixture
-from schug.demo import (
-    EXONS_37_FILE_PATH,
-    EXONS_38_FILE_PATH,
-    GENES_37_FILE_PATH,
-    GENES_38_FILE_PATH,
-    TRANSCRIPTS_37_FILE_PATH,
-    TRANSCRIPTS_38_FILE_PATH,
-)
-
-BUILD_GENES_RESOURCE: List[Tuple[Builds, str]] = [
-    (Builds.build_37, GENES_37_FILE_PATH),
-    (Builds.build_38, GENES_38_FILE_PATH),
-]
-
-BUILD_TRANSCRIPTS_RESOURCE: List[Tuple[Builds, str]] = [
-    (Builds.build_37, TRANSCRIPTS_37_FILE_PATH),
-    (Builds.build_38, TRANSCRIPTS_38_FILE_PATH),
-]
-
-BUILD_EXONS_RESOURCE: List[Tuple[Builds, str]] = [
-    (Builds.build_37, EXONS_37_FILE_PATH),
-    (Builds.build_38, EXONS_38_FILE_PATH),
-]
 
 MOCKED_FILE_PARSER = "chanjo2.meta.handle_load_intervals.read_resource_lines"
 
 
 def test_d4_interval_coverage_d4_not_found(
-    client: TestClient, mock_coverage_file: str, endpoints: Type, interval_query: dict
+        client: TestClient, mock_coverage_file: str, endpoints: Type, interval_query: dict
 ):
     """Test the function that returns the coverage over an interval of a D4 file.
     Testing with a D4 file not found on disk or on a remote server."""
@@ -65,10 +44,10 @@ def test_d4_interval_coverage_d4_not_found(
 
 
 def test_d4_interval_coverage(
-    client: TestClient,
-    real_coverage_path: str,
-    endpoints: Type,
-    interval_query: dict,
+        client: TestClient,
+        real_coverage_path: str,
+        endpoints: Type,
+        interval_query: dict,
 ):
     """Test the function that returns the coverage over an interval of a D4 file."""
 
@@ -91,10 +70,10 @@ def test_d4_interval_coverage(
 
 
 def test_d4_interval_coverage_single_chromosome(
-    client: TestClient,
-    real_coverage_path: str,
-    endpoints: Type,
-    interval_query: dict,
+        client: TestClient,
+        real_coverage_path: str,
+        endpoints: Type,
+        interval_query: dict,
 ):
     """Test the function that returns the coverage over an entire chsomosome of a D4 file."""
 
@@ -120,7 +99,7 @@ def test_d4_interval_coverage_single_chromosome(
 
 
 def test_d4_intervals_coverage_d4_not_found(
-    mock_coverage_file: str, client: TestClient, endpoints: Type
+        mock_coverage_file: str, client: TestClient, endpoints: Type
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file.
     Testing with a D4 file not found on disk or on a remote server."""
@@ -146,11 +125,11 @@ def test_d4_intervals_coverage_d4_not_found(
 
 
 def test_d4_intervals_coverage_malformed_bed_file(
-    bed_path_malformed: PosixPath,
-    real_coverage_path: str,
-    client: TestClient,
-    endpoints: Type,
-    real_d4_query: Dict[str, str],
+        bed_path_malformed: PosixPath,
+        real_coverage_path: str,
+        client: TestClient,
+        endpoints: Type,
+        real_d4_query: Dict[str, str],
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file.
     Testing with a BED file that is not correctly formatted."""
@@ -173,10 +152,10 @@ def test_d4_intervals_coverage_malformed_bed_file(
 
 
 def test_d4_intervals_coverage(
-    real_coverage_path: str,
-    client: TestClient,
-    endpoints: Type,
-    real_d4_query: Dict[str, str],
+        real_coverage_path: str,
+        client: TestClient,
+        endpoints: Type,
+        real_d4_query: Dict[str, str],
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file."""
 
@@ -199,24 +178,23 @@ def test_d4_intervals_coverage(
 
 @pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
 def test_load_genes(
-    build: str,
-    path: str,
-    client: TestClient,
-    endpoints: Type,
-    mocker: MockerFixture,
-    file_handler: Callable,
+        build: str,
+        path: str,
+        client: TestClient,
+        endpoints: Type,
+        mocker: MockerFixture,
 ):
     """Test the endpoint that adds genes to the database in a given genome build."""
 
     # GIVEN a patched response from Ensembl Biomart, via schug
-    gene_lines: Iterator = file_handler(path)
+    gene_lines: Iterator = resource_lines(path)
     mocker.patch(
         MOCKED_FILE_PARSER,
         return_value=gene_lines,
     )
 
     # GIVEN a number of genes contained in the demo file
-    nr_genes = len(list(file_handler(path))) - 1
+    nr_genes = len(list(resource_lines(path))) - 1
 
     # WHEN sending a request to the load_genes with genome build
     response: Response = client.post(f"{endpoints.LOAD_GENES}{build}")
@@ -238,7 +216,7 @@ def test_load_genes(
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
 def test_genes_by_multiple_ids(
-    build: str, client: TestClient, endpoints: Type, genes_per_build: Dict[str, List]
+        build: str, client: TestClient, endpoints: Type, genes_per_build: Dict[str, List]
 ):
     """Test filtering gene intervals providing more than one arg list"""
 
@@ -258,18 +236,17 @@ def test_genes_by_multiple_ids(
 
 @pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
 def test_genes_by_ensembl_ids(
-    build: str,
-    path: str,
-    client: TestClient,
-    endpoints: Type,
-    mocker: MockerFixture,
-    file_handler: Callable,
-    genes_per_build: Dict[str, List],
+        build: str,
+        path: str,
+        client: TestClient,
+        endpoints: Type,
+        mocker: MockerFixture,
+        genes_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of ensembl IDs."""
 
     # GIVEN a patched response from Ensembl Biomart, via schug
-    gene_lines: Iterator = file_handler(path)
+    gene_lines: Iterator = resource_lines(path)
     mocker.patch(
         MOCKED_FILE_PARSER,
         return_value=gene_lines,
@@ -293,18 +270,17 @@ def test_genes_by_ensembl_ids(
 
 @pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
 def test_genes_by_hgnc_ids(
-    build: str,
-    path: str,
-    client: TestClient,
-    endpoints: Type,
-    mocker: MockerFixture,
-    file_handler: Callable,
-    genes_per_build: Dict[str, List],
+        build: str,
+        path: str,
+        client: TestClient,
+        endpoints: Type,
+        mocker: MockerFixture,
+        genes_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of HGNC IDs."""
 
     # GIVEN a patched response from Ensembl Biomart, via schug
-    gene_lines: Iterator = file_handler(path)
+    gene_lines: Iterator = resource_lines(path)
     mocker.patch(
         MOCKED_FILE_PARSER,
         return_value=gene_lines,
@@ -328,18 +304,17 @@ def test_genes_by_hgnc_ids(
 
 @pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
 def test_genes_by_hgnc_symbols(
-    build: str,
-    path: str,
-    client: TestClient,
-    endpoints: Type,
-    mocker: MockerFixture,
-    file_handler: Callable,
-    genes_per_build: Dict[str, List],
+        build: str,
+        path: str,
+        client: TestClient,
+        endpoints: Type,
+        mocker: MockerFixture,
+        genes_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of HGNC symbols."""
 
     # GIVEN a patched response from Ensembl Biomart, via schug
-    gene_lines: Iterator = file_handler(path)
+    gene_lines: Iterator = resource_lines(path)
     mocker.patch(
         MOCKED_FILE_PARSER,
         return_value=gene_lines,
@@ -363,24 +338,23 @@ def test_genes_by_hgnc_symbols(
 
 @pytest.mark.parametrize("build, path", BUILD_TRANSCRIPTS_RESOURCE)
 def test_load_transcripts(
-    build: str,
-    path: str,
-    client: TestClient,
-    endpoints: Type,
-    mocker: MockerFixture,
-    file_handler: Callable,
+        build: str,
+        path: str,
+        client: TestClient,
+        endpoints: Type,
+        mocker: MockerFixture,
 ):
     """Test the endpoint that adds genes to the database in a given genome build."""
 
     # GIVEN a patched response from Ensembl Biomart, via schug
-    transcript_lines: Iterator = file_handler(path)
+    transcript_lines: Iterator = resource_lines(path)
     mocker.patch(
         MOCKED_FILE_PARSER,
         return_value=transcript_lines,
     )
 
     # GIVEN a number of transcripts contained in the demo file
-    nr_transcripts = len(list(file_handler(path))) - 1
+    nr_transcripts = len(list(resource_lines(path))) - 1
 
     # WHEN sending a request to the load_genes with genome build
     response: Response = client.post(f"{endpoints.LOAD_TRANSCRIPTS}{build}")
@@ -388,8 +362,8 @@ def test_load_transcripts(
     assert response.status_code == status.HTTP_200_OK
     # THEN all transcripts should be loaded
     assert (
-        response.json()["detail"]
-        == f"{nr_transcripts} transcripts loaded into the database"
+            response.json()["detail"]
+            == f"{nr_transcripts} transcripts loaded into the database"
     )
     # WHEN sending a request to the "transcripts" endpoint
     response: Response = client.get(f"{endpoints.TRANSCRIPTS}{build}")
@@ -403,24 +377,23 @@ def test_load_transcripts(
 
 @pytest.mark.parametrize("build, path", BUILD_EXONS_RESOURCE)
 def test_load_exons(
-    build: str,
-    path: str,
-    client: TestClient,
-    endpoints: Type,
-    mocker: MockerFixture,
-    file_handler: Callable,
+        build: str,
+        path: str,
+        client: TestClient,
+        endpoints: Type,
+        mocker: MockerFixture,
 ):
     """Test the endpoint that adds exons to the database in a given genome build."""
 
     # GIVEN a patched response from Ensembl Biomart, via schug
-    exons_lines: TextIOWrapper = file_handler(path)
+    exons_lines: TextIOWrapper = resource_lines(path)
     mocker.patch(
         MOCKED_FILE_PARSER,
         return_value=exons_lines,
     )
 
     # GIVEN a number of exons contained in the demo file
-    nr_exons = len(list(file_handler(path))) - 1
+    nr_exons = len(list(resource_lines(path))) - 1
 
     # WHEN sending a request to the load_genes with genome build
     response: Response = client.post(f"{endpoints.LOAD_EXONS}{build}")

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -16,7 +16,11 @@ from chanjo2.models.pydantic_models import (
     Gene,
     Transcript,
 )
-from chanjo2.populate_demo import BUILD_GENES_RESOURCE, BUILD_TRANSCRIPTS_RESOURCE, BUILD_EXONS_RESOURCE
+from chanjo2.populate_demo import (
+    BUILD_GENES_RESOURCE,
+    BUILD_TRANSCRIPTS_RESOURCE,
+    BUILD_EXONS_RESOURCE,
+)
 from chanjo2.populate_demo import resource_lines
 from fastapi import status
 from fastapi.testclient import TestClient
@@ -26,7 +30,7 @@ MOCKED_FILE_PARSER = "chanjo2.meta.handle_load_intervals.read_resource_lines"
 
 
 def test_d4_interval_coverage_d4_not_found(
-        client: TestClient, mock_coverage_file: str, endpoints: Type, interval_query: dict
+    client: TestClient, mock_coverage_file: str, endpoints: Type, interval_query: dict
 ):
     """Test the function that returns the coverage over an interval of a D4 file.
     Testing with a D4 file not found on disk or on a remote server."""
@@ -44,10 +48,10 @@ def test_d4_interval_coverage_d4_not_found(
 
 
 def test_d4_interval_coverage(
-        client: TestClient,
-        real_coverage_path: str,
-        endpoints: Type,
-        interval_query: dict,
+    client: TestClient,
+    real_coverage_path: str,
+    endpoints: Type,
+    interval_query: dict,
 ):
     """Test the function that returns the coverage over an interval of a D4 file."""
 
@@ -70,10 +74,10 @@ def test_d4_interval_coverage(
 
 
 def test_d4_interval_coverage_single_chromosome(
-        client: TestClient,
-        real_coverage_path: str,
-        endpoints: Type,
-        interval_query: dict,
+    client: TestClient,
+    real_coverage_path: str,
+    endpoints: Type,
+    interval_query: dict,
 ):
     """Test the function that returns the coverage over an entire chsomosome of a D4 file."""
 
@@ -99,7 +103,7 @@ def test_d4_interval_coverage_single_chromosome(
 
 
 def test_d4_intervals_coverage_d4_not_found(
-        mock_coverage_file: str, client: TestClient, endpoints: Type
+    mock_coverage_file: str, client: TestClient, endpoints: Type
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file.
     Testing with a D4 file not found on disk or on a remote server."""
@@ -125,11 +129,11 @@ def test_d4_intervals_coverage_d4_not_found(
 
 
 def test_d4_intervals_coverage_malformed_bed_file(
-        bed_path_malformed: PosixPath,
-        real_coverage_path: str,
-        client: TestClient,
-        endpoints: Type,
-        real_d4_query: Dict[str, str],
+    bed_path_malformed: PosixPath,
+    real_coverage_path: str,
+    client: TestClient,
+    endpoints: Type,
+    real_d4_query: Dict[str, str],
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file.
     Testing with a BED file that is not correctly formatted."""
@@ -152,10 +156,10 @@ def test_d4_intervals_coverage_malformed_bed_file(
 
 
 def test_d4_intervals_coverage(
-        real_coverage_path: str,
-        client: TestClient,
-        endpoints: Type,
-        real_d4_query: Dict[str, str],
+    real_coverage_path: str,
+    client: TestClient,
+    endpoints: Type,
+    real_d4_query: Dict[str, str],
 ):
     """Test the function that returns the coverage over multiple intervals of a D4 file."""
 
@@ -178,11 +182,11 @@ def test_d4_intervals_coverage(
 
 @pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
 def test_load_genes(
-        build: str,
-        path: str,
-        client: TestClient,
-        endpoints: Type,
-        mocker: MockerFixture,
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
 ):
     """Test the endpoint that adds genes to the database in a given genome build."""
 
@@ -216,7 +220,7 @@ def test_load_genes(
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
 def test_genes_by_multiple_ids(
-        build: str, client: TestClient, endpoints: Type, genes_per_build: Dict[str, List]
+    build: str, client: TestClient, endpoints: Type, genes_per_build: Dict[str, List]
 ):
     """Test filtering gene intervals providing more than one arg list"""
 
@@ -236,12 +240,12 @@ def test_genes_by_multiple_ids(
 
 @pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
 def test_genes_by_ensembl_ids(
-        build: str,
-        path: str,
-        client: TestClient,
-        endpoints: Type,
-        mocker: MockerFixture,
-        genes_per_build: Dict[str, List],
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
+    genes_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of ensembl IDs."""
 
@@ -270,12 +274,12 @@ def test_genes_by_ensembl_ids(
 
 @pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
 def test_genes_by_hgnc_ids(
-        build: str,
-        path: str,
-        client: TestClient,
-        endpoints: Type,
-        mocker: MockerFixture,
-        genes_per_build: Dict[str, List],
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
+    genes_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of HGNC IDs."""
 
@@ -304,12 +308,12 @@ def test_genes_by_hgnc_ids(
 
 @pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
 def test_genes_by_hgnc_symbols(
-        build: str,
-        path: str,
-        client: TestClient,
-        endpoints: Type,
-        mocker: MockerFixture,
-        genes_per_build: Dict[str, List],
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
+    genes_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of HGNC symbols."""
 
@@ -338,11 +342,11 @@ def test_genes_by_hgnc_symbols(
 
 @pytest.mark.parametrize("build, path", BUILD_TRANSCRIPTS_RESOURCE)
 def test_load_transcripts(
-        build: str,
-        path: str,
-        client: TestClient,
-        endpoints: Type,
-        mocker: MockerFixture,
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
 ):
     """Test the endpoint that adds genes to the database in a given genome build."""
 
@@ -362,8 +366,8 @@ def test_load_transcripts(
     assert response.status_code == status.HTTP_200_OK
     # THEN all transcripts should be loaded
     assert (
-            response.json()["detail"]
-            == f"{nr_transcripts} transcripts loaded into the database"
+        response.json()["detail"]
+        == f"{nr_transcripts} transcripts loaded into the database"
     )
     # WHEN sending a request to the "transcripts" endpoint
     response: Response = client.get(f"{endpoints.TRANSCRIPTS}{build}")
@@ -377,11 +381,11 @@ def test_load_transcripts(
 
 @pytest.mark.parametrize("build, path", BUILD_EXONS_RESOURCE)
 def test_load_exons(
-        build: str,
-        path: str,
-        client: TestClient,
-        endpoints: Type,
-        mocker: MockerFixture,
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
 ):
     """Test the endpoint that adds exons to the database in a given genome build."""
 

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -390,7 +390,7 @@ def test_load_exons(
     """Test the endpoint that adds exons to the database in a given genome build."""
 
     # GIVEN a patched response from Ensembl Biomart, via schug
-    exons_lines: TextIOWrapper = resource_lines(path)
+    exons_lines: Iterator = resource_lines(path)
     mocker.patch(
         MOCKED_FILE_PARSER,
         return_value=exons_lines,

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -397,7 +397,7 @@ def test_load_exons(
     )
 
     # GIVEN a number of exons contained in the demo file
-    nr_exons = len(list(resource_lines(path))) - 1
+    nr_exons: int = len(list(resource_lines(path))) - 1
 
     # WHEN sending a request to the load_genes with genome build
     response: Response = client.post(f"{endpoints.LOAD_EXONS}{build}")

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -198,7 +198,7 @@ def test_load_genes(
     )
 
     # GIVEN a number of genes contained in the demo file
-    nr_genes = len(list(resource_lines(path))) - 1
+    nr_genes: int = len(list(resource_lines(path))) - 1
 
     # WHEN sending a request to the load_genes with genome build
     response: Response = client.post(f"{endpoints.LOAD_GENES}{build}")

--- a/tests/src/chanjo2/test_populate_demo.py
+++ b/tests/src/chanjo2/test_populate_demo.py
@@ -1,7 +1,10 @@
 from chanjo2.crud.cases import get_cases
+from chanjo2.crud.intervals import get_genes, get_transcripts, get_exons
+from chanjo2.crud.samples import get_samples
 from chanjo2.dbutil import get_session
 from chanjo2.main import app
-from chanjo2.models.sql_models import Case
+from chanjo2.models.pydantic_models import Builds
+from chanjo2.models.sql_models import Case, Sample, Gene, Transcript, Exon
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import sessionmaker
 
@@ -14,6 +17,33 @@ def test_load_demo_data():
 
     # WHEN the app is launched
     with TestClient(app) as client:
-        # THEN a demo case should be found in the database
-        cases: List[Case] = get_cases(db)
+        # THEN database should contain a case
+        cases: List[Case] = get_cases(db=db)
         assert isinstance(cases[0], Case)
+
+        # THEN database should contain samples
+        samples: List[Sample] = get_samples(db=db)
+        assert isinstance(samples[0], Sample)
+
+        # THEN for each genome build
+        for build in Builds.get_enum_values():
+            # database should contain genes
+            genes: List[Gene] = get_genes(
+                db=db,
+                build=build,
+                ensembl_ids=None,
+                hgnc_ids=None,
+                hgnc_symbols=None,
+                limit=1,
+            )
+            assert isinstance(genes[0], Gene)
+
+            # database should contain transcripts
+            transcripts: List[Transcripts] = get_transcripts(
+                db=db, build=build, limit=1
+            )
+            assert isinstance(transcripts[0], Transcript)
+
+            # database should contain exons
+            exons: List[exons] = get_exons(db=db, build=build, limit=1)
+            assert isinstance(exons[0], Exon)


### PR DESCRIPTION
### This PR adds | fixes:
- Loads demo genes, transcripts and exons when chanjo2 demo is launched

### How to test:
- Start the demo instance and make sure those tables are populated

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
