### PR TITLE
Simplified tests using demo instance of database that already contains data

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,7 +99,7 @@ def client_fixture(session) -> TestClient:
 
 @pytest.fixture(name="demo_session", scope="function")
 def demo_session_fixture() -> TestClient:
-    """Returns an object of type sqlalchemy.orm.session.sessionmaker containing demo data.."""
+    """Returns an object of type sqlalchemy.orm.session.sessionmaker containing demo data."""
     return next(get_session())
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,13 +97,13 @@ def client_fixture(session) -> TestClient:
     return TestClient(app)
 
 
-@pytest.fixture(name="demo_session", scope="function")
+@pytest.fixture(name="demo_session", scope="module")
 def demo_session_fixture() -> TestClient:
     """Returns an object of type sqlalchemy.orm.session.sessionmaker containing demo data."""
     return next(get_session())
 
 
-@pytest.fixture(name="demo_client", scope="function")
+@pytest.fixture(name="demo_client", scope="module")
 def demo_client_fixture(demo_session) -> TestClient:
     """Returns a fastapi.testclient.TestClient used to test the endpoints of an app with a populated demo database."""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from enum import Enum
 from pathlib import PosixPath
 from typing import Dict, List, Tuple
 
@@ -55,25 +54,10 @@ class Endpoints(str, Enum):
     EXONS = "/intervals/exons/"
 
 
-class Helpers:
-    @staticmethod
-    def session_commit_item(session, item):
-        """Creates a database item and refreshes the session."""
-        session.add(item)
-        session.commit()
-        session.refresh(item)
-
-
 @pytest.fixture
 def endpoints() -> Endpoints:
     """returns an instance of the class Endpoints"""
     return Endpoints
-
-
-@pytest.fixture
-def helpers() -> Helpers:
-    """returns an instance of the class Helpers"""
-    return Helpers
 
 
 @pytest.fixture(name="test_db")
@@ -104,6 +88,28 @@ def client_fixture(session) -> TestClient:
     def _override_get_db():
         try:
             db = session
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_session] = _override_get_db
+
+    return TestClient(app)
+
+
+@pytest.fixture(name="demo_session", scope="function")
+def demo_session_fixture() -> TestClient:
+    """Returns an object of type sqlalchemy.orm.session.sessionmaker containing demo data.."""
+    return next(get_session())
+
+
+@pytest.fixture(name="demo_client", scope="function")
+def demo_client_fixture(demo_session) -> TestClient:
+    """Returns a fastapi.testclient.TestClient used to test the endpoints of an app with a populated demo database."""
+
+    def _override_get_db():
+        try:
+            db = demo_session
             yield db
         finally:
             db.close()

--- a/tests/src/chanjo2/endpoints/test_cases.py
+++ b/tests/src/chanjo2/endpoints/test_cases.py
@@ -1,10 +1,9 @@
 from typing import Dict, Type
 
 from chanjo2.models.pydantic_models import Case
-from chanjo2.models.sql_models import Case as SQLCase
+from chanjo2.populate_demo import DEMO_CASE
 from fastapi import status
 from fastapi.testclient import TestClient
-from sqlalchemy.orm import sessionmaker
 
 
 def test_create_case(client: TestClient, raw_case: Dict[str, str], endpoints: Type):
@@ -25,19 +24,14 @@ def test_create_case(client: TestClient, raw_case: Dict[str, str], endpoints: Ty
 
 
 def test_read_cases(
-    client: TestClient,
-    session: sessionmaker,
-    db_case: SQLCase,
+    demo_client: TestClient,
     endpoints: Type,
-    helpers: Type,
 ):
     """Test the endpoint returning all cases found in the database."""
 
-    # GIVEN a case object saved in the database
-    helpers.session_commit_item(session, db_case)
-
+    # GIVEN a populated database
     # THEN the read_cases endpoint should return the case
-    response = client.get(endpoints.CASES)
+    response = demo_client.get(endpoints.CASES)
     assert response.status_code == status.HTTP_200_OK
     result = response.json()
     assert len(result) == 1
@@ -45,19 +39,14 @@ def test_read_cases(
 
 
 def test_read_case(
-    client: TestClient,
-    session: sessionmaker,
-    db_case: SQLCase,
+    demo_client: TestClient,
     endpoints: Type,
-    helpers: Type,
 ):
     """Test the endpoint that returns a specific case."""
 
-    # GIVEN a case object saved in the database
-    helpers.session_commit_item(session, db_case)
-
+    # GIVEN a populated database
     # WHEN sending a GET request to retrieve the specific case using its name
-    response = client.get(f"{endpoints.CASES}{db_case.name}")
+    response = demo_client.get(f"{endpoints.CASES}{DEMO_CASE['name']}")
 
     # THEN it should  return success
     assert response.status_code == status.HTTP_200_OK

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -1,4 +1,3 @@
-from _io import TextIOWrapper
 from pathlib import PosixPath
 from typing import Dict, Iterator, List, Type
 
@@ -238,33 +237,22 @@ def test_genes_by_multiple_ids(
     assert result["detail"] == MULTIPLE_PARAMS_NOT_SUPPORTED_MSG
 
 
-@pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
+@pytest.mark.parametrize("build", Builds.get_enum_values())
 def test_genes_by_ensembl_ids(
     build: str,
-    path: str,
-    client: TestClient,
+    demo_client: TestClient,
     endpoints: Type,
-    mocker: MockerFixture,
     genes_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of ensembl IDs."""
 
-    # GIVEN a patched response from Ensembl Biomart, via schug
-    gene_lines: Iterator = resource_lines(path)
-    mocker.patch(
-        MOCKED_FILE_PARSER,
-        return_value=gene_lines,
-    )
-
-    # GIVEN that genes present in the database
-    client.post(f"{endpoints.LOAD_GENES}{build}")
-
+    # GIVEN a populated demo database
     # WHEN sending a request to the "genes" endpoint with a list of Ensembl IDs
     data = {
         "build": build,
         "ensembl_ids": genes_per_build[build]["ensembl_ids"],
     }
-    response: Response = client.post(endpoints.GENES, json=data)
+    response: Response = demo_client.post(endpoints.GENES, json=data)
     # THEN the expected number of genes should be returned
     assert response.status_code == status.HTTP_200_OK
     result = response.json()
@@ -272,33 +260,22 @@ def test_genes_by_ensembl_ids(
     assert Gene(**result[0])
 
 
-@pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
+@pytest.mark.parametrize("build", Builds.get_enum_values())
 def test_genes_by_hgnc_ids(
     build: str,
-    path: str,
-    client: TestClient,
+    demo_client: TestClient,
     endpoints: Type,
-    mocker: MockerFixture,
     genes_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of HGNC IDs."""
 
-    # GIVEN a patched response from Ensembl Biomart, via schug
-    gene_lines: Iterator = resource_lines(path)
-    mocker.patch(
-        MOCKED_FILE_PARSER,
-        return_value=gene_lines,
-    )
-
-    # GIVEN that genes present in the database
-    client.post(f"{endpoints.LOAD_GENES}{build}")
-
+    # GIVEN a populated demo database
     # WHEN sending a request to the "genes" endpoint with a list of HGNC ids
     data = {
         "build": build,
         "hgnc_ids": genes_per_build[build]["hgnc_ids"],
     }
-    response: Response = client.post(endpoints.GENES, json=data)
+    response: Response = demo_client.post(endpoints.GENES, json=data)
     # THEN the expected number of genes should be returned
     assert response.status_code == status.HTTP_200_OK
     result = response.json()
@@ -306,33 +283,22 @@ def test_genes_by_hgnc_ids(
     assert Gene(**result[0])
 
 
-@pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
+@pytest.mark.parametrize("build", Builds.get_enum_values())
 def test_genes_by_hgnc_symbols(
     build: str,
-    path: str,
-    client: TestClient,
+    demo_client: TestClient,
     endpoints: Type,
-    mocker: MockerFixture,
     genes_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of HGNC symbols."""
 
-    # GIVEN a patched response from Ensembl Biomart, via schug
-    gene_lines: Iterator = resource_lines(path)
-    mocker.patch(
-        MOCKED_FILE_PARSER,
-        return_value=gene_lines,
-    )
-
-    # GIVEN that genes present in the database
-    client.post(f"{endpoints.LOAD_GENES}{build}")
-
+    # GIVEN a populated demo database
     # WHEN sending a request to the "genes" endpoint with a list of HGNC symbols
     data = {
         "build": build,
         "hgnc_symbols": genes_per_build[build]["hgnc_symbols"],
     }
-    response: Response = client.post(endpoints.GENES, json=data)
+    response: Response = demo_client.post(endpoints.GENES, json=data)
     # THEN the expected number of genes should be returned
     assert response.status_code == status.HTTP_200_OK
     result = response.json()

--- a/tests/src/chanjo2/test_populate_demo.py
+++ b/tests/src/chanjo2/test_populate_demo.py
@@ -1,35 +1,30 @@
 from chanjo2.crud.cases import get_cases
 from chanjo2.crud.intervals import get_genes, get_transcripts, get_exons
 from chanjo2.crud.samples import get_samples
-from chanjo2.dbutil import get_session
-from chanjo2.main import app
 from chanjo2.models.pydantic_models import Builds
 from chanjo2.models.sql_models import Case, Sample, Gene, Transcript, Exon
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import sessionmaker
 
-client = TestClient(app)
-db: sessionmaker = next(get_session())
 
-
-def test_load_demo_data():
+def test_load_demo_data(demo_client: TestClient, demo_session: sessionmaker):
     """Test loading demo data."""
 
     # WHEN the app is launched
-    with TestClient(app) as client:
+    with demo_client:
         # THEN database should contain a case
-        cases: List[Case] = get_cases(db=db)
+        cases: List[Case] = get_cases(db=demo_session)
         assert isinstance(cases[0], Case)
 
         # THEN database should contain samples
-        samples: List[Sample] = get_samples(db=db)
+        samples: List[Sample] = get_samples(db=demo_session)
         assert isinstance(samples[0], Sample)
 
         # THEN for each genome build
         for build in Builds.get_enum_values():
             # database should contain genes
             genes: List[Gene] = get_genes(
-                db=db,
+                db=demo_session,
                 build=build,
                 ensembl_ids=None,
                 hgnc_ids=None,
@@ -40,10 +35,10 @@ def test_load_demo_data():
 
             # database should contain transcripts
             transcripts: List[Transcripts] = get_transcripts(
-                db=db, build=build, limit=1
+                db=demo_session, build=build, limit=1
             )
             assert isinstance(transcripts[0], Transcript)
 
             # database should contain exons
-            exons: List[exons] = get_exons(db=db, build=build, limit=1)
+            exons: List[exons] = get_exons(db=demo_session, build=build, limit=1)
             assert isinstance(exons[0], Exon)


### PR DESCRIPTION
### This PR adds | fixes:
- The demo database now contains all types of test data. This data can be used directly in tests without the need to load data in tests first. This allows removing many lines of code, that now become redundant.

### How to test:
- Automatic tests

### Expected outcome:
- [x] All tests should pass

### Review:
- [x] Code approved by
- [x] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
