### PR TITLE
Filter exons by Ensmbl IDs, Ensembl gene IDs, HGNC IDs, HGNC symbols

### DIFF
--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -7,9 +7,7 @@ WRONG_COVERAGE_FILE_MSG: str = (
     "Coverage_file_path must be either an existing local file path or a URL"
 )
 WRONG_BED_FILE_MSG: str = "Provided intervals files is not a valid BED file"
-MULTIPLE_PARAMS_NOT_SUPPORTED_MSG = (
-    "Please provide EITHER Ensembl IDs OR HGNC IDs OR HGNC symbols"
-)
+MULTIPLE_PARAMS_NOT_SUPPORTED_MSG = "Interval query contains too many filter parameters. Please specify genome build and max one type of filter."
 
 ENSEMBL_RESOURCE_CLIENT: Dict[str, Callable] = {
     "genes": fetch_ensembl_genes,

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -146,16 +146,11 @@ def get_transcript_from_ensembl_id(
 def create_db_transcript(db: Session, transcript: TranscriptBase) -> SQLTranscript:
     """Create and return a SQL transcript object."""
 
-    ensembl_gene: SQLGene = get_gene_from_ensembl_id(
-        db=db, ensembl_id=transcript.ensembl_gene_id
-    )
-
     return SQLTranscript(
         chromosome=transcript.chromosome,
         start=transcript.start,
         stop=transcript.stop,
         ensembl_id=transcript.ensembl_id,
-        ensembl_gene_ref=ensembl_gene.id if ensembl_gene else None,
         ensembl_gene_id=transcript.ensembl_gene_id,
         refseq_mrna=transcript.refseq_mrna,
         refseq_mrna_pred=transcript.refseq_mrna_pred,
@@ -193,11 +188,11 @@ def get_gene_intervals(
     genes = db.query(SQLGene)
     if hgnc_ids:
         genes: query.Query = _filter_intervals_by_hgnc_ids(
-            intervals=genes, interval_type=interval_type, hgnc_ids=hgnc_ids
+            intervals=genes, interval_type=SQLGene, hgnc_ids=hgnc_ids
         ).all()
     elif hgnc_symbols:
         genes: query.Query = _filter_intervals_by_hgnc_symbols(
-            intervals=genes, interval_type=interval_type, hgnc_symbols=hgnc_symbols
+            intervals=genes, interval_type=SQLGene, hgnc_symbols=hgnc_symbols
         ).all()
     if hgnc_ids or hgnc_symbols:
         ensembl_gene_ids: List[str] = [gene.ensembl_id for gene in genes]
@@ -226,21 +221,12 @@ def get_gene_intervals(
 def create_db_exon(db: Session, exon: ExonBase) -> SQLExon:
     """Create and return a SQL exon object."""
 
-    ensembl_gene: SQLGene = get_gene_from_ensembl_id(
-        db=db, ensembl_id=exon.ensembl_gene_id
-    )
-    ensembl_transcript: SQLTranscript = get_transcript_from_ensembl_id(
-        db=db, ensembl_id=exon.ensembl_transcript_id
-    )
-
     return SQLExon(
         chromosome=exon.chromosome,
         start=exon.start,
         stop=exon.stop,
         ensembl_id=exon.ensembl_id,
         ensembl_gene_id=exon.ensembl_gene_id,
-        ensembl_gene_ref=ensembl_gene.id if ensembl_gene else None,
-        ensembl_transcript_ref=ensembl_transcript.id if ensembl_transcript else None,
         build=exon.build,
     )
 

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -26,8 +26,7 @@ from chanjo2.models.pydantic_models import (
     Gene,
     Transcript,
     GeneQuery,
-    TranscriptQuery,
-    ExonQuery,
+    GeneIntervalQuery,
 )
 from chanjo2.models.sql_models import Exon as SQLExon
 from chanjo2.models.sql_models import Transcript as SQLTranscript
@@ -169,7 +168,7 @@ async def load_transcripts(
 
 @router.post("/intervals/transcripts")
 async def transcripts(
-    query: TranscriptQuery, session: Session = Depends(get_session)
+    query: GeneIntervalQuery, session: Session = Depends(get_session)
 ) -> List[Transcript]:
     """Return transcripts according to query parameters."""
     nr_filters = count_nr_filters(
@@ -218,7 +217,7 @@ async def load_exons(
 
 @router.post("/intervals/exons")
 async def exons(
-    query: ExonQuery, session: Session = Depends(get_session)
+    query: GeneIntervalQuery, session: Session = Depends(get_session)
 ) -> List[Exon]:
     """Return exons in the given genome build."""
     nr_filters = count_nr_filters(

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -27,6 +27,7 @@ from chanjo2.models.pydantic_models import (
     Transcript,
     GeneQuery,
     TranscriptQuery,
+    ExonQuery,
 )
 from fastapi import APIRouter, Depends, File, HTTPException, Response, status
 from fastapi.responses import JSONResponse
@@ -212,9 +213,9 @@ async def load_exons(
         )
 
 
-@router.get("/intervals/exons/{build}")
+@router.post("/intervals/exons")
 async def exons(
-    build: Builds, session: Session = Depends(get_session), limit: int = 100
+    query: ExonQuery, session: Session = Depends(get_session)
 ) -> List[Exon]:
     """Return exons in the given genome build."""
-    return get_exons(db=session, build=build, limit=limit)
+    return get_exons(db=session, build=query.build, limit=query.limit)

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -93,12 +93,8 @@ class GeneQuery(BaseModel):
     limit: Optional[int] = 100
 
 
-class TranscriptQuery(GeneQuery):
+class GeneIntervalQuery(GeneQuery):
     ensembl_gene_ids: Optional[List[str]]
-
-
-class ExonQuery(TranscriptQuery):
-    pass
 
 
 class Gene(IntervalBase):

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -97,8 +97,8 @@ class TranscriptQuery(GeneQuery):
     ensembl_gene_ids: Optional[List[str]]
 
 
-class ExonQuery(GeneQuery):
-    ensembl_transcript_id: Optional[List[str]]
+class ExonQuery(TranscriptQuery):
+    pass
 
 
 class Gene(IntervalBase):

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -106,8 +106,8 @@ class Gene(IntervalBase):
 
 
 class TranscriptBase(IntervalBase):
-    ensembl_gene_id: str
     ensembl_id: str
+    ensembl_gene_id: str
     refseq_mrna: Optional[str]
     refseq_mrna_pred: Optional[str]
     refseq_ncrna: Optional[str]
@@ -118,10 +118,10 @@ class TranscriptBase(IntervalBase):
 
 class Transcript(TranscriptBase):
     id: int
-    ensembl_gene_ref: Optional[int]
 
 
 class ExonBase(IntervalBase):
+    ensembl_id: str
     ensembl_gene_id: str
     ensembl_transcript_id: str
     ensembl_id: str
@@ -130,10 +130,6 @@ class ExonBase(IntervalBase):
 
 class Exon(IntervalBase):
     id: int
-    ensembl_id: str
-    ensembl_gene_ref: Optional[int]
-    ensembl_transcript_ref: Optional[int]
-    build: Builds
 
 
 class CoverageInterval(BaseModel):

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -97,6 +97,10 @@ class TranscriptQuery(GeneQuery):
     ensembl_gene_ids: Optional[List[str]]
 
 
+class ExonQuery(GeneQuery):
+    ensembl_transcript_id: Optional[List[str]]
+
+
 class Gene(IntervalBase):
     id: int
 

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -1,6 +1,6 @@
 from chanjo2.dbutil import Base
 from chanjo2.models.pydantic_models import Builds
-from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String, Table
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -73,9 +73,6 @@ class Transcript(Base):
     refseq_ncrna = Column(String(24), nullable=True, index=False)
     refseq_mane_select = Column(String(24), nullable=True, index=True)
     refseq_mane_plus_clinical = Column(String(24), nullable=True, index=True)
-    ensembl_gene_ref = Column(
-        Integer, ForeignKey("genes.id"), nullable=True, index=True
-    )
     ensembl_gene_id = Column(String(24), nullable=False, index=True)
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
@@ -92,12 +89,6 @@ class Exon(Base):
     stop = Column(Integer, nullable=False)
     ensembl_id = Column(String(24), nullable=False, index=False)
     ensembl_gene_id = Column(String(24), nullable=False, index=True)
-    ensembl_transcript_ref = Column(
-        Integer, ForeignKey("transcripts.id"), nullable=True, index=True
-    )
-    ensembl_gene_ref = Column(
-        Integer, ForeignKey("genes.id"), nullable=True, index=True
-    )
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,7 @@ class Endpoints(str, Enum):
     INTERVAL_COVERAGE = "/intervals/coverage/d4/interval/"
     INTERVALS_FILE_COVERAGE = "/intervals/coverage/d4/interval_file/"
     LOAD_EXONS = "/intervals/load/exons/"
-    EXONS = "/intervals/exons/"
+    EXONS = "/intervals/exons"
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,27 +22,19 @@ COVERAGE_FILE = "a_file.d4"
 BED_FILE = "a_file.bed"
 REMOTE_COVERAGE_FILE = "https://a_remote_host/a_file.d4"
 CONTENT: str = "content"
-GENE_LISTS_37: Dict[str, List] = {
-    "ensembl_ids": ["ENSG00000233440", "ENSG00000207157", "ENSG00000196593"],
+GENOMIC_IDS_37: Dict[str, List] = {
+    "ensembl_exons_ids": ["ENSE00001799379", "ENSE00001499436", "ENSE00001676225"],
+    "ensembl_transcript_ids": ["ENST00000418454", "ENST00000384428", "ENST00000414345"],
+    "ensembl_gene_ids": ["ENSG00000233440", "ENSG00000207157", "ENSG00000196593"],
     "hgnc_ids": [19121, 42488, 42737],
     "hgnc_symbols": ["HMGA1P6", "RNY3P4", "ANKRD20A19P"],
 }
-GENE_LISTS_38: Dict[str, List] = {
-    "ensembl_ids": ["ENSG00000160072", "ENSG00000142611", "ENSG00000171729"],
+GENOMIC_IDS_38: Dict[str, List] = {
+    "ensembl_exons_ids": ["ENSE00003889014", "ENSE00003689846", "ENSE00003510521"],
+    "ensembl_transcript_ids": ["ENST00000673477", "ENST00000378391", "ENST00000270722"],
+    "ensembl_gene_ids": ["ENSG00000160072", "ENSG00000142611", "ENSG00000171729"],
     "hgnc_ids": [24007, 14000, 25488],
     "hgnc_symbols": ["ATAD3B", "PRDM16", "TMEM51"],
-}
-TRANSCRIPT_LISTS_37: Dict[str, List] = {
-    "ensembl_ids": ["ENST00000418454", "ENST00000384428", "ENST00000414345"],
-    "ensembl_gene_ids": GENE_LISTS_37["ensembl_ids"],
-    "hgnc_ids": GENE_LISTS_37["hgnc_ids"],
-    "hgnc_symbols": GENE_LISTS_37["hgnc_symbols"],
-}
-TRANSCRIPT_LISTS_38: Dict[str, List] = {
-    "ensembl_ids": ["ENST00000673477", "ENST00000378391", "ENST00000270722"],
-    "ensembl_gene_ids": GENE_LISTS_38["ensembl_ids"],
-    "hgnc_ids": GENE_LISTS_38["hgnc_ids"],
-    "hgnc_symbols": GENE_LISTS_38["hgnc_symbols"],
 }
 
 engine = create_engine(TEST_DB, connect_args=DEMO_CONNECT_ARGS)
@@ -233,13 +225,7 @@ def real_d4_query(real_coverage_path) -> Dict[str, str]:
     }
 
 
-@pytest.fixture(name="genes_per_build")
-def genes_per_build() -> Dict[str, List]:
+@pytest.fixture(name="genomic_ids_per_build")
+def genomic_ids_per_build() -> Dict[str, List]:
     """Return a dict containing lists with test genes in different build specific formats."""
-    return {BUILD_37: GENE_LISTS_37, BUILD_38: GENE_LISTS_38}
-
-
-@pytest.fixture(name="transcripts_per_build")
-def transcripts_per_build() -> Dict[str, List]:
-    """Return a dict containing lists with test transcripts in different build specific formats."""
-    return {BUILD_37: TRANSCRIPT_LISTS_37, BUILD_38: TRANSCRIPT_LISTS_38}
+    return {BUILD_37: GENOMIC_IDS_37, BUILD_38: GENOMIC_IDS_38}

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -489,7 +489,7 @@ def test_load_exons(
     assert response.json()["detail"] == f"{nr_exons} exons loaded into the database"
 
     # WHEN sending a request to the "exons" endpoint
-    response: Response = client.get(f"{endpoints.EXONS}{build}")
+    response: Response = client.post(endpoints.EXONS, json={"build": build})
     assert response.status_code == status.HTTP_200_OK
     result = response.json()
     # THEN the expected number of exons should be returned

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -218,16 +218,19 @@ def test_load_genes(
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
-def test_genes_by_multiple_ids(
-    build: str, client: TestClient, endpoints: Type, genes_per_build: Dict[str, List]
+def test_genes_multiple_filters(
+    build: str,
+    client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
 ):
-    """Test filtering gene intervals providing more than one arg list"""
+    """Test filtering gene intervals providing more than one filter"""
 
     # GIVEN a query with genome build and more than one gene ID:
     data = {
         "build": build,
-        "ensembl_ids": genes_per_build[build]["ensembl_ids"],
-        "hgnc_ids": genes_per_build[build]["hgnc_ids"],
+        "ensembl_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
+        "hgnc_ids": genomic_ids_per_build[build]["hgnc_ids"],
     }
     # WHEN sending a POST request to the genes endpoint with the query params above
     response: Response = client.post(endpoints.GENES, json=data)
@@ -242,7 +245,7 @@ def test_genes_by_ensembl_ids(
     build: str,
     demo_client: TestClient,
     endpoints: Type,
-    genes_per_build: Dict[str, List],
+    genomic_ids_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of ensembl IDs."""
 
@@ -250,13 +253,13 @@ def test_genes_by_ensembl_ids(
     # WHEN sending a request to the "genes" endpoint with a list of Ensembl IDs
     data = {
         "build": build,
-        "ensembl_ids": genes_per_build[build]["ensembl_ids"],
+        "ensembl_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
     }
     response: Response = demo_client.post(endpoints.GENES, json=data)
     # THEN the expected number of genes should be returned
     assert response.status_code == status.HTTP_200_OK
     result = response.json()
-    assert len(result) == len(genes_per_build[build]["ensembl_ids"])
+    assert len(result) == len(genomic_ids_per_build[build]["ensembl_gene_ids"])
     assert Gene(**result[0])
 
 
@@ -265,7 +268,7 @@ def test_genes_by_hgnc_ids(
     build: str,
     demo_client: TestClient,
     endpoints: Type,
-    genes_per_build: Dict[str, List],
+    genomic_ids_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of HGNC IDs."""
 
@@ -273,13 +276,13 @@ def test_genes_by_hgnc_ids(
     # WHEN sending a request to the "genes" endpoint with a list of HGNC ids
     data = {
         "build": build,
-        "hgnc_ids": genes_per_build[build]["hgnc_ids"],
+        "hgnc_ids": genomic_ids_per_build[build]["hgnc_ids"],
     }
     response: Response = demo_client.post(endpoints.GENES, json=data)
     # THEN the expected number of genes should be returned
     assert response.status_code == status.HTTP_200_OK
     result = response.json()
-    assert len(result) == len(genes_per_build[build]["hgnc_ids"])
+    assert len(result) == len(genomic_ids_per_build[build]["hgnc_ids"])
     assert Gene(**result[0])
 
 
@@ -288,7 +291,7 @@ def test_genes_by_hgnc_symbols(
     build: str,
     demo_client: TestClient,
     endpoints: Type,
-    genes_per_build: Dict[str, List],
+    genomic_ids_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database genes using a list of HGNC symbols."""
 
@@ -296,13 +299,13 @@ def test_genes_by_hgnc_symbols(
     # WHEN sending a request to the "genes" endpoint with a list of HGNC symbols
     data = {
         "build": build,
-        "hgnc_symbols": genes_per_build[build]["hgnc_symbols"],
+        "hgnc_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
     }
     response: Response = demo_client.post(endpoints.GENES, json=data)
     # THEN the expected number of genes should be returned
     assert response.status_code == status.HTTP_200_OK
     result = response.json()
-    assert len(result) == len(genes_per_build[build]["hgnc_symbols"])
+    assert len(result) == len(genomic_ids_per_build[build]["hgnc_symbols"])
     assert Gene(**result[0])
 
 
@@ -346,19 +349,19 @@ def test_load_transcripts(
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
-def test_transcripts_by_multiple_ids(
+def test_transcripts_multiple_filters(
     build: str,
     client: TestClient,
     endpoints: Type,
-    transcripts_per_build: Dict[str, List],
+    genomic_ids_per_build: Dict[str, List],
 ):
-    """Test filtering transcript intervals providing more than one arg list."""
+    """Test filtering transcript intervals providing more than one filter.."""
 
-    # GIVEN a query to "transcripts" enspoint with genome build and more than one ID:
+    # GIVEN a query to "transcripts" enspoind with genome build and more than one ID:
     data = {
         "build": build,
-        "ensembl_ids": transcripts_per_build[build]["ensembl_ids"],
-        "ensembl_gene_ids": transcripts_per_build[build]["ensembl_gene_ids"],
+        "ensembl_ids": genomic_ids_per_build[build]["ensembl_transcript_ids"],
+        "ensembl_gene_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
     }
     # WHEN sending a POST request to the transcripts endpoint with the query params above
     response: Response = client.post(endpoints.TRANSCRIPTS, json=data)
@@ -373,7 +376,7 @@ def test_transcripts_by_ensembl_ids(
     build: str,
     demo_client: TestClient,
     endpoints: Type,
-    transcripts_per_build: Dict[str, List],
+    genomic_ids_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database transcripts using a list of Ensembl IDs."""
 
@@ -381,7 +384,7 @@ def test_transcripts_by_ensembl_ids(
     # WHEN sending a request to the "transcripts" endpoint with a list of Ensembl IDs
     data = {
         "build": build,
-        "ensembl_ids": transcripts_per_build[build]["ensembl_ids"],
+        "ensembl_ids": genomic_ids_per_build[build]["ensembl_transcript_ids"],
     }
     response: Response = demo_client.post(endpoints.TRANSCRIPTS, json=data)
 
@@ -396,7 +399,7 @@ def test_transcripts_by_ensembl_gene_ids(
     build: str,
     demo_client: TestClient,
     endpoints: Type,
-    transcripts_per_build: Dict[str, List],
+    genomic_ids_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database transcripts using a list of Ensembl gene IDs."""
 
@@ -404,7 +407,7 @@ def test_transcripts_by_ensembl_gene_ids(
     # WHEN sending a request to the "transcripts" endpoint with a list of Ensembl gene IDs
     data = {
         "build": build,
-        "ensembl_gene_ids": transcripts_per_build[build]["ensembl_gene_ids"],
+        "ensembl_gene_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
     }
     response: Response = demo_client.post(endpoints.TRANSCRIPTS, json=data)
 
@@ -419,7 +422,7 @@ def test_transcripts_by_hgnc_ids(
     build: str,
     demo_client: TestClient,
     endpoints: Type,
-    transcripts_per_build: Dict[str, List],
+    genomic_ids_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database transcripts using a list of HGNC gene IDs."""
 
@@ -427,7 +430,7 @@ def test_transcripts_by_hgnc_ids(
     # WHEN sending a request to the "transcripts" endpoint with a list of HGNC gene IDs
     data = {
         "build": build,
-        "hgnc_gene_ids": transcripts_per_build[build]["hgnc_ids"],
+        "hgnc_gene_ids": genomic_ids_per_build[build]["hgnc_ids"],
     }
     response: Response = demo_client.post(endpoints.TRANSCRIPTS, json=data)
 
@@ -442,7 +445,7 @@ def test_transcripts_by_hgnc_symbols(
     build: str,
     demo_client: TestClient,
     endpoints: Type,
-    transcripts_per_build: Dict[str, List],
+    genomic_ids_per_build: Dict[str, List],
 ):
     """Test the endpoint that filters database transcripts using a list of HGNC gene symbols."""
 
@@ -450,7 +453,7 @@ def test_transcripts_by_hgnc_symbols(
     # WHEN sending a request to the "transcripts" endpoint with a list of HGNC gene symbols
     data = {
         "build": build,
-        "hgnc_gene_symbols": transcripts_per_build[build]["hgnc_symbols"],
+        "hgnc_gene_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
     }
     response: Response = demo_client.post(endpoints.TRANSCRIPTS, json=data)
 
@@ -495,4 +498,119 @@ def test_load_exons(
     # THEN the expected number of exons should be returned
     assert len(result) == nr_exons
     # AND the exons should have the right format
+    assert Exon(**result[0])
+
+
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_exons_multiple_filters(
+    build: str,
+    client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test filtering exon intervals providing more than one filter."""
+
+    # GIVEN a query to "exons" enspoint with genome build and more than one ID:
+    data = {
+        "build": build,
+        "ensembl_ids": genomic_ids_per_build[build]["ensembl_exons_ids"],
+        "ensembl_gene_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
+    }
+    # WHEN sending a POST request to the exons endpoint with the query params above
+    response: Response = client.post(endpoints.EXONS, json=data)
+    # THEN it should return HTTP 400 error
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    result = response.json()
+    assert result["detail"] == MULTIPLE_PARAMS_NOT_SUPPORTED_MSG
+
+
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_exons_by_ensembl_ids(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the endpoint that filters database exons using a list of Ensembl IDs."""
+
+    # GIVEN a populated demo database
+    # WHEN sending a request to the "exons" endpoint with a list of Ensembl IDs
+    data = {
+        "build": build,
+        "ensembl_ids": genomic_ids_per_build[build]["ensembl_exons_ids"],
+    }
+    response: Response = demo_client.post(endpoints.EXONS, json=data)
+
+    # THEN exon documents should be returned
+    assert response.status_code == status.HTTP_200_OK
+    result = response.json()
+    assert Exon(**result[0])
+
+
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_exons_by_ensembl_gene_ids(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the endpoint that filters database exons using a list of Ensembl gene IDs."""
+
+    # GIVEN a populated demo database
+    # WHEN sending a request to the "exons" endpoint with a list of Ensembl gene IDs
+    data = {
+        "build": build,
+        "ensembl_gene_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
+    }
+    response: Response = demo_client.post(endpoints.EXONS, json=data)
+
+    # THEN exons documents should be returned
+    assert response.status_code == status.HTTP_200_OK
+    result = response.json()
+    assert Exon(**result[0])
+
+
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_exons_by_hgnc_ids(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the endpoint that filters database exons using a list of HGNC gene IDs."""
+
+    # GIVEN a populated demo database
+    # WHEN sending a request to the "exons" endpoint with a list of HGNC gene IDs
+    data = {
+        "build": build,
+        "hgnc_gene_ids": genomic_ids_per_build[build]["hgnc_ids"],
+    }
+    response: Response = demo_client.post(endpoints.EXONS, json=data)
+
+    # THEN exon documents should be returned
+    assert response.status_code == status.HTTP_200_OK
+    result = response.json()
+    assert Exon(**result[0])
+
+
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_exons_by_hgnc_symbols(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the endpoint that filters database exons using a list of HGNC gene symbols."""
+
+    # GIVEN a populated demo database
+    # WHEN sending a request to the "exons" endpoint with a list of HGNC gene symbols
+    data = {
+        "build": build,
+        "hgnc_gene_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
+    }
+    response: Response = demo_client.post(endpoints.EXONS, json=data)
+
+    # THEN transcript documents should be returned
+    assert response.status_code == status.HTTP_200_OK
+    result = response.json()
     assert Exon(**result[0])

--- a/tests/src/chanjo2/test_populate_demo.py
+++ b/tests/src/chanjo2/test_populate_demo.py
@@ -47,7 +47,7 @@ def test_load_demo_data(demo_client: TestClient, demo_session: sessionmaker):
             assert isinstance(transcripts[0], Transcript)
 
             # database should contain exons
-            exons: List[Transcripts] = get_gene_intervals(
+            exons: List[Exon] = get_gene_intervals(
                 db=demo_session,
                 build=build,
                 ensembl_ids=None,

--- a/tests/src/chanjo2/test_populate_demo.py
+++ b/tests/src/chanjo2/test_populate_demo.py
@@ -1,5 +1,5 @@
 from chanjo2.crud.cases import get_cases
-from chanjo2.crud.intervals import get_genes, get_transcripts, get_exons
+from chanjo2.crud.intervals import get_genes, get_gene_intervals
 from chanjo2.crud.samples import get_samples
 from chanjo2.models.pydantic_models import Builds
 from chanjo2.models.sql_models import Case, Sample, Gene, Transcript, Exon
@@ -34,7 +34,7 @@ def test_load_demo_data(demo_client: TestClient, demo_session: sessionmaker):
             assert isinstance(genes[0], Gene)
 
             # database should contain transcripts
-            transcripts: List[Transcripts] = get_transcripts(
+            transcripts: List[Transcripts] = get_gene_intervals(
                 db=demo_session,
                 build=build,
                 ensembl_ids=None,
@@ -42,9 +42,19 @@ def test_load_demo_data(demo_client: TestClient, demo_session: sessionmaker):
                 hgnc_symbols=None,
                 ensembl_gene_ids=None,
                 limit=1,
+                interval_type=Transcript,
             )
             assert isinstance(transcripts[0], Transcript)
 
             # database should contain exons
-            exons: List[exons] = get_exons(db=demo_session, build=build, limit=1)
+            exons: List[Transcripts] = get_gene_intervals(
+                db=demo_session,
+                build=build,
+                ensembl_ids=None,
+                hgnc_ids=None,
+                hgnc_symbols=None,
+                ensembl_gene_ids=None,
+                limit=1,
+                interval_type=Exon,
+            )
             assert isinstance(exons[0], Exon)


### PR DESCRIPTION
### This PR adds | fixes:
-  Filter exons by Ensmbl IDs, Ensembl gene IDs, HGNC IDs, HGNC symbols
- Simplified structure of SQLTranscript and SQLExon
- Simplified confetest

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
- Filter exons as described above

### Expected outcome:
- [ ] Exons should retuned after filtering

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
