### PR TITLE
Remove transcripts and exons on gene update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Demo case and demo sample loaded with demo instance startup
 - Endpoint for coverage queries over the intervals of a BED file
 - Include a default .env file loaded on app startup
-- Filter genes by Ensemble id, HGNC id, HGNC symbol
+- Filter genes, transcripts and exons by Ensemble id, HGNC id, HGNC symbol
 - Demo genes, transcripts and exons loaded on demo instance startup
 
 ### Fixed
@@ -28,6 +28,7 @@
 - Dockerfile building error due to missing d4tools lib
 - Add VARCHAR length to sample.coverage_file_path SQL field
 - Format of Build field in genes, transcripts and exons tables
+- Remove old exons and transcripts data when updating genes
 
 ### Changed
 

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -54,7 +54,7 @@ def _replace_empty_cols(line: str, nr_expected_columns: int) -> List[Union[str, 
 
 
 async def update_genes(
-    build: Builds, session: Session, lines: Optional[Iterator] = None
+        build: Builds, session: Session, lines: Optional[Iterator] = None
 ) -> int:
     """Loads genes into the database."""
 
@@ -70,7 +70,8 @@ async def update_genes(
             f"Ensembl genes file has an unexpected format:{header}. Expected format: {GENES_FILE_HEADER[build]}"
         )
 
-    delete_intervals_for_build(db=session, interval_type=SQLGene, build=build)
+    for interval_type in [SQLExon, SQLTranscript, SQLGene]:
+        delete_intervals_for_build(db=session, interval_type=interval_type, build=build)
 
     genes_bulk: List[SQLGene] = []
 
@@ -106,7 +107,7 @@ async def update_genes(
 
 
 async def update_transcripts(
-    build: Builds, session: Session, lines: Optional[Iterator] = None
+        build: Builds, session: Session, lines: Optional[Iterator] = None
 ) -> int:
     """Loads transcripts into the database."""
 
@@ -167,7 +168,7 @@ async def update_transcripts(
 
 
 async def update_exons(
-    build: Builds, session: Session, lines: Optional[Iterator] = None
+        build: Builds, session: Session, lines: Optional[Iterator] = None
 ) -> int:
     """Loads exons into the database."""
 

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -54,7 +54,7 @@ def _replace_empty_cols(line: str, nr_expected_columns: int) -> List[Union[str, 
 
 
 async def update_genes(
-        build: Builds, session: Session, lines: Optional[Iterator] = None
+    build: Builds, session: Session, lines: Optional[Iterator] = None
 ) -> int:
     """Loads genes into the database."""
 
@@ -107,7 +107,7 @@ async def update_genes(
 
 
 async def update_transcripts(
-        build: Builds, session: Session, lines: Optional[Iterator] = None
+    build: Builds, session: Session, lines: Optional[Iterator] = None
 ) -> int:
     """Loads transcripts into the database."""
 
@@ -168,7 +168,7 @@ async def update_transcripts(
 
 
 async def update_exons(
-        build: Builds, session: Session, lines: Optional[Iterator] = None
+    build: Builds, session: Session, lines: Optional[Iterator] = None
 ) -> int:
     """Loads exons into the database."""
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #89 

### How to test:
- Given a database populated with genes, transcripts and exons in a given build
- Use the API to update the genes in the same build

### Expected outcome:
- The transcripts and exons tables should now be empty

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
