### PR TITLE
Sample mean transcript coverage over a list of genes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Filter genes, transcripts and exons by Ensemble id, HGNC id, HGNC symbol
 - Demo genes, transcripts and exons loaded on demo instance startup
 - Return coverage over a list of genes for a sample in the database
+- Return coverage over a list of genes (transcripts only) for a sample in the database
 
 ### Fixed
 

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List, Optional, Tuple
 
 from fastapi import APIRouter, HTTPException, File, status, Depends
@@ -30,7 +29,6 @@ from chanjo2.models.pydantic_models import (
 from chanjo2.models.sql_models import Gene as SQLGene
 
 router = APIRouter()
-LOG = logging.getLogger("uvicorn.access")
 
 
 @router.get("/coverage/d4/interval/", response_model=CoverageInterval)
@@ -125,7 +123,7 @@ async def sample_genes_coverage(
 async def sample_transcripts_coverage(
     query: SampleGeneIntervalQuery, db: Session = Depends(get_session)
 ):
-    """Returns coverage over genes transcripts for a given sample in the database."""
+    """Returns coverage over a list of genes (transcripts intervals only) for a given sample in the database."""
 
     sample: SQLSample = get_sample(db=db, sample_name=query.sample_name)
     if sample is None:

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -19,7 +19,7 @@ from chanjo2.meta.handle_d4 import (
     set_d4_file,
     set_interval,
     genes_coverage_completeness,
-    genes_transcript_coverage,
+    get_genes_transcript_coverage,
 )
 from chanjo2.models.pydantic_models import (
     CoverageInterval,
@@ -152,4 +152,4 @@ async def sample_transcripts_coverage(
         limit=None,
     )
 
-    return genes_transcript_coverage(db=db, d4_file=d4_file, genes=genes)
+    return get_genes_transcript_coverage(db=db, d4_file=d4_file, genes=genes)

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -14,8 +14,8 @@ from chanjo2.crud.samples import get_sample
 from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_bed import parse_bed
 from chanjo2.meta.handle_d4 import (
-    interval_coverage,
     intervals_coverage,
+    intervals_mean_coverage,
     set_d4_file,
     set_interval,
     genes_coverage_completeness,
@@ -56,7 +56,7 @@ def d4_interval_coverage(
         start=start,
         end=end,
         interval=interval,
-        mean_coverage=interval_coverage(d4_file, interval),
+        mean_coverage=intervals_mean_coverage(d4_file=d4_file, intervals=[interval])[0],
     )
 
 

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional, Tuple
 
 from fastapi import APIRouter, HTTPException, File, status, Depends
@@ -5,7 +6,7 @@ from pyd4 import D4File
 from sqlmodel import Session
 
 from chanjo2.constants import WRONG_BED_FILE_MSG, WRONG_COVERAGE_FILE_MSG
-from chanjo2.crud.intervals import get_genes
+from chanjo2.crud.intervals import get_genes, get_gene_intervals
 from chanjo2.crud.samples import get_sample
 from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_bed import parse_bed
@@ -16,18 +17,20 @@ from chanjo2.meta.handle_d4 import (
     set_interval,
     genes_coverage,
 )
-from chanjo2.models.pydantic_models import CoverageInterval, SampleGeneQuery
+from chanjo2.models.pydantic_models import CoverageInterval, SampleGeneQuery, SampleGeneIntervalQuery
 from chanjo2.models.sql_models import Gene as SQLGene
+from chanjo2.models.sql_models import Transcript as SQLTranscript
 
 router = APIRouter()
+LOG = logging.getLogger("uvicorn.access")
 
 
 @router.get("/coverage/d4/interval/", response_model=CoverageInterval)
 def d4_interval_coverage(
-    coverage_file_path: str,
-    chromosome: str,
-    start: Optional[int] = None,
-    end: Optional[int] = None,
+        coverage_file_path: str,
+        chromosome: str,
+        start: Optional[int] = None,
+        end: Optional[int] = None,
 ):
     """Return coverage on the given interval for a D4 resource located on the disk or on a remote server."""
 
@@ -78,7 +81,7 @@ def d4_intervals_coverage(coverage_file_path: str, bed_file: bytes = File(...)):
 
 @router.post("/coverage/sample/genes_coverage", response_model=List[CoverageInterval])
 async def sample_genes_coverage(
-    query: SampleGeneQuery, db: Session = Depends(get_session)
+        query: SampleGeneQuery, db: Session = Depends(get_session)
 ):
     """Returns coverage over a list of genes (entire gene) for a given sample in the database."""
 
@@ -106,3 +109,38 @@ async def sample_genes_coverage(
     )
 
     return genes_coverage(d4_file=d4_file, genes=genes)
+
+
+@router.post("/coverage/sample/transcripts_coverage", response_model=str)
+async def sample_transcripts_coverage(query: SampleGeneIntervalQuery, db: Session = Depends(get_session)):
+    """Returns coverage over genes transcripts for a given sample in the database."""
+
+    sample: SQLSample = get_sample(db=db, sample_name=query.sample_name)
+    if sample is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=SAMPLE_NOT_FOUND,
+        )
+    try:
+        d4_file: D4File = set_d4_file(coverage_file_path=sample.coverage_file_path)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=WRONG_COVERAGE_FILE_MSG,
+        )
+
+    transcripts: List[SQLTranscript] = get_gene_intervals(
+        db=db,
+        build=query.build,
+        ensembl_ids=None,
+        hgnc_ids=query.hgnc_ids,
+        hgnc_symbols=query.hgnc_symbols,
+        ensembl_gene_ids=query.ensembl_gene_ids,
+        limit=None,
+        interval_type=SQLTranscript,
+    )
+    """
+    for tx in transcripts:
+        LOG.warning(tx.)
+    """
+    return "HELLO BITCHES"

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -78,6 +78,16 @@ def genes_transcript_coverage(db: Session, d4_file: D4File, genes: List[SQLGene]
             ensembl_gene_ids=[gene.ensembl_id],
             limit=None,
         )
+        mean_gene_cov = 0
+        if gene_transcripts:
+            mean_gene_cov = mean(
+                d4_file.mean(
+                    [
+                        (transcript.chromosome, transcript.start, transcript.stop)
+                        for transcript in gene_transcripts
+                    ]
+                )
+            )
 
         transcripts_cov.append(
             CoverageInterval(
@@ -87,14 +97,7 @@ def genes_transcript_coverage(db: Session, d4_file: D4File, genes: List[SQLGene]
                 chromosome=gene.chromosome,
                 start=gene.start,
                 end=gene.stop,
-                mean_coverage=mean(
-                    d4_file.mean(
-                        [
-                            (transcript.chromosome, transcript.start, transcript.stop)
-                            for transcript in gene_transcripts
-                        ]
-                    )
-                ),
+                mean_coverage=mean_gene_cov,
             )
         )
     return transcripts_cov

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -100,7 +100,9 @@ def genes_coverage_completeness(
     return genes_cov
 
 
-def get_genes_transcript_coverage(db: Session, d4_file: D4File, genes: List[SQLGene]):
+def get_genes_transcript_coverage(
+    db: Session, d4_file: D4File, genes: List[SQLGene]
+) -> List[CoverageInterval]:
     """Return coverage of transcripts for a list of genes."""
     transcripts_cov: List[CoverageInterval] = []
     for gene in genes:

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -78,9 +78,9 @@ def genes_transcript_coverage(db: Session, d4_file: D4File, genes: List[SQLGene]
             ensembl_gene_ids=[gene.ensembl_id],
             limit=None,
         )
-        mean_gene_cov = 0
+        mean_gene_cov: float = 0
         if gene_transcripts:
-            mean_gene_cov = mean(
+            mean_gene_cov: float = mean(
                 d4_file.mean(
                     [
                         (transcript.chromosome, transcript.start, transcript.stop)

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -24,11 +24,11 @@ def set_d4_file(coverage_file_path: str) -> D4File:
     return D4File(coverage_file_path)
 
 
-def interval_coverage(
-    d4_file: D4File, interval: Tuple[str, Optional[int], Optional[int]]
-) -> float:
-    """Return coverage over a single interval of a D4 file."""
-    return d4_file.mean([interval])[0]
+def intervals_mean_coverage(
+    d4_file: D4File, intervals: List[Tuple[str, int, int]]
+) -> List[float]:
+    """Return the mean value over a list of intervals of a D4 file."""
+    return d4_file.mean(intervals)
 
 
 def intervals_coverage(
@@ -87,7 +87,9 @@ def genes_coverage_completeness(
                 chromosome=gene.chromosome,
                 start=gene.start,
                 end=gene.stop,
-                mean_coverage=d4_file.mean((gene.chromosome, gene.start, gene.stop)),
+                mean_coverage=intervals_mean_coverage(
+                    d4_file, intervals=[(gene.chromosome, gene.start, gene.stop)]
+                )[0],
                 completeness=evaluate_region_completeness(
                     d4_file=d4_file,
                     chromosome=gene.chromosome,
@@ -119,11 +121,12 @@ def get_genes_transcript_coverage(
         mean_gene_cov: float = 0
         if gene_transcripts:
             mean_gene_cov: float = mean(
-                d4_file.mean(
-                    [
+                intervals_mean_coverage(
+                    d4_file=d4_file,
+                    intervals=[
                         (transcript.chromosome, transcript.start, transcript.stop)
                         for transcript in gene_transcripts
-                    ]
+                    ],
                 )
             )
 

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -100,7 +100,7 @@ def genes_coverage_completeness(
     return genes_cov
 
 
-def genes_transcript_coverage(db: Session, d4_file: D4File, genes: List[SQLGene]):
+def get_genes_transcript_coverage(db: Session, d4_file: D4File, genes: List[SQLGene]):
     """Return coverage of transcripts for a list of genes."""
     transcripts_cov: List[CoverageInterval] = []
     for gene in genes:

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -97,4 +97,4 @@ def genes_transcript_coverage(db: Session, d4_file: D4File, genes: List[SQLGene]
                 ),
             )
         )
-        return transcripts_cov
+    return transcripts_cov

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -7,7 +7,7 @@ from chanjo2.models.sql_models import Gene as SQLGene
 
 
 def set_interval(
-    chrom: str, start: Optional[int] = None, end: Optional[int] = None
+        chrom: str, start: Optional[int] = None, end: Optional[int] = None
 ) -> Tuple[str, Optional[int], Optional[int]]:
     """Create the interval tuple used by the pyd4 utility."""
     return (chrom, start, end) if start and end else chrom
@@ -19,14 +19,14 @@ def set_d4_file(coverage_file_path: str) -> D4File:
 
 
 def interval_coverage(
-    d4_file: D4File, interval: Tuple[str, Optional[int], Optional[int]]
+        d4_file: D4File, interval: Tuple[str, Optional[int], Optional[int]]
 ) -> float:
     """Return coverage over a single interval of a D4 file."""
     return d4_file.mean([interval])[0]
 
 
 def intervals_coverage(
-    d4_file: D4File, intervals: List[Tuple[str, int, int]]
+        d4_file: D4File, intervals: List[Tuple[str, int, int]]
 ) -> List[CoverageInterval]:
     """Return coverage over a list of intervals."""
     intervals_cov: List[CoverageInterval] = []
@@ -58,3 +58,8 @@ def genes_coverage(d4_file: D4File, genes: List[SQLGene]) -> List[CoverageInterv
             )
         )
     return genes_cov
+
+
+"""
+def gene_transcripts_coverage()
+"""

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from decimal import Decimal
 from enum import Enum
 from pathlib import Path
 from typing import Any, List, Optional, Tuple
@@ -131,7 +130,7 @@ class Exon(IntervalBase):
 
 class CoverageInterval(BaseModel):
     chromosome: str
-    completeness: List[Tuple[int, Decimal]] = Field(default_factory=list)
+    completeness: List[Tuple] = Field(default_factory=list)
     ensembl_gene_id: Optional[str]
     end: Optional[int]
     hgnc_id: Optional[int]

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -28,8 +28,8 @@ class IntervalType(str, Enum):
 
 
 class CaseBase(BaseModel):
-    name: str
     display_name: Optional[str] = None
+    name: str
 
 
 class CaseCreate(CaseBase):
@@ -37,9 +37,9 @@ class CaseCreate(CaseBase):
 
 
 class SampleBase(BaseModel):
-    name: str
-    display_name: str
     coverage_file_path: str
+    display_name: str
+    name: str
 
     @validator("coverage_file_path", pre=True)
     def validate_coverage_path(cls, value: str) -> Any:
@@ -54,9 +54,9 @@ class SampleCreate(SampleBase):
 
 
 class Sample(SampleBase):
-    id: int
-    created_at: datetime
     case_id: int
+    created_at: datetime
+    id: int
 
     class Config:
         orm_mode = True
@@ -81,10 +81,10 @@ class Interval(IntervalBase):
 
 
 class GeneBase(IntervalBase):
+    build: Builds
     ensembl_id: str
     hgnc_id: Optional[int]
     hgnc_symbol: Optional[str]
-    build: Builds
 
 
 class GeneQuery(BaseModel):
@@ -104,6 +104,7 @@ class Gene(IntervalBase):
 
 
 class TranscriptBase(IntervalBase):
+    build: Builds
     ensembl_id: str
     ensembl_gene_id: str
     refseq_mrna: Optional[str]
@@ -111,7 +112,6 @@ class TranscriptBase(IntervalBase):
     refseq_ncrna: Optional[str]
     refseq_mane_select: Optional[str]
     refseq_mane_plus_clinical: Optional[str]
-    build: Builds
 
 
 class Transcript(TranscriptBase):
@@ -119,11 +119,10 @@ class Transcript(TranscriptBase):
 
 
 class ExonBase(IntervalBase):
+    build: Builds
     ensembl_id: str
     ensembl_gene_id: str
     ensembl_transcript_id: str
-    ensembl_id: str
-    build: Builds
 
 
 class Exon(IntervalBase):
@@ -131,20 +130,20 @@ class Exon(IntervalBase):
 
 
 class CoverageInterval(BaseModel):
+    chromosome: str
+    completeness: List[Tuple[int, Decimal]] = Field(default_factory=list)
     ensembl_gene_id: Optional[str]
+    end: Optional[int]
     hgnc_id: Optional[int]
     hgnc_symbol: Optional[str]
     interval_id: Optional[int]
-    chromosome: str
-    start: Optional[int]
-    end: Optional[int]
     mean_coverage: float
-    completeness: List[Tuple[int, Decimal]] = Field(default_factory=list)
+    start: Optional[int]
 
 
 class SampleGeneQuery(BaseModel):
-    completeness_thresholds: Optional[List[int]]
     build: Builds
+    completeness_thresholds: Optional[List[int]]
     ensembl_ids: Optional[List[str]]
     hgnc_ids: Optional[List[int]]
     hgnc_symbols: Optional[List[str]]

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -133,16 +133,24 @@ class CoverageInterval(BaseModel):
     ensembl_gene_id: Optional[str]
     hgnc_id: Optional[int]
     hgnc_symbol: Optional[str]
+    interval_id: Optional[int]
     chromosome: str
     start: Optional[int]
     end: Optional[int]
-    interval_id: Optional[int]
     mean_coverage: float
 
 
 class SampleGeneQuery(BaseModel):
     build: Builds
     ensembl_ids: Optional[List[str]]
+    hgnc_ids: Optional[List[int]]
+    hgnc_symbols: Optional[List[str]]
+    sample_name: str
+
+
+class SampleGeneIntervalQuery(BaseModel):
+    build: Builds
+    ensembl_gene_ids: Optional[List[str]]
     hgnc_ids: Optional[List[int]]
     hgnc_symbols: Optional[List[str]]
     sample_name: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ class Endpoints(str, Enum):
     INTERVAL_COVERAGE = "/coverage/d4/interval/"
     INTERVALS_FILE_COVERAGE = "/coverage/d4/interval_file/"
     SAMPLE_GENES_COVERAGE = "/coverage/sample/genes_coverage"
+    SAMPLE_TRANSCRIPTS_COVERAGE = "/coverage/sample/transcripts_coverage"
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ class Endpoints(str, Enum):
     EXONS = "/intervals/exons"
     INTERVAL_COVERAGE = "/coverage/d4/interval/"
     INTERVALS_FILE_COVERAGE = "/coverage/d4/interval_file/"
-    INTERVALS_SAMPLE_COVERAGE = "/coverage/sample/genes_coverage"
+    SAMPLE_GENES_COVERAGE = "/coverage/sample/genes_coverage"
 
 
 @pytest.fixture

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -159,8 +159,8 @@ def test_d4_intervals_coverage(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    result = response.json()
-    for interval in result:
+    coverage_intervals = response.json()
+    for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
 
@@ -186,8 +186,8 @@ def test_sample_gene_coverage_hgnc_symbols(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    result = response.json()
-    for interval in result:
+    coverage_intervals = response.json()
+    for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
 
@@ -213,8 +213,8 @@ def test_sample_gene_coverage_hgnc_ids(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    result = response.json()
-    for interval in result:
+    coverage_intervals = response.json()
+    for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
 
@@ -240,8 +240,8 @@ def test_sample_gene_coverage_ensembl_ids(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    result = response.json()
-    for interval in result:
+    coverage_intervals = response.json()
+    for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
 
@@ -268,8 +268,8 @@ def test_sample_transcripts_coverage_hgnc_symbols(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    result = response.json()
-    for interval in result:
+    coverage_intervals = response.json()
+    for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
 
@@ -296,8 +296,8 @@ def test_sample_transcripts_coverage_hgnc_ids(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    result = response.json()
-    for interval in result:
+    coverage_intervals = response.json()
+    for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
 
@@ -324,6 +324,6 @@ def test_sample_transcripts_coverage_ensembl_ids(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    result = response.json()
-    for interval in result:
+    coverage_intervals = response.json()
+    for interval in coverage_intervals:
         assert CoverageInterval(**interval)

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -179,7 +179,7 @@ def test_samples_gene_coverage_hgnc_symbols(
     }
 
     # THEN the response should be successful
-    response = demo_client.post(endpoints.INTERVALS_SAMPLE_COVERAGE, json=sample_query)
+    response = demo_client.post(endpoints.SAMPLE_GENES_COVERAGE, json=sample_query)
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
@@ -205,7 +205,7 @@ def test_samples_gene_coverage_hgnc_ids(
     }
 
     # THEN the response should be successful
-    response = demo_client.post(endpoints.INTERVALS_SAMPLE_COVERAGE, json=sample_query)
+    response = demo_client.post(endpoints.SAMPLE_GENES_COVERAGE, json=sample_query)
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
@@ -231,7 +231,7 @@ def test_samples_gene_coverage_ensembl_ids(
     }
 
     # THEN the response should be successful
-    response = demo_client.post(endpoints.INTERVALS_SAMPLE_COVERAGE, json=sample_query)
+    response = demo_client.post(endpoints.SAMPLE_GENES_COVERAGE, json=sample_query)
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -309,7 +309,7 @@ def test_sample_transcripts_coverage_ensembl_ids(
     sample_query: Dict[str, str] = {
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
-        "ensembl_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
+        "ensembl_gene_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
     }
 
     # THEN the response should be successful

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -171,7 +171,7 @@ def test_samples_gene_coverage_hgnc_symbols(
 ):
     """Test the function that returns the coverage over multiple genes of a sample when a list of HGNC symbols is provided."""
 
-    # GIVING a sample coverage query containing HGNC gene symbols
+    # GIVING a sample gene coverage query containing HGNC gene symbols
     sample_query: Dict[str, str] = {
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
@@ -197,7 +197,7 @@ def test_samples_gene_coverage_hgnc_ids(
 ):
     """Test the function that returns the coverage over multiple genes of a sampl when a list of HGNC IDs is providede."""
 
-    # GIVING a sample coverage query containing HGNC IDs
+    # GIVING a sample gene coverage query containing HGNC IDs
     sample_query: Dict[str, str] = {
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
@@ -223,7 +223,7 @@ def test_samples_gene_coverage_ensembl_ids(
 ):
     """Test the function that returns the coverage over multiple genes of a sample when a list of Enseml IDs is provided."""
 
-    # GIVING a sample coverage query containing Ensembl IDs
+    # GIVING a sample gene coverage query containing Ensembl IDs
     sample_query: Dict[str, str] = {
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
@@ -238,3 +238,84 @@ def test_samples_gene_coverage_ensembl_ids(
     result = response.json()
     for interval in result:
         assert CoverageInterval(**interval)
+
+    @pytest.mark.parametrize("build", Builds.get_enum_values())
+    def test_samples_transcripts_coverage_hgnc_symbols(
+        build: str,
+        demo_client: TestClient,
+        endpoints: Type,
+        genomic_ids_per_build: Dict[str, List],
+    ):
+        """Test the function that returns the coverage over transcripts of multiple genes of a sample when a list of HGNC symbols is provided."""
+
+        # GIVING a sample transcript coverage query containing HGNC gene symbols
+        sample_query: Dict[str, str] = {
+            "sample_name": DEMO_SAMPLE["name"],
+            "build": build,
+            "hgnc_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
+        }
+
+        # THEN the response should be successful
+        response = demo_client.post(
+            endpoints.SAMPLE_TRANSCRIPTS_COVERAGE, json=sample_query
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        # AND return coverage intervals data
+        result = response.json()
+        for interval in result:
+            assert CoverageInterval(**interval)
+
+    @pytest.mark.parametrize("build", Builds.get_enum_values())
+    def test_samples_transcripts_coverage_hgnc_ids(
+        build: str,
+        demo_client: TestClient,
+        endpoints: Type,
+        genomic_ids_per_build: Dict[str, List],
+    ):
+        """Test the function that returns the coverage over transcripts of multiple genes of a sampl when a list of HGNC IDs is providede."""
+
+        # GIVING a sample transcript coverage query containing HGNC IDs
+        sample_query: Dict[str, str] = {
+            "sample_name": DEMO_SAMPLE["name"],
+            "build": build,
+            "hgnc_ids": genomic_ids_per_build[build]["hgnc_ids"],
+        }
+
+        # THEN the response should be successful
+        response = demo_client.post(
+            endpoints.SAMPLE_TRANSCRIPTS_COVERAGE, json=sample_query
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        # AND return coverage intervals data
+        result = response.json()
+        for interval in result:
+            assert CoverageInterval(**interval)
+
+    @pytest.mark.parametrize("build", Builds.get_enum_values())
+    def test_samples_transcripts_coverage_ensembl_ids(
+        build: str,
+        demo_client: TestClient,
+        endpoints: Type,
+        genomic_ids_per_build: Dict[str, List],
+    ):
+        """Test the function that returns the coverage over  transcripts of multiple genes of a sample when a list of Enseml IDs is provided."""
+
+        # GIVING a sample transcript coverage query containing Ensembl IDs
+        sample_query: Dict[str, str] = {
+            "sample_name": DEMO_SAMPLE["name"],
+            "build": build,
+            "ensembl_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
+        }
+
+        # THEN the response should be successful
+        response = demo_client.post(
+            endpoints.SAMPLE_TRANSCRIPTS_COVERAGE, json=sample_query
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        # AND return coverage intervals data
+        result = response.json()
+        for interval in result:
+            assert CoverageInterval(**interval)

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -163,7 +163,7 @@ def test_d4_intervals_coverage(
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
-def test_samples_gene_coverage_hgnc_symbols(
+def test_sample_gene_coverage_hgnc_symbols(
     build: str,
     demo_client: TestClient,
     endpoints: Type,
@@ -189,7 +189,7 @@ def test_samples_gene_coverage_hgnc_symbols(
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
-def test_samples_gene_coverage_hgnc_ids(
+def test_sample_gene_coverage_hgnc_ids(
     build: str,
     demo_client: TestClient,
     endpoints: Type,
@@ -215,7 +215,7 @@ def test_samples_gene_coverage_hgnc_ids(
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
-def test_samples_gene_coverage_ensembl_ids(
+def test_sample_gene_coverage_ensembl_ids(
     build: str,
     demo_client: TestClient,
     endpoints: Type,
@@ -239,83 +239,86 @@ def test_samples_gene_coverage_ensembl_ids(
     for interval in result:
         assert CoverageInterval(**interval)
 
-    @pytest.mark.parametrize("build", Builds.get_enum_values())
-    def test_samples_transcripts_coverage_hgnc_symbols(
-        build: str,
-        demo_client: TestClient,
-        endpoints: Type,
-        genomic_ids_per_build: Dict[str, List],
-    ):
-        """Test the function that returns the coverage over transcripts of multiple genes of a sample when a list of HGNC symbols is provided."""
 
-        # GIVING a sample transcript coverage query containing HGNC gene symbols
-        sample_query: Dict[str, str] = {
-            "sample_name": DEMO_SAMPLE["name"],
-            "build": build,
-            "hgnc_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
-        }
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_sample_transcripts_coverage_hgnc_symbols(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the function that returns the coverage over transcripts of multiple genes of a sample when a list of HGNC symbols is provided."""
 
-        # THEN the response should be successful
-        response = demo_client.post(
-            endpoints.SAMPLE_TRANSCRIPTS_COVERAGE, json=sample_query
-        )
-        assert response.status_code == status.HTTP_200_OK
+    # GIVING a sample transcript coverage query containing HGNC gene symbols
+    sample_query: Dict[str, str] = {
+        "sample_name": DEMO_SAMPLE["name"],
+        "build": build,
+        "hgnc_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
+    }
 
-        # AND return coverage intervals data
-        result = response.json()
-        for interval in result:
-            assert CoverageInterval(**interval)
+    # THEN the response should be successful
+    response = demo_client.post(
+        endpoints.SAMPLE_TRANSCRIPTS_COVERAGE, json=sample_query
+    )
+    assert response.status_code == status.HTTP_200_OK
 
-    @pytest.mark.parametrize("build", Builds.get_enum_values())
-    def test_samples_transcripts_coverage_hgnc_ids(
-        build: str,
-        demo_client: TestClient,
-        endpoints: Type,
-        genomic_ids_per_build: Dict[str, List],
-    ):
-        """Test the function that returns the coverage over transcripts of multiple genes of a sampl when a list of HGNC IDs is providede."""
+    # AND return coverage intervals data
+    result = response.json()
+    for interval in result:
+        assert CoverageInterval(**interval)
 
-        # GIVING a sample transcript coverage query containing HGNC IDs
-        sample_query: Dict[str, str] = {
-            "sample_name": DEMO_SAMPLE["name"],
-            "build": build,
-            "hgnc_ids": genomic_ids_per_build[build]["hgnc_ids"],
-        }
 
-        # THEN the response should be successful
-        response = demo_client.post(
-            endpoints.SAMPLE_TRANSCRIPTS_COVERAGE, json=sample_query
-        )
-        assert response.status_code == status.HTTP_200_OK
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_sample_transcripts_coverage_hgnc_ids(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the function that returns the coverage over transcripts of multiple genes of a sampl when a list of HGNC IDs is providede."""
 
-        # AND return coverage intervals data
-        result = response.json()
-        for interval in result:
-            assert CoverageInterval(**interval)
+    # GIVING a sample transcript coverage query containing HGNC IDs
+    sample_query: Dict[str, str] = {
+        "sample_name": DEMO_SAMPLE["name"],
+        "build": build,
+        "hgnc_ids": genomic_ids_per_build[build]["hgnc_ids"],
+    }
 
-    @pytest.mark.parametrize("build", Builds.get_enum_values())
-    def test_samples_transcripts_coverage_ensembl_ids(
-        build: str,
-        demo_client: TestClient,
-        endpoints: Type,
-        genomic_ids_per_build: Dict[str, List],
-    ):
-        """Test the function that returns the coverage over  transcripts of multiple genes of a sample when a list of Enseml IDs is provided."""
+    # THEN the response should be successful
+    response = demo_client.post(
+        endpoints.SAMPLE_TRANSCRIPTS_COVERAGE, json=sample_query
+    )
+    assert response.status_code == status.HTTP_200_OK
 
-        # GIVING a sample transcript coverage query containing Ensembl IDs
-        sample_query: Dict[str, str] = {
-            "sample_name": DEMO_SAMPLE["name"],
-            "build": build,
-            "ensembl_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
-        }
+    # AND return coverage intervals data
+    result = response.json()
+    for interval in result:
+        assert CoverageInterval(**interval)
 
-        # THEN the response should be successful
-        response = demo_client.post(
-            endpoints.SAMPLE_TRANSCRIPTS_COVERAGE, json=sample_query
-        )
-        assert response.status_code == status.HTTP_200_OK
 
-        # AND return coverage intervals data
-        result = response.json()
-        for interval in result:
-            assert CoverageInterval(**interval)
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_sample_transcripts_coverage_ensembl_ids(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the function that returns the coverage over  transcripts of multiple genes of a sample when a list of Enseml IDs is provided."""
+
+    # GIVING a sample transcript coverage query containing Ensembl IDs
+    sample_query: Dict[str, str] = {
+        "sample_name": DEMO_SAMPLE["name"],
+        "build": build,
+        "ensembl_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
+    }
+
+    # THEN the response should be successful
+    response = demo_client.post(
+        endpoints.SAMPLE_TRANSCRIPTS_COVERAGE, json=sample_query
+    )
+    assert response.status_code == status.HTTP_200_OK
+
+    # AND return coverage intervals data
+    result = response.json()
+    for interval in result:
+        assert CoverageInterval(**interval)

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -159,7 +159,7 @@ def test_d4_intervals_coverage(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    coverage_intervals = response.json()
+    coverage_intervals: List = response.json()
     for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
@@ -186,7 +186,7 @@ def test_sample_gene_coverage_hgnc_symbols(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    coverage_intervals = response.json()
+    coverage_intervals: List = response.json()
     for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
@@ -213,7 +213,7 @@ def test_sample_gene_coverage_hgnc_ids(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    coverage_intervals = response.json()
+    coverage_intervals: List = response.json()
     for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
@@ -240,7 +240,7 @@ def test_sample_gene_coverage_ensembl_ids(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    coverage_intervals = response.json()
+    coverage_intervals: List = response.json()
     for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
@@ -268,7 +268,7 @@ def test_sample_transcripts_coverage_hgnc_symbols(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    coverage_intervals = response.json()
+    coverage_intervals: List = response.json()
     for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
@@ -296,7 +296,7 @@ def test_sample_transcripts_coverage_hgnc_ids(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    coverage_intervals = response.json()
+    coverage_intervals: List = response.json()
     for interval in coverage_intervals:
         assert CoverageInterval(**interval)
 
@@ -324,6 +324,6 @@ def test_sample_transcripts_coverage_ensembl_ids(
     assert response.status_code == status.HTTP_200_OK
 
     # AND return coverage intervals data
-    coverage_intervals = response.json()
+    coverage_intervals: List = response.json()
     for interval in coverage_intervals:
         assert CoverageInterval(**interval)


### PR DESCRIPTION
### This PR adds | fixes:
- Return coverage over a list of genes (transcripts only) for a sample in the database

### How to test:
- Launch an instance of the app and provide a sample with a d4 file and a list of genes in various formats (ensembl ids, hgnc ids, hgnc symbols)

### Expected outcome:
- [x] Mean transcript coverage should be returned for each provided gene

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
