### PR TITLE
Gene coverage completeness over a list of thresholds alongside coverage stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Include a default .env file loaded on app startup
 - Filter genes, transcripts and exons by Ensemble id, HGNC id, HGNC symbol
 - Demo genes, transcripts and exons loaded on demo instance startup
-- Return coverage and coverage completeness over a list of genes for a sample in the database
+- Return coverage and coverage completeness (custom thresholds) over a list of genes for a sample in the database
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Include a default .env file loaded on app startup
 - Filter genes, transcripts and exons by Ensemble id, HGNC id, HGNC symbol
 - Demo genes, transcripts and exons loaded on demo instance startup
-- Return coverage over a list of genes for a sample in the database
+- Return coverage and coverage completeness over a list of genes for a sample in the database
 
 ### Fixed
 

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -4,7 +4,11 @@ from fastapi import APIRouter, HTTPException, File, status, Depends
 from pyd4 import D4File
 from sqlmodel import Session
 
-from chanjo2.constants import WRONG_BED_FILE_MSG, WRONG_COVERAGE_FILE_MSG
+from chanjo2.constants import (
+    WRONG_BED_FILE_MSG,
+    WRONG_COVERAGE_FILE_MSG,
+    SAMPLE_NOT_FOUND,
+)
 from chanjo2.crud.intervals import get_genes
 from chanjo2.crud.samples import get_sample
 from chanjo2.dbutil import get_session
@@ -14,7 +18,7 @@ from chanjo2.meta.handle_d4 import (
     intervals_coverage,
     set_d4_file,
     set_interval,
-    genes_coverage,
+    genes_coverage_completeness,
 )
 from chanjo2.models.pydantic_models import CoverageInterval, SampleGeneQuery
 from chanjo2.models.sql_models import Gene as SQLGene
@@ -105,4 +109,8 @@ async def sample_genes_coverage(
         limit=None,
     )
 
-    return genes_coverage(d4_file=d4_file, genes=genes)
+    return genes_coverage_completeness(
+        d4_file=d4_file,
+        genes=genes,
+        completeness_threholds=query.completeness_thresholds,
+    )

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -1,5 +1,7 @@
+from decimal import Decimal
 from typing import List, Optional, Tuple
 
+from numpy import ndarray
 from pyd4 import D4File
 
 from chanjo2.models.pydantic_models import CoverageInterval
@@ -42,9 +44,36 @@ def intervals_coverage(
     return intervals_cov
 
 
-def genes_coverage(d4_file: D4File, genes: List[SQLGene]) -> List[CoverageInterval]:
-    """Return coverage over a list of genes."""
+def evaluate_region_completeness(
+    d4_file: D4File,
+    chromosome: str,
+    start: int,
+    stop: int,
+    completeness_threholds: Optional[List[int]],
+) -> List[Tuple[int, Decimal]]:
+    """Use NumPy to Calculate the coverage completeness over a list of threshold values for a chromosomal region."""
+
+    if completeness_threholds is None:
+        return []
+
+    region_size: int = stop - start
+    per_base_depth: ndarray = d4_file.load_to_np(f"{chromosome}:{start}-{stop}")
+
+    completeness_values: List[Tuple[int, Decimal]] = []
+
+    for threshold in completeness_threholds:
+        completeness = Decimal((per_base_depth > threshold).sum() / region_size)
+        completeness_values.append((threshold, completeness))
+
+    return completeness_values
+
+
+def genes_coverage_completeness(
+    d4_file: D4File, genes: List[SQLGene], completeness_threholds: List[Optional[int]]
+) -> List[CoverageInterval]:
+    """Return mean coverage and coverage completeness over a list of genes."""
     genes_cov: List[CoverageInterval] = []
+
     for gene in genes:
         genes_cov.append(
             CoverageInterval(
@@ -55,6 +84,13 @@ def genes_coverage(d4_file: D4File, genes: List[SQLGene]) -> List[CoverageInterv
                 start=gene.start,
                 end=gene.stop,
                 mean_coverage=d4_file.mean((gene.chromosome, gene.start, gene.stop)),
+                completeness=evaluate_region_completeness(
+                    d4_file=d4_file,
+                    chromosome=gene.chromosome,
+                    start=gene.start,
+                    stop=gene.stop,
+                    completeness_threholds=completeness_threholds,
+                ),
             )
         )
     return genes_cov

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -1,10 +1,11 @@
 from datetime import datetime
+from decimal import Decimal
 from enum import Enum
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Tuple
 
 import validators
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, validator, Field
 
 from chanjo2.constants import WRONG_COVERAGE_FILE_MSG
 
@@ -138,9 +139,11 @@ class CoverageInterval(BaseModel):
     end: Optional[int]
     interval_id: Optional[int]
     mean_coverage: float
+    completeness: List[Tuple[int, Decimal]] = Field(default_factory=list)
 
 
 class SampleGeneQuery(BaseModel):
+    completeness_thresholds: Optional[List[int]]
     build: Builds
     ensembl_ids: Optional[List[str]]
     hgnc_ids: Optional[List[int]]

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -13,7 +13,7 @@ from chanjo2.models.pydantic_models import (
 )
 from chanjo2.populate_demo import DEMO_SAMPLE
 
-COVERAGE_COMPLETENESS_THRESHOLDS = [10, 20, 30]
+COVERAGE_COMPLETENESS_THRESHOLDS: List[int] = [10, 20, 30]
 
 
 def test_d4_interval_coverage_d4_not_found(

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -13,6 +13,8 @@ from chanjo2.models.pydantic_models import (
 )
 from chanjo2.populate_demo import DEMO_SAMPLE
 
+COVERAGE_COMPLETENESS_THRESHOLDS = [10, 20, 30]
+
 
 def test_d4_interval_coverage_d4_not_found(
     client: TestClient, mock_coverage_file: str, endpoints: Type, interval_query: dict
@@ -176,6 +178,7 @@ def test_samples_gene_coverage_hgnc_symbols(
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
         "hgnc_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
+        "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
     # THEN the response should be successful
@@ -202,6 +205,7 @@ def test_samples_gene_coverage_hgnc_ids(
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
         "hgnc_ids": genomic_ids_per_build[build]["hgnc_ids"],
+        "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
     # THEN the response should be successful
@@ -228,6 +232,7 @@ def test_samples_gene_coverage_ensembl_ids(
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
         "ensembl_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
+        "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
     # THEN the response should be successful


### PR DESCRIPTION
### This PR adds | fixes:
- Adds an optional parameter to return coverage completeness with custom thresholds together with coverage for genes

### How to test:
- Provide a list of thresholds to calculate the coverage completeness when running a query for gene coverage for a sample

### Expected outcome:
- [x] Completeness stats should be returned in results

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
