### PR TITLE
Transcripts completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Return coverage over a list of genes for a sample in the database
 - Return coverage and coverage completeness (custom thresholds) over a list of genes for a sample in the database
 - Return coverage over a list of genes (transcripts only) for a sample in the database
+- Return coverage completeness over a list of gene transcripts for a sample in the database
 
 ### Fixed
 

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -15,7 +15,7 @@ from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_bed import parse_bed
 from chanjo2.meta.handle_d4 import (
     intervals_coverage,
-    intervals_mean_coverage,
+    get_intervals_mean_coverage,
     set_d4_file,
     set_interval,
     get_genes_coverage_completeness,
@@ -56,7 +56,9 @@ def d4_interval_coverage(
         start=start,
         end=end,
         interval=interval,
-        mean_coverage=intervals_mean_coverage(d4_file=d4_file, intervals=[interval])[0],
+        mean_coverage=get_intervals_mean_coverage(
+            d4_file=d4_file, intervals=[interval]
+        )[0],
     )
 
 

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -18,8 +18,8 @@ from chanjo2.meta.handle_d4 import (
     intervals_mean_coverage,
     set_d4_file,
     set_interval,
-    genes_coverage_completeness,
-    get_genes_transcript_coverage,
+    get_genes_coverage_completeness,
+    get_transcripts_coverage_completeness,
 )
 from chanjo2.models.pydantic_models import (
     CoverageInterval,
@@ -114,7 +114,7 @@ async def sample_genes_coverage(
         limit=None,
     )
 
-    return genes_coverage_completeness(
+    return get_genes_coverage_completeness(
         d4_file=d4_file,
         genes=genes,
         completeness_threholds=query.completeness_thresholds,
@@ -152,4 +152,9 @@ async def sample_transcripts_coverage(
         limit=None,
     )
 
-    return get_genes_transcript_coverage(db=db, d4_file=d4_file, genes=genes)
+    return get_transcripts_coverage_completeness(
+        db=db,
+        d4_file=d4_file,
+        genes=genes,
+        completeness_threholds=query.completeness_thresholds,
+    )

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -68,7 +68,12 @@ def evaluate_intervals_completeness(
             nr_complete_bases += (per_base_depth_region > threshold).sum()
 
         completeness_values.append(
-            (threshold, Decimal(nr_complete_bases.item() / total_region_length))
+            (
+                threshold,
+                Decimal(nr_complete_bases.item() / total_region_length)
+                if nr_complete_bases
+                else 0,
+            )
         )
 
     return completeness_values

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -1,4 +1,3 @@
-import logging
 from decimal import Decimal
 from statistics import mean
 from typing import List, Optional, Tuple
@@ -11,8 +10,6 @@ from chanjo2.crud.intervals import get_gene_intervals
 from chanjo2.models.pydantic_models import CoverageInterval
 from chanjo2.models.sql_models import Gene as SQLGene
 from chanjo2.models.sql_models import Transcript as SQLTranscript
-
-LOG = logging.getLogger("uvicorn.access")
 
 
 def set_interval(

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -59,7 +59,7 @@ def intervals_coverage(
     return intervals_cov
 
 
-def evaluate_intervals_completeness(
+def get_intervals_completeness(
     d4_file: D4File,
     intervals: List[Tuple[str, int, int]],
     completeness_threholds: Optional[List[int]],
@@ -110,7 +110,7 @@ def get_genes_coverage_completeness(
                 mean_coverage=get_intervals_mean_coverage(
                     d4_file, intervals=get_intervals_coords_list(intervals=[gene])[0]
                 ),
-                completeness=evaluate_intervals_completeness(
+                completeness=get_intervals_completeness(
                     d4_file=d4_file,
                     intervals=[(gene.chromosome, gene.start, gene.stop)],
                     completeness_threholds=completeness_threholds,
@@ -158,7 +158,7 @@ def get_transcripts_coverage_completeness(
                 start=gene.start,
                 end=gene.stop,
                 mean_coverage=mean_gene_cov,
-                completeness=evaluate_intervals_completeness(
+                completeness=get_intervals_completeness(
                     d4_file=d4_file,
                     intervals=intervals,
                     completeness_threholds=completeness_threholds,

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -1,8 +1,9 @@
+import logging
 from decimal import Decimal
 from statistics import mean
 from typing import List, Optional, Tuple
 
-from numpy import ndarray
+from numpy import ndarray, int64
 from pyd4 import D4File
 from sqlmodel import Session
 
@@ -10,6 +11,8 @@ from chanjo2.crud.intervals import get_gene_intervals
 from chanjo2.models.pydantic_models import CoverageInterval
 from chanjo2.models.sql_models import Gene as SQLGene
 from chanjo2.models.sql_models import Transcript as SQLTranscript
+
+LOG = logging.getLogger("uvicorn.access")
 
 
 def set_interval(
@@ -48,31 +51,33 @@ def intervals_coverage(
     return intervals_cov
 
 
-def evaluate_region_completeness(
+def evaluate_intervals_completeness(
     d4_file: D4File,
-    chromosome: str,
-    start: int,
-    stop: int,
+    intervals: List[Tuple[str, int, int]],
     completeness_threholds: Optional[List[int]],
 ) -> List[Tuple[int, Decimal]]:
-    """Use NumPy to Calculate the coverage completeness over a list of threshold values for a chromosomal region."""
+    """Use NumPy to calculate the coverage completeness over a list of threshold values for a chromosomal region."""
 
     if completeness_threholds is None:
         return []
 
-    region_size: int = stop - start
-    per_base_depth: ndarray = d4_file.load_to_np(f"{chromosome}:{start}-{stop}")
-
     completeness_values: List[Tuple[int, Decimal]] = []
+    total_region_length = sum([interval[2] - interval[1] for interval in intervals])
+    per_base_depth: ndarray = d4_file.load_to_np(intervals)
 
     for threshold in completeness_threholds:
-        completeness = Decimal((per_base_depth > threshold).sum() / region_size)
-        completeness_values.append((threshold, completeness))
+        nr_complete_bases: int64 = 0
+        for per_base_depth_region in per_base_depth:
+            nr_complete_bases += (per_base_depth_region > threshold).sum()
+
+        completeness_values.append(
+            (threshold, Decimal(nr_complete_bases.item() / total_region_length))
+        )
 
     return completeness_values
 
 
-def genes_coverage_completeness(
+def get_genes_coverage_completeness(
     d4_file: D4File, genes: List[SQLGene], completeness_threholds: List[Optional[int]]
 ) -> List[CoverageInterval]:
     """Return mean coverage and coverage completeness over a list of genes."""
@@ -90,11 +95,9 @@ def genes_coverage_completeness(
                 mean_coverage=intervals_mean_coverage(
                     d4_file, intervals=[(gene.chromosome, gene.start, gene.stop)]
                 )[0],
-                completeness=evaluate_region_completeness(
+                completeness=evaluate_intervals_completeness(
                     d4_file=d4_file,
-                    chromosome=gene.chromosome,
-                    start=gene.start,
-                    stop=gene.stop,
+                    intervals=[(gene.chromosome, gene.start, gene.stop)],
                     completeness_threholds=completeness_threholds,
                 ),
             )
@@ -102,8 +105,11 @@ def genes_coverage_completeness(
     return genes_cov
 
 
-def get_genes_transcript_coverage(
-    db: Session, d4_file: D4File, genes: List[SQLGene]
+def get_transcripts_coverage_completeness(
+    db: Session,
+    d4_file: D4File,
+    genes: List[SQLGene],
+    completeness_threholds: List[Optional[int]],
 ) -> List[CoverageInterval]:
     """Return coverage of transcripts for a list of genes."""
     transcripts_cov: List[CoverageInterval] = []
@@ -118,16 +124,15 @@ def get_genes_transcript_coverage(
             ensembl_gene_ids=[gene.ensembl_id],
             limit=None,
         )
+        intervals: List[Tuple[str, int, int]] = [
+            (transcript.chromosome, transcript.start, transcript.stop)
+            for transcript in gene_transcripts
+        ]
         mean_gene_cov: float = 0
+
         if gene_transcripts:
             mean_gene_cov: float = mean(
-                intervals_mean_coverage(
-                    d4_file=d4_file,
-                    intervals=[
-                        (transcript.chromosome, transcript.start, transcript.stop)
-                        for transcript in gene_transcripts
-                    ],
-                )
+                intervals_mean_coverage(d4_file=d4_file, intervals=intervals)
             )
 
         transcripts_cov.append(
@@ -139,6 +144,11 @@ def get_genes_transcript_coverage(
                 start=gene.start,
                 end=gene.stop,
                 mean_coverage=mean_gene_cov,
+                completeness=evaluate_intervals_completeness(
+                    d4_file=d4_file,
+                    intervals=intervals,
+                    completeness_threholds=completeness_threholds,
+                ),
             )
         )
     return transcripts_cov

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -59,7 +59,9 @@ def evaluate_intervals_completeness(
         return []
 
     completeness_values: List[Tuple[int, Decimal]] = []
-    total_region_length: int = sum([interval[2] - interval[1] for interval in intervals])
+    total_region_length: int = sum(
+        [interval[2] - interval[1] for interval in intervals]
+    )
     per_base_depth: ndarray = d4_file.load_to_np(intervals)
 
     for threshold in completeness_threholds:

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -59,7 +59,7 @@ def evaluate_intervals_completeness(
         return []
 
     completeness_values: List[Tuple[int, Decimal]] = []
-    total_region_length = sum([interval[2] - interval[1] for interval in intervals])
+    total_region_length: int = sum([interval[2] - interval[1] for interval in intervals])
     per_base_depth: ndarray = d4_file.load_to_np(intervals)
 
     for threshold in completeness_threholds:

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -24,7 +24,7 @@ def set_d4_file(coverage_file_path: str) -> D4File:
     return D4File(coverage_file_path)
 
 
-def intervals_mean_coverage(
+def get_intervals_mean_coverage(
     d4_file: D4File, intervals: List[Tuple[str, int, int]]
 ) -> List[float]:
     """Return the mean value over a list of intervals of a D4 file."""
@@ -96,7 +96,7 @@ def get_genes_coverage_completeness(
                 chromosome=gene.chromosome,
                 start=gene.start,
                 end=gene.stop,
-                mean_coverage=intervals_mean_coverage(
+                mean_coverage=get_intervals_mean_coverage(
                     d4_file, intervals=[(gene.chromosome, gene.start, gene.stop)]
                 )[0],
                 completeness=evaluate_intervals_completeness(
@@ -136,7 +136,7 @@ def get_transcripts_coverage_completeness(
 
         if gene_transcripts:
             mean_gene_cov: float = mean(
-                intervals_mean_coverage(d4_file=d4_file, intervals=intervals)
+                get_intervals_mean_coverage(d4_file=d4_file, intervals=intervals)
             )
 
         transcripts_cov.append(

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -151,6 +151,7 @@ class SampleGeneQuery(BaseModel):
 
 class SampleGeneIntervalQuery(BaseModel):
     build: Builds
+    completeness_thresholds: Optional[List[int]]
     ensembl_gene_ids: Optional[List[str]]
     hgnc_ids: Optional[List[int]]
     hgnc_symbols: Optional[List[str]]

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -259,6 +259,7 @@ def test_sample_transcripts_coverage_hgnc_symbols(
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
         "hgnc_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
+        "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
     # THEN the response should be successful
@@ -287,6 +288,7 @@ def test_sample_transcripts_coverage_hgnc_ids(
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
         "hgnc_ids": genomic_ids_per_build[build]["hgnc_ids"],
+        "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
     # THEN the response should be successful
@@ -315,6 +317,7 @@ def test_sample_transcripts_coverage_ensembl_ids(
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
         "ensembl_gene_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
+        "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
     # THEN the response should be successful


### PR DESCRIPTION
### This PR adds | fixes:
- Returns coverage completeness also for gene transcripts coverage queries

### How to test:
- Run a query for coverage over the transcripts of one or more gene for a sample in the database
- Provide also completeness thresholds

### Expected outcome:
- [x] Completeness stats should be returned in the response

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
