### PR TITLE
Coverage and completeness over exons of a sample endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@
 - Demo genes, transcripts and exons loaded on demo instance startup
 - Return coverage over a list of genes for a sample in the database
 - Return coverage and coverage completeness (custom thresholds) over a list of genes for a sample in the database
-- Return coverage over a list of genes (transcripts only) for a sample in the database
-- Return coverage completeness over a list of gene transcripts for a sample in the database
+- Return transcripts coverage and coverage completeness (custom thresholds) over a list of genes for a sample in the
+  database
+- Return exons coverage and coverage completeness (custom thresholds) over a list of genes for a sample in the database
 
 ### Fixed
 

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -1,11 +1,12 @@
 import logging
 from typing import List, Optional
 
+from sqlalchemy.orm import Session, query
+
 from chanjo2.crud.cases import filter_cases_by_name
 from chanjo2.models.pydantic_models import SampleCreate
 from chanjo2.models.sql_models import Case as SQLCase
 from chanjo2.models.sql_models import Sample as SQLSample
-from sqlalchemy.orm import Session, query
 
 LOG = logging.getLogger("uvicorn.access")
 

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -120,19 +120,20 @@ def get_genes_coverage_completeness(
     return genes_cov
 
 
-def get_transcripts_coverage_completeness(
+def get_gene_interval_coverage_completeness(
     db: Session,
     d4_file: D4File,
     genes: List[SQLGene],
+    interval_type: Union[SQLTranscript, SQLExon],
     completeness_threholds: List[Optional[int]],
 ) -> List[CoverageInterval]:
     """Return coverage of transcripts for a list of genes."""
     transcripts_cov: List[CoverageInterval] = []
     for gene in genes:
-        gene_transcripts: List[SQLTranscript] = get_gene_intervals(
+        sql_intervals: List[Union[SQLTranscript, SQLExon]] = get_gene_intervals(
             db=db,
             build=gene.build,
-            interval_type=SQLTranscript,
+            interval_type=interval_type,
             ensembl_ids=None,
             hgnc_ids=None,
             hgnc_symbols=None,
@@ -140,11 +141,11 @@ def get_transcripts_coverage_completeness(
             limit=None,
         )
         intervals: List[Tuple[str, int, int]] = get_intervals_coords_list(
-            intervals=gene_transcripts
+            intervals=sql_intervals
         )
         mean_gene_cov: float = 0
 
-        if gene_transcripts:
+        if sql_intervals:
             mean_gene_cov: float = mean(
                 get_intervals_mean_coverage(d4_file=d4_file, intervals=intervals)
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ class Endpoints(str, Enum):
     INTERVALS_FILE_COVERAGE = "/coverage/d4/interval_file/"
     SAMPLE_GENES_COVERAGE = "/coverage/sample/genes_coverage"
     SAMPLE_TRANSCRIPTS_COVERAGE = "/coverage/sample/transcripts_coverage"
+    SAMPLE_EXONS_COVERAGE = "/coverage/sample/exons_coverage"
 
 
 @pytest.fixture

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -330,3 +330,84 @@ def test_sample_transcripts_coverage_ensembl_ids(
     coverage_intervals: List = response.json()
     for interval in coverage_intervals:
         assert CoverageInterval(**interval)
+
+
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_sample_exons_coverage_hgnc_symbols(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the function that returns the coverage over exons of multiple genes of a sample when a list of HGNC symbols is provided."""
+
+    # GIVING a sample transcript coverage query containing HGNC gene symbols
+    sample_query: Dict[str, str] = {
+        "sample_name": DEMO_SAMPLE["name"],
+        "build": build,
+        "hgnc_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
+        "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
+    }
+
+    # THEN the response should be successful
+    response = demo_client.post(endpoints.SAMPLE_EXONS_COVERAGE, json=sample_query)
+    assert response.status_code == status.HTTP_200_OK
+
+    # AND return coverage intervals data
+    coverage_intervals: List = response.json()
+    for interval in coverage_intervals:
+        assert CoverageInterval(**interval)
+
+
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_sample_exons_coverage_hgnc_ids(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the function that returns the coverage over exons of multiple genes of a sampl when a list of HGNC IDs is providede."""
+
+    # GIVING a sample transcript coverage query containing HGNC IDs
+    sample_query: Dict[str, str] = {
+        "sample_name": DEMO_SAMPLE["name"],
+        "build": build,
+        "hgnc_ids": genomic_ids_per_build[build]["hgnc_ids"],
+        "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
+    }
+
+    # THEN the response should be successful
+    response = demo_client.post(endpoints.SAMPLE_EXONS_COVERAGE, json=sample_query)
+    assert response.status_code == status.HTTP_200_OK
+
+    # AND return coverage intervals data
+    coverage_intervals: List = response.json()
+    for interval in coverage_intervals:
+        assert CoverageInterval(**interval)
+
+
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_sample_exons_coverage_ensembl_ids(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the function that returns the coverage over exons of multiple genes of a sample when a list of Enseml IDs is provided."""
+
+    # GIVING a sample transcript coverage query containing Ensembl IDs
+    sample_query: Dict[str, str] = {
+        "sample_name": DEMO_SAMPLE["name"],
+        "build": build,
+        "ensembl_gene_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
+        "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
+    }
+
+    # THEN the response should be successful
+    response = demo_client.post(endpoints.SAMPLE_EXONS_COVERAGE, json=sample_query)
+    assert response.status_code == status.HTTP_200_OK
+
+    # AND return coverage intervals data
+    coverage_intervals: List = response.json()
+    for interval in coverage_intervals:
+        assert CoverageInterval(**interval)


### PR DESCRIPTION
### This PR adds | fixes:
- Adds and endpoint that accepts a sample name and gene list and returns coverage and completeness over the exons of these genes

### How to test:
- Launch an instance of the app and test the endpoint 

### Expected outcome:
- Exon coverage and completeness values should be returned

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
