### PR TITLE
Strict validation of gene lists provided in sample coverage queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,4 +59,4 @@
 - Load genes, transcripts and exons in batches of 10K records
 - Simpler code to load genes and transcripts into the database
 - Updated version of several GitHub actions
-- Validate sample coverage queries so that only gene list format can be provided
+- Validate sample coverage queries so that only one gene list format can be provided

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,9 @@
 - Updated a few python dependencies
 - Moved validation of sample's coverage file path to sample's pydantic model
 - Installing the pyd4 module as a requirement of this repository
-- Moved the endpoints contants to a class in test fixtures
+- Moved the endpoints constants to a class in test fixtures
 - More explicit names for two endpoints
 - Load genes, transcripts and exons in batches of 10K records
 - Simpler code to load genes and transcripts into the database
 - Updated version of several GitHub actions
+- Validate sample coverage queries so that only gene list format can be provided

--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -9,6 +9,9 @@ WRONG_COVERAGE_FILE_MSG: str = (
 )
 WRONG_BED_FILE_MSG: str = "Provided intervals files is not a valid BED file"
 MULTIPLE_PARAMS_NOT_SUPPORTED_MSG = "Interval query contains too many filter parameters. Please specify genome build and max one type of filter."
+MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG = (
+    "Please provide either Ensembl gene IDs, HGNC gene IDS or HGNC gene symbols."
+)
 
 ENSEMBL_RESOURCE_CLIENT: Dict[str, Callable] = {
     "genes": fetch_ensembl_genes,

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -24,7 +24,6 @@ from chanjo2.meta.handle_d4 import (
 )
 from chanjo2.models.pydantic_models import (
     CoverageInterval,
-    SampleGeneQuery,
     SampleGeneIntervalQuery,
 )
 from chanjo2.models.sql_models import Exon as SQLExon
@@ -112,7 +111,7 @@ def get_sample_coverage_file(
 
 @router.post("/coverage/sample/genes_coverage", response_model=List[CoverageInterval])
 async def sample_genes_coverage(
-    query: SampleGeneQuery, db: Session = Depends(get_session)
+    query: SampleGeneIntervalQuery, db: Session = Depends(get_session)
 ):
     """Returns coverage over a list of genes (entire gene) for a given sample in the database."""
 
@@ -121,9 +120,9 @@ async def sample_genes_coverage(
     genes: List[SQLGene] = get_genes(
         db=db,
         build=query.build,
-        ensembl_ids=query.ensembl_ids,
-        hgnc_ids=query.hgnc_ids,
-        hgnc_symbols=query.hgnc_symbols,
+        ensembl_ids=query.ensembl_gene_ids,
+        hgnc_ids=query.hgnc_gene_ids,
+        hgnc_symbols=query.hgnc_gene_symbols,
         limit=None,
     )
 
@@ -148,8 +147,8 @@ async def sample_transcripts_coverage(
         db=db,
         build=query.build,
         ensembl_ids=query.ensembl_gene_ids,
-        hgnc_ids=query.hgnc_ids,
-        hgnc_symbols=query.hgnc_symbols,
+        hgnc_ids=query.hgnc_gene_ids,
+        hgnc_symbols=query.hgnc_gene_symbols,
         limit=None,
     )
 
@@ -174,8 +173,8 @@ async def sample_exons_coverage(
         db=db,
         build=query.build,
         ensembl_ids=query.ensembl_gene_ids,
-        hgnc_ids=query.hgnc_ids,
-        hgnc_symbols=query.hgnc_symbols,
+        hgnc_ids=query.hgnc_gene_ids,
+        hgnc_symbols=query.hgnc_gene_symbols,
         limit=None,
     )
 

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -140,36 +140,12 @@ class CoverageInterval(BaseModel):
     start: Optional[int]
 
 
-class SampleGeneQuery(BaseModel):
-    build: Builds
-    completeness_thresholds: Optional[List[int]]
-    ensembl_ids: Optional[List[str]]
-    hgnc_ids: Optional[List[int]]
-    hgnc_symbols: Optional[List[str]]
-    sample_name: str
-
-    @root_validator
-    def check_genes_lists(cls, values):
-        nr_provided_gene_lists = 0
-        for gene_list in [
-            values.get("ensembl_ids"),
-            values.get("hgnc_ids"),
-            values.get("hgnc_symbols"),
-        ]:
-            if gene_list:
-                nr_provided_gene_lists += 1
-        if nr_provided_gene_lists != 1:
-            raise ValueError(
-                "Please provide either Ensembl IDs, HGNC IDS or HGNC symbols "
-            )
-
-
 class SampleGeneIntervalQuery(BaseModel):
     build: Builds
     completeness_thresholds: Optional[List[int]]
     ensembl_gene_ids: Optional[List[str]]
-    hgnc_ids: Optional[List[int]]
-    hgnc_symbols: Optional[List[str]]
+    hgnc_gene_ids: Optional[List[int]]
+    hgnc_gene_symbols: Optional[List[str]]
     sample_name: str
 
     @root_validator
@@ -177,12 +153,13 @@ class SampleGeneIntervalQuery(BaseModel):
         nr_provided_gene_lists = 0
         for gene_list in [
             values.get("ensembl_gene_ids"),
-            values.get("hgnc_ids"),
-            values.get("hgnc_symbols"),
+            values.get("hgnc_gene_ids"),
+            values.get("hgnc_gene_symbols"),
         ]:
             if gene_list:
                 nr_provided_gene_lists += 1
         if nr_provided_gene_lists != 1:
             raise ValueError(
-                "Please provide either Ensembl gene IDs, HGNC IDS or HGNC symbols "
+                "Please provide either Ensembl gene IDs, HGNC gene IDS or HGNC gene symbols "
             )
+        return values

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -6,7 +6,10 @@ from typing import Any, List, Optional, Tuple
 import validators
 from pydantic import BaseModel, validator, Field, root_validator
 
-from chanjo2.constants import WRONG_COVERAGE_FILE_MSG
+from chanjo2.constants import (
+    WRONG_COVERAGE_FILE_MSG,
+    MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG,
+)
 
 
 class Builds(str, Enum):
@@ -148,7 +151,7 @@ class SampleGeneIntervalQuery(BaseModel):
     hgnc_gene_symbols: Optional[List[str]]
     sample_name: str
 
-    @root_validator
+    @root_validator(pre=True)
     def check_genes_lists(cls, values):
         nr_provided_gene_lists = 0
         for gene_list in [
@@ -158,8 +161,5 @@ class SampleGeneIntervalQuery(BaseModel):
         ]:
             if gene_list:
                 nr_provided_gene_lists += 1
-        if nr_provided_gene_lists != 1:
-            raise ValueError(
-                "Please provide either Ensembl gene IDs, HGNC gene IDS or HGNC gene symbols "
-            )
+        assert nr_provided_gene_lists == 1, MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG
         return values

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Any, List, Optional, Tuple
 
 import validators
-from pydantic import BaseModel, validator, Field
+from pydantic import BaseModel, validator, Field, root_validator
 
 from chanjo2.constants import WRONG_COVERAGE_FILE_MSG
 
@@ -148,6 +148,21 @@ class SampleGeneQuery(BaseModel):
     hgnc_symbols: Optional[List[str]]
     sample_name: str
 
+    @root_validator
+    def check_genes_lists(cls, values):
+        nr_provided_gene_lists = 0
+        for gene_list in [
+            values.get("ensembl_ids"),
+            values.get("hgnc_ids"),
+            values.get("hgnc_symbols"),
+        ]:
+            if gene_list:
+                nr_provided_gene_lists += 1
+        if nr_provided_gene_lists != 1:
+            raise ValueError(
+                "Please provide either Ensembl IDs, HGNC IDS or HGNC symbols "
+            )
+
 
 class SampleGeneIntervalQuery(BaseModel):
     build: Builds
@@ -156,3 +171,18 @@ class SampleGeneIntervalQuery(BaseModel):
     hgnc_ids: Optional[List[int]]
     hgnc_symbols: Optional[List[str]]
     sample_name: str
+
+    @root_validator
+    def check_genes_lists(cls, values):
+        nr_provided_gene_lists = 0
+        for gene_list in [
+            values.get("ensembl_gene_ids"),
+            values.get("hgnc_ids"),
+            values.get("hgnc_symbols"),
+        ]:
+            if gene_list:
+                nr_provided_gene_lists += 1
+        if nr_provided_gene_lists != 1:
+            raise ValueError(
+                "Please provide either Ensembl gene IDs, HGNC IDS or HGNC symbols "
+            )

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -161,5 +161,6 @@ class SampleGeneIntervalQuery(BaseModel):
         ]:
             if gene_list:
                 nr_provided_gene_lists += 1
-        assert nr_provided_gene_lists == 1, MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG
+        if nr_provided_gene_lists != 1:
+            raise ValueError(MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG)
         return values

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -153,7 +153,7 @@ class SampleGeneIntervalQuery(BaseModel):
 
     @root_validator(pre=True)
     def check_genes_lists(cls, values):
-        nr_provided_gene_lists = 0
+        nr_provided_gene_lists: int = 0
         for gene_list in [
             values.get("ensembl_gene_ids"),
             values.get("hgnc_gene_ids"),

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -5,7 +5,11 @@ import pytest
 from fastapi import status
 from fastapi.testclient import TestClient
 
-from chanjo2.constants import WRONG_COVERAGE_FILE_MSG, WRONG_BED_FILE_MSG
+from chanjo2.constants import (
+    WRONG_COVERAGE_FILE_MSG,
+    WRONG_BED_FILE_MSG,
+    MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG,
+)
 from chanjo2.demo import gene_panel_file, gene_panel_path
 from chanjo2.models.pydantic_models import (
     CoverageInterval,
@@ -162,6 +166,33 @@ def test_d4_intervals_coverage(
     coverage_intervals: List = response.json()
     for interval in coverage_intervals:
         assert CoverageInterval(**interval)
+
+
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_sample_coverage_multiple_genes_lists(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the validation of the parameters passed to the sample coverage endpoints when multiple gene lists are passed"""
+
+    # GIVEN a sample gene coverage query containing multiple gene lists (hgnc_gene_symbols and hgnc_gene_ids)
+    sample_query: Dict[str, str] = {
+        "sample_name": DEMO_SAMPLE["name"],
+        "build": build,
+        "hgnc_gene_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
+        "hgnc_gene_ids": genomic_ids_per_build[build]["hgnc_ids"],
+    }
+
+    # THEN the response should be return error
+    response = demo_client.post(endpoints.SAMPLE_GENES_COVERAGE, json=sample_query)
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    # AND a meaningful message
+    result = response.json()
+
+    assert result["detail"][0]["msg"] == MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -175,7 +175,7 @@ def test_sample_coverage_multiple_genes_lists(
     endpoints: Type,
     genomic_ids_per_build: Dict[str, List],
 ):
-    """Test the validation of the parameters passed to the sample coverage endpoints when multiple gene lists are passed"""
+    """Test the validation of the parameters passed to the sample coverage endpoints when multiple gene lists are passed."""
 
     # GIVEN a sample gene coverage query containing multiple gene lists (hgnc_gene_symbols and hgnc_gene_ids)
     sample_query: Dict[str, str] = {

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -177,7 +177,7 @@ def test_sample_gene_coverage_hgnc_symbols(
     sample_query: Dict[str, str] = {
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
-        "hgnc_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
+        "hgnc_gene_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
@@ -204,7 +204,7 @@ def test_sample_gene_coverage_hgnc_ids(
     sample_query: Dict[str, str] = {
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
-        "hgnc_ids": genomic_ids_per_build[build]["hgnc_ids"],
+        "hgnc_gene_ids": genomic_ids_per_build[build]["hgnc_ids"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
@@ -231,7 +231,7 @@ def test_sample_gene_coverage_ensembl_ids(
     sample_query: Dict[str, str] = {
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
-        "ensembl_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
+        "ensembl_gene_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
@@ -258,7 +258,7 @@ def test_sample_transcripts_coverage_hgnc_symbols(
     sample_query: Dict[str, str] = {
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
-        "hgnc_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
+        "hgnc_gene_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
@@ -287,7 +287,7 @@ def test_sample_transcripts_coverage_hgnc_ids(
     sample_query: Dict[str, str] = {
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
-        "hgnc_ids": genomic_ids_per_build[build]["hgnc_ids"],
+        "hgnc_gene_ids": genomic_ids_per_build[build]["hgnc_ids"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
@@ -345,7 +345,7 @@ def test_sample_exons_coverage_hgnc_symbols(
     sample_query: Dict[str, str] = {
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
-        "hgnc_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
+        "hgnc_gene_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 
@@ -372,7 +372,7 @@ def test_sample_exons_coverage_hgnc_ids(
     sample_query: Dict[str, str] = {
         "sample_name": DEMO_SAMPLE["name"],
         "build": build,
-        "hgnc_ids": genomic_ids_per_build[build]["hgnc_ids"],
+        "hgnc_gene_ids": genomic_ids_per_build[build]["hgnc_ids"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
     }
 


### PR DESCRIPTION
### This PR adds | fixes:
- Make sure user provides ONE list of genes in the following formats: HGNC IDS, HGNC symbols or Ensembl IDs
- Simplify the models so that the 3 endpoints (gene coverage, transcript coverage and exon coverage) accept the same type of query

### How to test:
- Automatic tests

### Expected outcome:
- [x] If multiple gene lists are provided (or none is provided) then the endpoints return error

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
