### PR TITLE
SampleS coverage and competeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,9 @@
 - Filter genes, transcripts and exons by Ensemble id, HGNC id, HGNC symbol
 - Demo genes, transcripts and exons loaded on demo instance startup
 - Return coverage over a list of genes for a sample in the database
-- Return coverage and coverage completeness (custom thresholds) over a list of genes for a sample in the database
-- Return transcripts coverage and coverage completeness (custom thresholds) over a list of genes for a sample in the
-  database
-- Return exons coverage and coverage completeness (custom thresholds) over a list of genes for a sample in the database
+- Return coverage and coverage completeness (custom thresholds) over a list of genes for database samples
+- Return transcripts coverage and coverage completeness (custom thresholds) over a list of genes for database samples
+- Return exons coverage and coverage completeness (custom thresholds) over a list of genes for database samples
 
 ### Fixed
 

--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -3,7 +3,7 @@ from typing import Callable, Dict, List
 from schug.load.ensembl import fetch_ensembl_exon_lines as fetch_ensembl_exons
 from schug.load.ensembl import fetch_ensembl_genes, fetch_ensembl_transcripts
 
-SAMPLE_NOT_FOUND: str = "Sample not present in the database"
+SAMPLE_NOT_FOUND: str = "One of more requested samples were not present in the database"
 WRONG_COVERAGE_FILE_MSG: str = (
     "Coverage_file_path must be either an existing local file path or a URL"
 )

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -29,7 +29,7 @@ def get_samples(db: Session, limit: int = 100) -> List[SQLSample]:
     return db.query(SQLSample).limit(limit).all()
 
 
-def get_samples_by_name(db: Session, sample_names: List) -> List[SQLSample]:
+def get_samples_by_name(db: Session, sample_names: List[str]) -> List[SQLSample]:
     """Filter samples by a list of names."""
     query = db.query(SQLSample)
     return _filter_samples_by_name(samples=query, sample_names=sample_names).all()

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -13,10 +13,10 @@ LOG = logging.getLogger("uvicorn.access")
 
 def _filter_samples_by_name(
     samples: query.Query,
-    sample_name: str,
-) -> SQLSample:
+    sample_names: List[str],
+) -> query.Query:
     """Filter samples by sample name."""
-    return samples.filter(SQLSample.name == sample_name).first()
+    return samples.filter(SQLSample.name.in_(sample_names))
 
 
 def _filter_samples_by_case(
@@ -30,6 +30,12 @@ def _filter_samples_by_case(
 def get_samples(db: Session, limit: int = 100) -> List[SQLSample]:
     """Return all samples."""
     return db.query(SQLSample).limit(limit).all()
+
+
+def get_samples_by_name(db: Session, sample_names: List) -> List[SQLSample]:
+    """Filter samples by a list of names."""
+    query = db.query(SQLSample)
+    return _filter_samples_by_name(samples=query, sample_names=sample_names).all()
 
 
 def get_case_samples(db: Session, case_name: str) -> List[SQLSample]:
@@ -46,7 +52,9 @@ def get_sample(db: Session, sample_name: str) -> SQLSample:
     pipeline = {"filter_samples_by_name": _filter_samples_by_name}
     query = db.query(SQLSample)
 
-    return pipeline["filter_samples_by_name"](query, sample_name)
+    return pipeline["filter_samples_by_name"](
+        samples=query, sample_names=[sample_name]
+    ).first()
 
 
 def create_sample_in_case(db: Session, sample: SampleCreate) -> Optional[SQLSample]:

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List, Optional
 
 from sqlalchemy.orm import Session, query
@@ -7,8 +6,6 @@ from chanjo2.crud.cases import filter_cases_by_name
 from chanjo2.models.pydantic_models import SampleCreate
 from chanjo2.models.sql_models import Case as SQLCase
 from chanjo2.models.sql_models import Sample as SQLSample
-
-LOG = logging.getLogger("uvicorn.access")
 
 
 def _filter_samples_by_name(

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -17,7 +17,7 @@ from chanjo2.meta.handle_bed import parse_bed
 from chanjo2.meta.handle_d4 import (
     intervals_coverage,
     get_intervals_mean_coverage,
-    set_d4_file,
+    get_d4_file,
     set_interval,
     get_genes_coverage_completeness,
     get_gene_interval_coverage_completeness,
@@ -46,7 +46,7 @@ def d4_interval_coverage(
         chrom=chromosome, start=start, end=end
     )
     try:
-        d4_file: D4File = set_d4_file(coverage_file_path)
+        d4_file: D4File = get_d4_file(coverage_file_path)
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -72,7 +72,7 @@ def d4_intervals_coverage(coverage_file_path: str, bed_file: bytes = File(...)):
     """Return coverage on the given intervals for a D4 resource located on the disk or on a remote server."""
 
     try:
-        d4_file: D4File = set_d4_file(coverage_file_path=coverage_file_path)
+        d4_file: D4File = get_d4_file(coverage_file_path=coverage_file_path)
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -100,12 +100,12 @@ def get_samples_coverage_file(
     samples_d4_files: List[Tuple[str, D4File]] = []
     sql_samples: List[SQLSample] = get_samples_by_name(db=db, sample_names=samples)
 
-    if len(sqlsamples) < len(samples):
+    if len(sql_samples) < len(samples):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=SAMPLE_NOT_FOUND,
         )
-    for sqlsample in sqlsamples:
+    for sqlsample in sql_samples:
         try:
             d4_file: D4File = get_d4_file(
                 coverage_file_path=sqlsample.coverage_file_path

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -56,14 +56,18 @@ def d4_interval_coverage(
             detail=WRONG_COVERAGE_FILE_MSG,
         )
 
+    LOG.warning(d4_file)
     return CoverageInterval(
         chromosome=chromosome,
         start=start,
         end=end,
         interval=interval,
-        mean_coverage=get_intervals_mean_coverage(
-            d4_file=d4_file, intervals=[interval]
-        )[0],
+        mean_coverage=[
+            (
+                "D4File",
+                get_intervals_mean_coverage(d4_file=d4_file, intervals=[interval])[0],
+            )
+        ],
     )
 
 

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List, Optional, Tuple, Union
 
 from fastapi import APIRouter, HTTPException, File, status, Depends
@@ -31,8 +30,6 @@ from chanjo2.models.sql_models import Exon as SQLExon
 from chanjo2.models.sql_models import Gene as SQLGene
 from chanjo2.models.sql_models import Transcript as SQLTranscript
 
-LOG = logging.getLogger("uvicorn.access")
-
 router = APIRouter()
 
 
@@ -56,7 +53,6 @@ def d4_interval_coverage(
             detail=WRONG_COVERAGE_FILE_MSG,
         )
 
-    LOG.warning(d4_file)
     return CoverageInterval(
         chromosome=chromosome,
         start=start,
@@ -115,8 +111,7 @@ def get_samples_coverage_file(
                 coverage_file_path=sqlsample.coverage_file_path
             )
             samples_d4_files.append((sqlsample.name, d4_file))
-        except Exception as ex:
-            LOG.warning(ex)
+        except Exception:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=WRONG_COVERAGE_FILE_MSG,

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List, Optional, Tuple, Union
 
 from fastapi import APIRouter, HTTPException, File, status, Depends
@@ -11,7 +12,7 @@ from chanjo2.constants import (
     SAMPLE_NOT_FOUND,
 )
 from chanjo2.crud.intervals import get_genes
-from chanjo2.crud.samples import get_sample
+from chanjo2.crud.samples import get_samples_by_name
 from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_bed import parse_bed
 from chanjo2.meta.handle_d4 import (
@@ -29,6 +30,8 @@ from chanjo2.models.pydantic_models import (
 from chanjo2.models.sql_models import Exon as SQLExon
 from chanjo2.models.sql_models import Gene as SQLGene
 from chanjo2.models.sql_models import Transcript as SQLTranscript
+
+LOG = logging.getLogger("uvicorn.access")
 
 router = APIRouter()
 
@@ -89,33 +92,44 @@ def d4_intervals_coverage(coverage_file_path: str, bed_file: bytes = File(...)):
     return intervals_coverage(d4_file=d4_file, intervals=intervals)
 
 
-def get_sample_coverage_file(
-    db: Session, sample_name: str
-) -> Union[D4File, JSONResponse]:
-    sample: SQLSample = get_sample(db=db, sample_name=sample_name)
-    if sample is None:
+def get_samples_coverage_file(
+    db: Session, samples: List[str]
+) -> Union[List[Tuple[str, D4File]], JSONResponse]:
+    """Return a list of sample names with relative D4 coverage files."""
+
+    samples_d4_files: List[Tuple[str, D4File]] = []
+    sqlsamples: List[SQLSample] = get_samples_by_name(db=db, sample_names=samples)
+
+    if len(sqlsamples) < len(samples):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=SAMPLE_NOT_FOUND,
         )
-    try:
-        d4_file: D4File = set_d4_file(coverage_file_path=sample.coverage_file_path)
-    except Exception:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=SAMPLE_NOT_FOUND,
-        )
+    for sqlsample in sqlsamples:
+        try:
+            d4_file: D4File = set_d4_file(
+                coverage_file_path=sqlsample.coverage_file_path
+            )
+            samples_d4_files.append((sqlsample.name, d4_file))
+        except Exception as ex:
+            LOG.warning(ex)
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=WRONG_COVERAGE_FILE_MSG,
+            )
 
-    return d4_file
+    return samples_d4_files
 
 
-@router.post("/coverage/sample/genes_coverage", response_model=List[CoverageInterval])
-async def sample_genes_coverage(
+@router.post("/coverage/samples/genes_coverage", response_model=List[CoverageInterval])
+async def samples_genes_coverage(
     query: SampleGeneIntervalQuery, db: Session = Depends(get_session)
 ):
     """Returns coverage over a list of genes (entire gene) for a given sample in the database."""
 
-    d4_file: D4File = get_sample_coverage_file(db=db, sample_name=query.sample_name)
+    samples_d4_files: Tuple[str, D4File] = get_samples_coverage_file(
+        db=db, samples=query.samples
+    )
 
     genes: List[SQLGene] = get_genes(
         db=db,
@@ -127,21 +141,23 @@ async def sample_genes_coverage(
     )
 
     return get_genes_coverage_completeness(
-        d4_file=d4_file,
+        samples_d4_files=samples_d4_files,
         genes=genes,
         completeness_threholds=query.completeness_thresholds,
     )
 
 
 @router.post(
-    "/coverage/sample/transcripts_coverage", response_model=List[CoverageInterval]
+    "/coverage/samples/transcripts_coverage", response_model=List[CoverageInterval]
 )
-async def sample_transcripts_coverage(
+async def samples_transcripts_coverage(
     query: SampleGeneIntervalQuery, db: Session = Depends(get_session)
 ):
     """Returns coverage over a list of genes (transcripts intervals only) for a given sample in the database."""
 
-    d4_file: D4File = get_sample_coverage_file(db=db, sample_name=query.sample_name)
+    samples_d4_files: Tuple[str, D4File] = get_samples_coverage_file(
+        db=db, samples=query.samples
+    )
 
     genes: List[SQLGene] = get_genes(
         db=db,
@@ -154,20 +170,22 @@ async def sample_transcripts_coverage(
 
     return get_gene_interval_coverage_completeness(
         db=db,
-        d4_file=d4_file,
+        samples_d4_files=samples_d4_files,
         genes=genes,
         interval_type=SQLTranscript,
         completeness_threholds=query.completeness_thresholds,
     )
 
 
-@router.post("/coverage/sample/exons_coverage", response_model=List[CoverageInterval])
-async def sample_exons_coverage(
+@router.post("/coverage/samples/exons_coverage", response_model=List[CoverageInterval])
+async def samples_exons_coverage(
     query: SampleGeneIntervalQuery, db: Session = Depends(get_session)
 ):
     """Returns coverage over a list of genes (exons intervals only) for a given sample in the database."""
 
-    d4_file: D4File = get_sample_coverage_file(db=db, sample_name=query.sample_name)
+    samples_d4_files: Tuple[str, D4File] = get_samples_coverage_file(
+        db=db, samples=query.samples
+    )
 
     genes: List[SQLGene] = get_genes(
         db=db,
@@ -180,7 +198,7 @@ async def sample_exons_coverage(
 
     return get_gene_interval_coverage_completeness(
         db=db,
-        d4_file=d4_file,
+        samples_d4_files=samples_d4_files,
         genes=genes,
         interval_type=SQLExon,
         completeness_threholds=query.completeness_thresholds,

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -107,7 +107,7 @@ def get_samples_coverage_file(
         )
     for sqlsample in sqlsamples:
         try:
-            d4_file: D4File = set_d4_file(
+            d4_file: D4File = get_d4_file(
                 coverage_file_path=sqlsample.coverage_file_path
             )
             samples_d4_files.append((sqlsample.name, d4_file))

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -98,7 +98,7 @@ def get_samples_coverage_file(
     """Return a list of sample names with relative D4 coverage files."""
 
     samples_d4_files: List[Tuple[str, D4File]] = []
-    sqlsamples: List[SQLSample] = get_samples_by_name(db=db, sample_names=samples)
+    sql_samples: List[SQLSample] = get_samples_by_name(db=db, sample_names=samples)
 
     if len(sqlsamples) < len(samples):
         raise HTTPException(

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -111,7 +111,9 @@ def get_genes_coverage_completeness(
             samples_mean_coverage.append(
                 (
                     sample,
-                    get_intervals_mean_coverage(d4_file=d4_file, intervals=gene_coords),
+                    get_intervals_mean_coverage(d4_file=d4_file, intervals=gene_coords)[
+                        0
+                    ],
                 )
             )
             samples_cov_completeness.append(

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -20,7 +20,7 @@ def set_interval(
     return (chrom, start, end) if start and end else chrom
 
 
-def set_d4_file(coverage_file_path: str) -> D4File:
+def get_d4_file(coverage_file_path: str) -> D4File:
     """Create a D4 file from a file path/URL."""
     return D4File(coverage_file_path)
 

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -1,4 +1,3 @@
-import logging
 from decimal import Decimal
 from statistics import mean
 from typing import List, Optional, Tuple, Union
@@ -12,8 +11,6 @@ from chanjo2.models.pydantic_models import CoverageInterval
 from chanjo2.models.sql_models import Exon as SQLExon
 from chanjo2.models.sql_models import Gene as SQLGene
 from chanjo2.models.sql_models import Transcript as SQLTranscript
-
-LOG = logging.getLogger("uvicorn.access")
 
 
 def set_interval(

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -1,3 +1,4 @@
+import logging
 from decimal import Decimal
 from statistics import mean
 from typing import List, Optional, Tuple, Union
@@ -11,6 +12,8 @@ from chanjo2.models.pydantic_models import CoverageInterval
 from chanjo2.models.sql_models import Exon as SQLExon
 from chanjo2.models.sql_models import Gene as SQLGene
 from chanjo2.models.sql_models import Transcript as SQLTranscript
+
+LOG = logging.getLogger("uvicorn.access")
 
 
 def set_interval(
@@ -162,6 +165,7 @@ def get_gene_interval_coverage_completeness(
             ensembl_gene_ids=[gene.ensembl_id],
             limit=None,
         )
+
         intervals: List[Tuple[str, int, int]] = get_intervals_coords_list(
             intervals=sql_intervals
         )
@@ -169,7 +173,7 @@ def get_gene_interval_coverage_completeness(
         samples_mean_coverage: List[Tuple[str, float]] = []
         samples_cov_completeness: List[Tuple[str, Decimal]] = []
 
-        if sql_intervals:
+        if intervals:
             for sample, d4_file in samples_d4_files:
                 samples_mean_coverage.append(
                     (
@@ -200,8 +204,8 @@ def get_gene_interval_coverage_completeness(
                 chromosome=gene.chromosome,
                 start=gene.start,
                 end=gene.stop,
-                mean_coverage=samples_cov_completeness,
-                completeness=[],
+                mean_coverage=samples_mean_coverage,
+                completeness=samples_cov_completeness,
             )
         )
     return transcripts_cov

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -53,7 +53,7 @@ def intervals_coverage(
                 chromosome=interval[0],
                 start=interval[1],
                 end=interval[2],
-                mean_coverage=d4_file.mean(interval),
+                mean_coverage=[("D4File", d4_file.mean(interval))],
             )
         )
     return intervals_cov

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -139,7 +139,7 @@ class CoverageInterval(BaseModel):
     hgnc_id: Optional[int]
     hgnc_symbol: Optional[str]
     interval_id: Optional[int]
-    mean_coverage: float
+    mean_coverage: List[Tuple] = Field(default_factory=list)
     start: Optional[int]
 
 
@@ -149,7 +149,7 @@ class SampleGeneIntervalQuery(BaseModel):
     ensembl_gene_ids: Optional[List[str]]
     hgnc_gene_ids: Optional[List[int]]
     hgnc_gene_symbols: Optional[List[str]]
-    sample_name: str
+    samples: List[str]
 
     @root_validator(pre=True)
     def check_genes_lists(cls, values):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,9 +57,9 @@ class Endpoints(str, Enum):
     EXONS = "/intervals/exons"
     INTERVAL_COVERAGE = "/coverage/d4/interval/"
     INTERVALS_FILE_COVERAGE = "/coverage/d4/interval_file/"
-    SAMPLE_GENES_COVERAGE = "/coverage/sample/genes_coverage"
-    SAMPLE_TRANSCRIPTS_COVERAGE = "/coverage/sample/transcripts_coverage"
-    SAMPLE_EXONS_COVERAGE = "/coverage/sample/exons_coverage"
+    SAMPLE_GENES_COVERAGE = "/coverage/samples/genes_coverage"
+    SAMPLE_TRANSCRIPTS_COVERAGE = "/coverage/samples/transcripts_coverage"
+    SAMPLE_EXONS_COVERAGE = "/coverage/samples/exons_coverage"
 
 
 @pytest.fixture

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -56,7 +56,7 @@ def test_d4_interval_coverage(
     # THEN the mean coverage over the interval should be returned
     result = response.json()
     coverage_data = CoverageInterval(**result)
-    assert coverage_data.mean_coverage > 0
+    assert coverage_data.mean_coverage
 
     # THEN the queried interval should also be present
     assert coverage_data.chromosome
@@ -83,7 +83,7 @@ def test_d4_interval_coverage_single_chromosome(
     # AND the mean coverage over the entire chromosome should be present in the result
     result = response.json()
     coverage_data = CoverageInterval(**result)
-    assert coverage_data.mean_coverage > 0
+    assert coverage_data.mean_coverage
     # together with the queried interval
     assert coverage_data.chromosome
     assert coverage_data.start is None

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -179,7 +179,7 @@ def test_sample_coverage_multiple_genes_lists(
 
     # GIVEN a sample gene coverage query containing multiple gene lists (hgnc_gene_symbols and hgnc_gene_ids)
     sample_query: Dict[str, str] = {
-        "sample_name": DEMO_SAMPLE["name"],
+        "samples": [DEMO_SAMPLE["name"]],
         "build": build,
         "hgnc_gene_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
         "hgnc_gene_ids": genomic_ids_per_build[build]["hgnc_ids"],
@@ -206,7 +206,7 @@ def test_sample_gene_coverage_hgnc_symbols(
 
     # GIVEN a sample gene coverage query containing HGNC gene symbols
     sample_query: Dict[str, str] = {
-        "sample_name": DEMO_SAMPLE["name"],
+        "samples": [DEMO_SAMPLE["name"]],
         "build": build,
         "hgnc_gene_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
@@ -233,7 +233,7 @@ def test_sample_gene_coverage_hgnc_ids(
 
     # GIVING a sample gene coverage query containing HGNC IDs
     sample_query: Dict[str, str] = {
-        "sample_name": DEMO_SAMPLE["name"],
+        "samples": [DEMO_SAMPLE["name"]],
         "build": build,
         "hgnc_gene_ids": genomic_ids_per_build[build]["hgnc_ids"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
@@ -260,7 +260,7 @@ def test_sample_gene_coverage_ensembl_ids(
 
     # GIVING a sample gene coverage query containing Ensembl IDs
     sample_query: Dict[str, str] = {
-        "sample_name": DEMO_SAMPLE["name"],
+        "samples": [DEMO_SAMPLE["name"]],
         "build": build,
         "ensembl_gene_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
@@ -287,7 +287,7 @@ def test_sample_transcripts_coverage_hgnc_symbols(
 
     # GIVING a sample transcript coverage query containing HGNC gene symbols
     sample_query: Dict[str, str] = {
-        "sample_name": DEMO_SAMPLE["name"],
+        "samples": [DEMO_SAMPLE["name"]],
         "build": build,
         "hgnc_gene_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
@@ -316,7 +316,7 @@ def test_sample_transcripts_coverage_hgnc_ids(
 
     # GIVING a sample transcript coverage query containing HGNC IDs
     sample_query: Dict[str, str] = {
-        "sample_name": DEMO_SAMPLE["name"],
+        "samples": [DEMO_SAMPLE["name"]],
         "build": build,
         "hgnc_gene_ids": genomic_ids_per_build[build]["hgnc_ids"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
@@ -345,7 +345,7 @@ def test_sample_transcripts_coverage_ensembl_ids(
 
     # GIVING a sample transcript coverage query containing Ensembl IDs
     sample_query: Dict[str, str] = {
-        "sample_name": DEMO_SAMPLE["name"],
+        "samples": [DEMO_SAMPLE["name"]],
         "build": build,
         "ensembl_gene_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
@@ -374,7 +374,7 @@ def test_sample_exons_coverage_hgnc_symbols(
 
     # GIVING a sample transcript coverage query containing HGNC gene symbols
     sample_query: Dict[str, str] = {
-        "sample_name": DEMO_SAMPLE["name"],
+        "samples": [DEMO_SAMPLE["name"]],
         "build": build,
         "hgnc_gene_symbols": genomic_ids_per_build[build]["hgnc_symbols"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
@@ -401,7 +401,7 @@ def test_sample_exons_coverage_hgnc_ids(
 
     # GIVING a sample transcript coverage query containing HGNC IDs
     sample_query: Dict[str, str] = {
-        "sample_name": DEMO_SAMPLE["name"],
+        "samples": [DEMO_SAMPLE["name"]],
         "build": build,
         "hgnc_gene_ids": genomic_ids_per_build[build]["hgnc_ids"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,
@@ -428,7 +428,7 @@ def test_sample_exons_coverage_ensembl_ids(
 
     # GIVING a sample transcript coverage query containing Ensembl IDs
     sample_query: Dict[str, str] = {
-        "sample_name": DEMO_SAMPLE["name"],
+        "samples": [DEMO_SAMPLE["name"]],
         "build": build,
         "ensembl_gene_ids": genomic_ids_per_build[build]["ensembl_gene_ids"],
         "completeness_thresholds": COVERAGE_COMPLETENESS_THRESHOLDS,


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #100 

### How to test:
- Feed the coverage endpoints with a list of samples (could be a list with one element) and run a query for coverage over some genes/transcripts/exons 

### Expected outcome:
- The coverage and completeness fields should be lists instead of single values

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
