### PR TITLE
Speed up queries by optimizing Genes, Transcripts and Exons table indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,4 @@
 - Simpler code to load genes and transcripts into the database
 - Updated version of several GitHub actions
 - Validate sample coverage queries so that only one gene list format can be provided
+- Speed up queries by optimizing Genes, Transcripts and Exons table indexes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,4 +59,4 @@
 - Simpler code to load genes and transcripts into the database
 - Updated version of several GitHub actions
 - Validate sample coverage queries so that only one gene list format can be provided
-- Speed up queries by optimizing Genes, Transcripts and Exons table indexes
+- Speed up queries by optimizing Genes, Transcripts and Exons tables and indexes

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional, Union, Dict, Tuple
+from typing import List, Optional, Union
 
 from sqlalchemy import delete
 from sqlalchemy.orm import Session, query
@@ -123,7 +123,7 @@ def get_gene_intervals(
     ensembl_gene_ids: Optional[List[str]],
     limit: Optional[int],
     interval_type: Union[SQLTranscript, SQLExon],
-) -> Dict[str, List[Tuple[str, int, int]]]:
+) -> List[Union[SQLTranscript, SQLExon]]:
     """Retrieve transcripts or exons from a list of genes."""
 
     intervals: query.Query = db.query(interval_type).join(SQLGene)

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -194,10 +194,9 @@ def get_gene_intervals(
         intervals = intervals.filter(SQLGene.ensembl_id.in_(hgnc_ids))
     elif hgnc_symbols:
         intervals = intervals.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
-    elif hgnc_ids:
-        intervals = intervals.filter(SQLGene.hgnc_id.in_(hgnc_ids))
 
-    intervals = intervals.filter(interval_type.build == build)
+    intervals: query.Query = intervals.filter(interval_type.build == build)
+
     if limit:
         return intervals.limit(limit).all()
 

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -134,7 +134,7 @@ def get_gene_intervals(
             interval_type.ensembl_gene_id.in_(ensembl_gene_ids)
         )
     elif hgnc_ids:
-        intervals = intervals.filter(SQLGene.ensembl_id.in_(hgnc_ids))
+        intervals = intervals.filter(SQLGene.hgnc_id.in_(hgnc_ids))
     elif hgnc_symbols:
         intervals = intervals.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
 

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -74,7 +74,7 @@ def get_genes(
     genes: query.Query = db.query(SQLGene)
 
     if ensembl_ids:
-        genes = genes.filter(SQLGene.ensembl_id.in_(ensembl_ids))
+        genes: query.Query = genes.filter(SQLGene.ensembl_id.in_(ensembl_ids))
     elif hgnc_ids:
         genes = genes.filter(SQLGene.hgnc_id.in_(hgnc_ids))
     elif hgnc_symbols:

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -138,7 +138,7 @@ def get_gene_intervals(
     elif hgnc_symbols:
         intervals: query.Query = intervals.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
 
-    intervals = intervals.filter(interval_type.build == build)
+    intervals: query.Query = intervals.filter(interval_type.build == build)
 
     if limit:
         return intervals.limit(limit).all()

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -108,9 +108,7 @@ def get_genes(
 ) -> List[SQLGene]:
     """Return genes according to specified fields."""
     genes: query.Query = db.query(SQLGene)
-    genes: query.Query = _filter_intervals_by_build(
-        intervals=genes, interval_type=SQLGene, build=build
-    )
+
     if ensembl_ids:
         genes: query.Query = _filter_intervals_by_ensembl_ids(
             intervals=genes, interval_type=SQLGene, ensembl_ids=ensembl_ids
@@ -123,7 +121,9 @@ def get_genes(
         genes: query.Query = _filter_intervals_by_hgnc_symbols(
             intervals=genes, interval_type=SQLGene, hgnc_symbols=hgnc_symbols
         )
-
+    genes: query.Query = _filter_intervals_by_build(
+        intervals=genes, interval_type=SQLGene, build=build
+    )
     if limit:
         return genes.limit(limit).all()
     return genes.all()
@@ -196,10 +196,6 @@ def get_gene_intervals(
     if hgnc_ids or hgnc_symbols:
         ensembl_gene_ids: List[str] = [gene.ensembl_id for gene in genes]
 
-    intervals: query.Query = _filter_intervals_by_build(
-        intervals=intervals, interval_type=interval_type, build=build
-    )
-
     if ensembl_ids:
         intervals: query.Query = _filter_intervals_by_ensembl_ids(
             intervals=intervals, interval_type=interval_type, ensembl_ids=ensembl_ids
@@ -211,6 +207,9 @@ def get_gene_intervals(
             ensembl_gene_ids=ensembl_gene_ids,
         )
 
+    intervals: query.Query = _filter_intervals_by_build(
+        intervals=intervals, interval_type=interval_type, build=build
+    )
     if limit:
         return intervals.limit(limit).all()
 

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -108,6 +108,9 @@ def get_genes(
 ) -> List[SQLGene]:
     """Return genes according to specified fields."""
     genes: query.Query = db.query(SQLGene)
+    genes: query.Query = _filter_intervals_by_build(
+        intervals=genes, interval_type=SQLGene, build=build
+    )
     if ensembl_ids:
         genes: query.Query = _filter_intervals_by_ensembl_ids(
             intervals=genes, interval_type=SQLGene, ensembl_ids=ensembl_ids
@@ -120,9 +123,7 @@ def get_genes(
         genes: query.Query = _filter_intervals_by_hgnc_symbols(
             intervals=genes, interval_type=SQLGene, hgnc_symbols=hgnc_symbols
         )
-    genes: query.Query = _filter_intervals_by_build(
-        intervals=genes, interval_type=SQLGene, build=build
-    )
+
     if limit:
         return genes.limit(limit).all()
     return genes.all()

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -136,7 +136,7 @@ def get_gene_intervals(
     elif hgnc_ids:
         intervals: query.Query = intervals.filter(SQLGene.hgnc_id.in_(hgnc_ids))
     elif hgnc_symbols:
-        intervals = intervals.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
+        intervals: query.Query = intervals.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
 
     intervals = intervals.filter(interval_type.build == build)
 

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -78,7 +78,7 @@ def get_genes(
     elif hgnc_ids:
         genes = genes.filter(SQLGene.hgnc_id.in_(hgnc_ids))
     elif hgnc_symbols:
-        genes = genes.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
+        genes: query.Query = genes.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
 
     genes = _filter_intervals_by_build(
         intervals=genes, interval_type=SQLGene, build=build

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -130,7 +130,7 @@ def get_gene_intervals(
     if ensembl_ids:
         intervals: query.Query = intervals.filter(interval_type.ensembl_id.in_(ensembl_ids))
     elif ensembl_gene_ids:
-        intervals = intervals.filter(
+        intervals: : query.Query = intervals.filter(
             interval_type.ensembl_gene_id.in_(ensembl_gene_ids)
         )
     elif hgnc_ids:

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -80,7 +80,7 @@ def get_genes(
     elif hgnc_symbols:
         genes: query.Query = genes.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
 
-    genes = _filter_intervals_by_build(
+    genes: query.Query = _filter_intervals_by_build(
         intervals=genes, interval_type=SQLGene, build=build
     )
     if limit:

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -76,7 +76,7 @@ def get_genes(
     if ensembl_ids:
         genes: query.Query = genes.filter(SQLGene.ensembl_id.in_(ensembl_ids))
     elif hgnc_ids:
-        genes = genes.filter(SQLGene.hgnc_id.in_(hgnc_ids))
+        genes: query.Query = genes.filter(SQLGene.hgnc_id.in_(hgnc_ids))
     elif hgnc_symbols:
         genes: query.Query = genes.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
 

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -128,7 +128,7 @@ def get_gene_intervals(
 
     intervals: query.Query = db.query(interval_type).join(SQLGene)
     if ensembl_ids:
-        intervals = intervals.filter(interval_type.ensembl_id.in_(ensembl_ids))
+        intervals: query.Query = intervals.filter(interval_type.ensembl_id.in_(ensembl_ids))
     elif ensembl_gene_ids:
         intervals = intervals.filter(
             interval_type.ensembl_gene_id.in_(ensembl_gene_ids)

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -136,7 +136,7 @@ def get_gene_intervals(
     elif hgnc_ids:
         intervals = intervals.filter(SQLGene.ensembl_id.in_(hgnc_ids))
     elif hgnc_symbols:
-        intervals = intervals.filter(SQLGene.hgnc_id.in_(hgnc_symbols))
+        intervals = intervals.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
 
     intervals = intervals.filter(interval_type.build == build)
 

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -195,6 +195,10 @@ def get_gene_intervals(
     if hgnc_ids or hgnc_symbols:
         ensembl_gene_ids: List[str] = [gene.ensembl_id for gene in genes]
 
+    intervals: query.Query = _filter_intervals_by_build(
+        intervals=intervals, interval_type=interval_type, build=build
+    )
+
     if ensembl_ids:
         intervals: query.Query = _filter_intervals_by_ensembl_ids(
             intervals=intervals, interval_type=interval_type, ensembl_ids=ensembl_ids
@@ -205,10 +209,6 @@ def get_gene_intervals(
             interval_type=interval_type,
             ensembl_gene_ids=ensembl_gene_ids,
         )
-
-    intervals: query.Query = _filter_intervals_by_build(
-        intervals=intervals, interval_type=interval_type, build=build
-    )
 
     if limit:
         return intervals.limit(limit).all()

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -134,7 +134,7 @@ def get_gene_intervals(
             interval_type.ensembl_gene_id.in_(ensembl_gene_ids)
         )
     elif hgnc_ids:
-        intervals = intervals.filter(SQLGene.hgnc_id.in_(hgnc_ids))
+        intervals: query.Query = intervals.filter(SQLGene.hgnc_id.in_(hgnc_ids))
     elif hgnc_symbols:
         intervals = intervals.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
 

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -34,42 +34,6 @@ def count_intervals_for_build(
     return db.query(interval_type).where(interval_type.build == build).count()
 
 
-def _filter_intervals_by_ensembl_ids(
-    intervals: query.Query,
-    interval_type: Union[SQLGene, SQLTranscript, SQLExon],
-    ensembl_ids: List[str],
-) -> List[Union[SQLGene, SQLTranscript, SQLExon]]:
-    """Filter intervals using a list of Ensembl IDs"""
-    return intervals.filter(interval_type.ensembl_id.in_(ensembl_ids))
-
-
-def _filter_intervals_by_ensembl_gene_ids(
-    intervals: query.Query,
-    interval_type: Union[SQLGene, SQLTranscript, SQLExon],
-    ensembl_gene_ids: List[str],
-) -> query.Query:
-    """Filter intervals using a list of Ensembl gene IDs."""
-    return intervals.filter(interval_type.ensembl_gene_id.in_(ensembl_gene_ids))
-
-
-def _filter_intervals_by_hgnc_ids(
-    intervals: query.Query,
-    interval_type: Union[SQLGene, SQLTranscript, SQLExon],
-    hgnc_ids: List[int],
-) -> query.Query:
-    """Filter intervals using a list of HGNC IDs."""
-    return intervals.filter(interval_type.hgnc_id.in_(hgnc_ids))
-
-
-def _filter_intervals_by_hgnc_symbols(
-    intervals: query.Query,
-    interval_type: Union[SQLGene, SQLTranscript, SQLExon],
-    hgnc_symbols: List[str],
-) -> query.Query:
-    """Filter intervals using a list of HGNC symbols."""
-    return intervals.filter(interval_type.hgnc_symbol.in_(hgnc_symbols))
-
-
 def _filter_intervals_by_build(
     intervals: query.Query,
     interval_type: Union[SQLGene, SQLTranscript, SQLExon],
@@ -110,39 +74,18 @@ def get_genes(
     genes: query.Query = db.query(SQLGene)
 
     if ensembl_ids:
-        genes: query.Query = _filter_intervals_by_ensembl_ids(
-            intervals=genes, interval_type=SQLGene, ensembl_ids=ensembl_ids
-        )
+        genes = genes.filter(SQLGene.ensembl_id.in_(ensembl_ids))
     elif hgnc_ids:
-        genes: query.Query = _filter_intervals_by_hgnc_ids(
-            intervals=genes, interval_type=SQLGene, hgnc_ids=hgnc_ids
-        )
+        genes = genes.filter(SQLGene.hgnc_id.in_(hgnc_ids))
     elif hgnc_symbols:
-        genes: query.Query = _filter_intervals_by_hgnc_symbols(
-            intervals=genes, interval_type=SQLGene, hgnc_symbols=hgnc_symbols
-        )
-    genes: query.Query = _filter_intervals_by_build(
+        genes = genes.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
+
+    genes = _filter_intervals_by_build(
         intervals=genes, interval_type=SQLGene, build=build
     )
     if limit:
         return genes.limit(limit).all()
     return genes.all()
-
-
-def get_gene_from_ensembl_id(db: Session, ensembl_id: str) -> Optional[SQLGene]:
-    """Return a gene given its Ensembl ID."""
-
-    return db.query(SQLGene).filter(SQLGene.ensembl_id == ensembl_id).first()
-
-
-def get_transcript_from_ensembl_id(
-    db: Session, ensembl_id: str
-) -> Optional[SQLTranscript]:
-    """Return a transcript given its Ensembl ID."""
-
-    return (
-        db.query(SQLTranscript).filter(SQLTranscript.ensembl_id == ensembl_id).first()
-    )
 
 
 def create_db_transcript(transcript: TranscriptBase) -> SQLTranscript:
@@ -193,9 +136,9 @@ def get_gene_intervals(
     elif hgnc_ids:
         intervals = intervals.filter(SQLGene.ensembl_id.in_(hgnc_ids))
     elif hgnc_symbols:
-        intervals = intervals.filter(SQLGene.hgnc_symbol.in_(hgnc_symbols))
+        intervals = intervals.filter(SQLGene.hgnc_id.in_(hgnc_symbols))
 
-    intervals: query.Query = intervals.filter(interval_type.build == build)
+    intervals = intervals.filter(interval_type.build == build)
 
     if limit:
         return intervals.limit(limit).all()

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -128,9 +128,11 @@ def get_gene_intervals(
 
     intervals: query.Query = db.query(interval_type).join(SQLGene)
     if ensembl_ids:
-        intervals: query.Query = intervals.filter(interval_type.ensembl_id.in_(ensembl_ids))
+        intervals: query.Query = intervals.filter(
+            interval_type.ensembl_id.in_(ensembl_ids)
+        )
     elif ensembl_gene_ids:
-        intervals: : query.Query = intervals.filter(
+        intervals: query.Query = intervals.filter(
             interval_type.ensembl_gene_id.in_(ensembl_gene_ids)
         )
     elif hgnc_ids:

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -124,7 +124,7 @@ def get_gene_intervals(
     limit: Optional[int],
     interval_type: Union[SQLTranscript, SQLExon],
 ) -> Dict[str, List[Tuple[str, int, int]]]:
-    """Retrieve the coordinates for transcripts or exons from a list of genes."""
+    """Retrieve transcripts or exons from a list of genes."""
 
     intervals: query.Query = db.query(interval_type).join(SQLGene)
     if ensembl_ids:

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -1,5 +1,9 @@
 from typing import List, Union
 
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import JSONResponse
+from sqlmodel import Session
+
 from chanjo2.constants import (
     MULTIPLE_PARAMS_NOT_SUPPORTED_MSG,
 )
@@ -20,9 +24,6 @@ from chanjo2.models.pydantic_models import (
 )
 from chanjo2.models.sql_models import Exon as SQLExon
 from chanjo2.models.sql_models import Transcript as SQLTranscript
-from fastapi import APIRouter, Depends, HTTPException, Response, status
-from fastapi.responses import JSONResponse
-from sqlmodel import Session
 
 router = APIRouter()
 
@@ -165,6 +166,7 @@ async def exons(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=MULTIPLE_PARAMS_NOT_SUPPORTED_MSG,
         )
+
     return get_gene_intervals(
         db=session,
         build=query.build,

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -150,7 +150,7 @@ def get_gene_interval_coverage_completeness(
     completeness_threholds: List[Optional[int]],
 ) -> List[CoverageInterval]:
     """Return coverage of transcripts for a list of genes."""
-    transcripts_cov: List[CoverageInterval] = []
+    intervals_cov: List[CoverageInterval] = []
     for gene in genes:
         sql_intervals: List[Union[SQLTranscript, SQLExon]] = get_gene_intervals(
             db=db,
@@ -193,7 +193,7 @@ def get_gene_interval_coverage_completeness(
                     )
                 )
 
-        transcripts_cov.append(
+        intervals_cov.append(
             CoverageInterval(
                 ensembl_gene_id=gene.ensembl_id,
                 hgnc_id=gene.hgnc_id,
@@ -205,4 +205,4 @@ def get_gene_interval_coverage_completeness(
                 completeness=samples_cov_completeness,
             )
         )
-    return transcripts_cov
+    return intervals_cov

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -1,8 +1,9 @@
-from chanjo2.dbutil import Base
-from chanjo2.models.pydantic_models import Builds
-from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String, Index
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
+
+from chanjo2.dbutil import Base
+from chanjo2.models.pydantic_models import Builds
 
 
 class Case(Base):
@@ -51,11 +52,16 @@ class Gene(Base):
     chromosome = Column(String(6), nullable=False)
     start = Column(Integer, nullable=False)
     stop = Column(Integer, nullable=False)
-    ensembl_id = Column(String(24), nullable=False, index=True)
-    hgnc_id = Column(Integer, nullable=True, index=True)
-    hgnc_symbol = Column(String(64), nullable=True, index=True)
+    ensembl_id = Column(String(24), nullable=False)
+    hgnc_id = Column(Integer, nullable=True)
+    hgnc_symbol = Column(String(64), nullable=True)
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
+    )
+    __table_args__ = (
+        Index("geneidx_ens_id_build", "ensembl_id", "build"),
+        Index("geneidx_hgnc_id_build", "hgnc_id", "build"),
+        Index("geneidx_hgnc_symbol_build", "hgnc_symbol", "build"),
     )
 
 
@@ -68,15 +74,16 @@ class Transcript(Base):
     start = Column(Integer, nullable=False)
     stop = Column(Integer, nullable=False)
     ensembl_id = Column(String(24), nullable=False, index=True)
-    refseq_mrna = Column(String(24), nullable=True, index=True)
-    refseq_mrna_pred = Column(String(24), nullable=True, index=False)
-    refseq_ncrna = Column(String(24), nullable=True, index=False)
+    refseq_mrna = Column(String(24), nullable=True)
+    refseq_mrna_pred = Column(String(24), nullable=True)
+    refseq_ncrna = Column(String(24), nullable=True)
     refseq_mane_select = Column(String(24), nullable=True, index=True)
     refseq_mane_plus_clinical = Column(String(24), nullable=True, index=True)
-    ensembl_gene_id = Column(String(24), nullable=False, index=True)
+    ensembl_gene_id = Column(String(24), nullable=False)
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
+    __table_args__ = (Index("txidx_ens_gene_build", "ensembl_gene_id", "build"),)
 
 
 class Exon(Base):
@@ -88,7 +95,8 @@ class Exon(Base):
     start = Column(Integer, nullable=False)
     stop = Column(Integer, nullable=False)
     ensembl_id = Column(String(24), nullable=False, index=False)
-    ensembl_gene_id = Column(String(24), nullable=False, index=True)
+    ensembl_gene_id = Column(String(24), nullable=False)
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
+    __table_args__ = (Index("exonidx_ens_gene_build", "ensembl_gene_id", "build"),)

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -89,7 +89,7 @@ class Transcript(Base):
         primaryjoin="Transcript.ensembl_gene_id==Gene.ensembl_id",
     )
 
-    __table_args__ = (Index("txidx_ensembl_gene_build", "ensembl_gene_id", "build"),)
+    __table_args__ = (Index("transcript_idx_ensembl_gene_build", "ensembl_gene_id", "build"),)
 
 
 class Exon(Base):

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -59,17 +59,9 @@ class Gene(Base):
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
     __table_args__ = (
-        Index("geneidx_build_ensembl_id", "build", "ensembl_id"),
-        Index(
-            "geneidx_build_hgnc_id",
-            "build",
-            "hgnc_id",
-        ),
-        Index(
-            "geneidx_build_hgnc_symbol",
-            "build",
-            "hgnc_symbol",
-        ),
+        Index("geneidx_ensembl_id_build", "ensembl_id", "build"),
+        Index("geneidx_hgnc_id_build", "hgnc_id", "build"),
+        Index("geneidx_hgnc_symbol_build", "hgnc_symbol", "build"),
     )
 
 
@@ -91,7 +83,7 @@ class Transcript(Base):
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
-    __table_args__ = (Index("txidx_build_ensembl_gene", "build", "ensembl_gene_id"),)
+    __table_args__ = (Index("txidx_ensembl_gene_build", "ensembl_gene_id", "build"),)
 
 
 class Exon(Base):
@@ -107,4 +99,4 @@ class Exon(Base):
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
-    __table_args__ = (Index("exonidx_build_ensembl_gene", "build", "ensembl_gene_id"),)
+    __table_args__ = (Index("exonidx_ensembl_gene:_build", "ensembl_gene_id", "build"),)

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -59,7 +59,7 @@ class Gene(Base):
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
     __table_args__ = (
-        Index("geneidx_build_ensemble_id", "build", "ensembl_id"),
+        Index("geneidx_build_ensembl_id", "build", "ensembl_id"),
         Index(
             "geneidx_build_hgnc_id",
             "build",
@@ -91,7 +91,7 @@ class Transcript(Base):
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
-    __table_args__ = (Index("txidx_build_ensemble_gene", "build", "ensembl_gene_id"),)
+    __table_args__ = (Index("txidx_build_ensembl_gene", "build", "ensembl_gene_id"),)
 
 
 class Exon(Base):
@@ -107,4 +107,4 @@ class Exon(Base):
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
-    __table_args__ = (Index("exonidx_build_ensemble_gene", "build", "ensembl_gene_id"),)
+    __table_args__ = (Index("exonidx_build_ensembl_gene", "build", "ensembl_gene_id"),)

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -89,7 +89,9 @@ class Transcript(Base):
         primaryjoin="Transcript.ensembl_gene_id==Gene.ensembl_id",
     )
 
-    __table_args__ = (Index("transcript_idx_ensembl_gene_build", "ensembl_gene_id", "build"),)
+    __table_args__ = (
+        Index("transcript_idx_ensembl_gene_build", "ensembl_gene_id", "build"),
+    )
 
 
 class Exon(Base):
@@ -111,4 +113,6 @@ class Exon(Base):
         primaryjoin="Exon.ensembl_gene_id==Gene.ensembl_id",
     )
 
-    __table_args__ = (Index("exon_idx_ensembl_gene:_build", "ensembl_gene_id", "build"),)
+    __table_args__ = (
+        Index("exon_idx_ensembl_gene:_build", "ensembl_gene_id", "build"),
+    )

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -111,4 +111,4 @@ class Exon(Base):
         primaryjoin="Exon.ensembl_gene_id==Gene.ensembl_id",
     )
 
-    __table_args__ = (Index("exonidx_ensembl_gene:_build", "ensembl_gene_id", "build"),)
+    __table_args__ = (Index("exon_idx_ensembl_gene:_build", "ensembl_gene_id", "build"),)

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -59,9 +59,9 @@ class Gene(Base):
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
     __table_args__ = (
-        Index("geneidx_ensembl_id_build", "ensembl_id", "build"),
-        Index("geneidx_hgnc_id_build", "hgnc_id", "build"),
-        Index("geneidx_hgnc_symbol_build", "hgnc_symbol", "build"),
+        Index("gene_idx_ensembl_id_build", "ensembl_id", "build"),
+        Index("gene_idx_hgnc_id_build", "hgnc_id", "build"),
+        Index("gene_idx_hgnc_symbol_build", "hgnc_symbol", "build"),
     )
 
 

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -59,9 +59,17 @@ class Gene(Base):
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
     __table_args__ = (
-        Index("geneidx_ens_id_build", "ensembl_id", "build"),
-        Index("geneidx_hgnc_id_build", "hgnc_id", "build"),
-        Index("geneidx_hgnc_symbol_build", "hgnc_symbol", "build"),
+        Index("geneidx_build_ens_id", "build", "ensembl_id"),
+        Index(
+            "geneidx_build_hgnc_id",
+            "build",
+            "hgnc_id",
+        ),
+        Index(
+            "geneidx_build_hgnc_symbol",
+            "build",
+            "hgnc_symbol",
+        ),
     )
 
 
@@ -83,7 +91,7 @@ class Transcript(Base):
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
-    __table_args__ = (Index("txidx_ens_gene_build", "ensembl_gene_id", "build"),)
+    __table_args__ = (Index("txidx_build_ens_gene", "build", "ensembl_gene_id"),)
 
 
 class Exon(Base):
@@ -99,4 +107,4 @@ class Exon(Base):
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
-    __table_args__ = (Index("exonidx_ens_gene_build", "ensembl_gene_id", "build"),)
+    __table_args__ = (Index("exonidx_build_ensemble_gene", "build", "ensembl_gene_id"),)

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -79,10 +79,16 @@ class Transcript(Base):
     refseq_ncrna = Column(String(24), nullable=True)
     refseq_mane_select = Column(String(24), nullable=True, index=True)
     refseq_mane_plus_clinical = Column(String(24), nullable=True, index=True)
-    ensembl_gene_id = Column(String(24), nullable=False)
+    ensembl_gene_id = Column(String(24), ForeignKey("genes.ensembl_id"), nullable=False)
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
+
+    genes = relationship(
+        "Gene",
+        primaryjoin="Transcript.ensembl_gene_id==Gene.ensembl_id",
+    )
+
     __table_args__ = (Index("txidx_ensembl_gene_build", "ensembl_gene_id", "build"),)
 
 
@@ -95,8 +101,14 @@ class Exon(Base):
     start = Column(Integer, nullable=False)
     stop = Column(Integer, nullable=False)
     ensembl_id = Column(String(24), nullable=False, index=False)
-    ensembl_gene_id = Column(String(24), nullable=False)
+    ensembl_gene_id = Column(String(24), ForeignKey("genes.ensembl_id"), nullable=False)
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
+
+    genes = relationship(
+        "Gene",
+        primaryjoin="Exon.ensembl_gene_id==Gene.ensembl_id",
+    )
+
     __table_args__ = (Index("exonidx_ensembl_gene:_build", "ensembl_gene_id", "build"),)

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -59,7 +59,7 @@ class Gene(Base):
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
     __table_args__ = (
-        Index("geneidx_build_ens_id", "build", "ensembl_id"),
+        Index("geneidx_build_ensemble_id", "build", "ensembl_id"),
         Index(
             "geneidx_build_hgnc_id",
             "build",
@@ -91,7 +91,7 @@ class Transcript(Base):
     build = Column(
         Enum(Builds, values_callable=lambda x: Builds.get_enum_values()), index=True
     )
-    __table_args__ = (Index("txidx_build_ens_gene", "build", "ensembl_gene_id"),)
+    __table_args__ = (Index("txidx_build_ensemble_gene", "build", "ensembl_gene_id"),)
 
 
 class Exon(Base):

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -222,7 +222,7 @@ def test_transcripts_no_filters(
     }
     response: Response = demo_client.post(endpoints.TRANSCRIPTS, json=data)
 
-    # THEN transcript documents should be returned
+    # THEN transcript objects should be returned
     assert response.status_code == status.HTTP_200_OK
     transcripts = response.json()
     assert Transcript(**transcripts[0])

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -245,7 +245,7 @@ def test_transcripts_by_ensembl_ids(
     }
     response: Response = demo_client.post(endpoints.TRANSCRIPTS, json=data)
 
-    # THEN transcript documents should be returned
+    # THEN transcript objects should be returned
     assert response.status_code == status.HTTP_200_OK
     transcripts = response.json()
     assert Transcript(**transcripts[0])
@@ -268,7 +268,7 @@ def test_transcripts_by_ensembl_gene_ids(
     }
     response: Response = demo_client.post(endpoints.TRANSCRIPTS, json=data)
 
-    # THEN transcript documents should be returned
+    # THEN transcript objects should be returned
     assert response.status_code == status.HTTP_200_OK
     transcripts = response.json()
     assert Transcript(**transcripts[0])
@@ -291,7 +291,7 @@ def test_transcripts_by_hgnc_ids(
     }
     response: Response = demo_client.post(endpoints.TRANSCRIPTS, json=data)
 
-    # THEN transcript documents should be returned
+    # THEN transcript objects should be returned
     assert response.status_code == status.HTTP_200_OK
     transcripts = response.json()
     assert Transcript(**transcripts[0])
@@ -314,7 +314,7 @@ def test_transcripts_by_hgnc_symbols(
     }
     response: Response = demo_client.post(endpoints.TRANSCRIPTS, json=data)
 
-    # THEN transcript documents should be returned
+    # THEN transcript objects should be returned
     assert response.status_code == status.HTTP_200_OK
     transcripts = response.json()
     assert Transcript(**transcripts[0])
@@ -387,7 +387,7 @@ def test_exons_no_filters(
     }
     response: Response = demo_client.post(endpoints.EXONS, json=data)
 
-    # THEN exon documents should be returned
+    # THEN exon objects should be returned
     assert response.status_code == status.HTTP_200_OK
     exons = response.json()
     assert Exon(**exons[0])
@@ -410,7 +410,7 @@ def test_exons_by_ensembl_ids(
     }
     response: Response = demo_client.post(endpoints.EXONS, json=data)
 
-    # THEN exon documents should be returned
+    # THEN exon objects should be returned
     assert response.status_code == status.HTTP_200_OK
     exons = response.json()
     assert Exon(**exons[0])
@@ -433,7 +433,7 @@ def test_exons_by_ensembl_gene_ids(
     }
     response: Response = demo_client.post(endpoints.EXONS, json=data)
 
-    # THEN exons documents should be returned
+    # THEN exons objects should be returned
     assert response.status_code == status.HTTP_200_OK
     exons = response.json()
     assert Exon(**exons[0])
@@ -456,7 +456,7 @@ def test_exons_by_hgnc_ids(
     }
     response: Response = demo_client.post(endpoints.EXONS, json=data)
 
-    # THEN exon documents should be returned
+    # THEN exon objects should be returned
     assert response.status_code == status.HTTP_200_OK
     exons = response.json()
     assert Exon(**exons[0])
@@ -479,7 +479,7 @@ def test_exons_by_hgnc_symbols(
     }
     response: Response = demo_client.post(endpoints.EXONS, json=data)
 
-    # THEN transcript documents should be returned
+    # THEN exon objects should be returned
     assert response.status_code == status.HTTP_200_OK
     exons = response.json()
     assert Exon(**exons[0])

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -181,14 +181,6 @@ def test_load_transcripts(
         response.json()["detail"]
         == f"{nr_transcripts} transcripts loaded into the database"
     )
-    # WHEN sending a request to the "transcripts" endpoint
-    response: Response = client.post(f"{endpoints.TRANSCRIPTS}", json={"build": build})
-    assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    # THEN the expected number of transcripts should be returned
-    assert len(result) == nr_transcripts
-    # AND the transcript should have the right format
-    assert Transcript(**result[0])
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
@@ -215,6 +207,28 @@ def test_transcripts_multiple_filters(
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_transcripts_no_filters(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the endpoint that returns database transcripts without any filter."""
+
+    # GIVEN a populated demo database
+    # WHEN sending a request to the "transcripts" endpoint
+    data = {
+        "build": build,
+    }
+    response: Response = demo_client.post(endpoints.TRANSCRIPTS, json=data)
+
+    # THEN transcript documents should be returned
+    assert response.status_code == status.HTTP_200_OK
+    transcripts = response.json()
+    assert Transcript(**transcripts[0])
+
+
+@pytest.mark.parametrize("build", Builds.get_enum_values())
 def test_transcripts_by_ensembl_ids(
     build: str,
     demo_client: TestClient,
@@ -233,8 +247,8 @@ def test_transcripts_by_ensembl_ids(
 
     # THEN transcript documents should be returned
     assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    assert Transcript(**result[0])
+    transcripts = response.json()
+    assert Transcript(**transcripts[0])
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
@@ -256,8 +270,8 @@ def test_transcripts_by_ensembl_gene_ids(
 
     # THEN transcript documents should be returned
     assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    assert Transcript(**result[0])
+    transcripts = response.json()
+    assert Transcript(**transcripts[0])
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
@@ -279,8 +293,8 @@ def test_transcripts_by_hgnc_ids(
 
     # THEN transcript documents should be returned
     assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    assert Transcript(**result[0])
+    transcripts = response.json()
+    assert Transcript(**transcripts[0])
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
@@ -302,8 +316,8 @@ def test_transcripts_by_hgnc_symbols(
 
     # THEN transcript documents should be returned
     assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    assert Transcript(**result[0])
+    transcripts = response.json()
+    assert Transcript(**transcripts[0])
 
 
 @pytest.mark.parametrize("build, path", BUILD_EXONS_RESOURCE)
@@ -334,15 +348,6 @@ def test_load_exons(
     # THEN all exons should be loaded
     assert response.json()["detail"] == f"{nr_exons} exons loaded into the database"
 
-    # WHEN sending a request to the "exons" endpoint
-    response: Response = client.post(endpoints.EXONS, json={"build": build})
-    assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    # THEN the expected number of exons should be returned
-    assert len(result) == nr_exons
-    # AND the exons should have the right format
-    assert Exon(**result[0])
-
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
 def test_exons_multiple_filters(
@@ -353,7 +358,7 @@ def test_exons_multiple_filters(
 ):
     """Test filtering exon intervals providing more than one filter."""
 
-    # GIVEN a query to "exons" enspoint with genome build and more than one ID:
+    # GIVEN a query to "exons" endpoint with genome build and more than one ID:
     data = {
         "build": build,
         "ensembl_ids": genomic_ids_per_build[build]["ensembl_exons_ids"],
@@ -365,6 +370,27 @@ def test_exons_multiple_filters(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
     result = response.json()
     assert result["detail"] == MULTIPLE_PARAMS_NOT_SUPPORTED_MSG
+
+
+@pytest.mark.parametrize("build", Builds.get_enum_values())
+def test_exons_no_filters(
+    build: str,
+    demo_client: TestClient,
+    endpoints: Type,
+    genomic_ids_per_build: Dict[str, List],
+):
+    """Test the endpoint that returns exons without any filter."""
+    # GIVEN a populated demo database
+    # WHEN sending a request to the "exons" endpoint without any filter
+    data = {
+        "build": build,
+    }
+    response: Response = demo_client.post(endpoints.EXONS, json=data)
+
+    # THEN exon documents should be returned
+    assert response.status_code == status.HTTP_200_OK
+    exons = response.json()
+    assert Exon(**exons[0])
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
@@ -386,8 +412,8 @@ def test_exons_by_ensembl_ids(
 
     # THEN exon documents should be returned
     assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    assert Exon(**result[0])
+    exons = response.json()
+    assert Exon(**exons[0])
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
@@ -409,8 +435,8 @@ def test_exons_by_ensembl_gene_ids(
 
     # THEN exons documents should be returned
     assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    assert Exon(**result[0])
+    exons = response.json()
+    assert Exon(**exons[0])
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
@@ -432,8 +458,8 @@ def test_exons_by_hgnc_ids(
 
     # THEN exon documents should be returned
     assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    assert Exon(**result[0])
+    exons = response.json()
+    assert Exon(**exons[0])
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())
@@ -455,5 +481,5 @@ def test_exons_by_hgnc_symbols(
 
     # THEN transcript documents should be returned
     assert response.status_code == status.HTTP_200_OK
-    result = response.json()
-    assert Exon(**result[0])
+    exons = response.json()
+    assert Exon(**exons[0])


### PR DESCRIPTION
### This PR adds | fixes:
-  Fix #103 

### How to test:
- Launch a sample coverage query on transcripts and exons

### Expected outcome:
- [x] The query should be quick(er)

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
