### PR TITLE
Fix coverage completeness algorithm to be >= a threshold, not only >

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - Format of Build field in genes, transcripts and exons tables
 - Increased size of allowed HGNC symbols in the MySQL gene model
 - Remove old exons and transcripts data when updating genes
+- Algorithm to calculate coverage completeness
 
 ### Changed
 

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -78,7 +78,7 @@ def get_intervals_completeness(
     for threshold in completeness_threholds:
         nr_complete_bases: int64 = 0
         for per_base_depth_region in per_base_depth:
-            nr_complete_bases += (per_base_depth_region > threshold).sum()
+            nr_complete_bases += (per_base_depth_region >= threshold).sum()
 
         completeness_values.append(
             (


### PR DESCRIPTION
### This PR adds | fixes:
- Calculating the coverage completeness must be >= a given threshold, not only > than threshold

### How to test:
-

### Expected outcome:
- [ ] Coverage completeness values should be higher than those returned by main branch

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
