### PR TITLE
Modify coverage endpoints (genes/transcripts/exons) to accept a sample list or a case name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,11 @@
 - Filter genes, transcripts and exons by Ensemble id, HGNC id, HGNC symbol
 - Demo genes, transcripts and exons loaded on demo instance startup
 - Return coverage over a list of genes for a sample in the database
-- Return coverage and coverage completeness (custom thresholds) over a list of genes for database samples
-- Return transcripts coverage and coverage completeness (custom thresholds) over a list of genes for database samples
-- Return exons coverage and coverage completeness (custom thresholds) over a list of genes for database samples
+- Return coverage and coverage completeness (custom thresholds) over a list of genes for a case or a list of samples
+- Return transcripts coverage and coverage completeness (custom thresholds) over a list of genes for a case or a list of
+  samples
+- Return exons coverage and coverage completeness (custom thresholds) over a list of genes for a case or a list of
+  samples
 
 ### Fixed
 

--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -12,7 +12,6 @@ MULTIPLE_PARAMS_NOT_SUPPORTED_MSG = "Interval query contains too many filter par
 MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG = (
     "Please provide either Ensembl gene IDs, HGNC gene IDS or HGNC gene symbols."
 )
-AMBIGUOUS_SAMPLES_INPUT = "Please provide either a name of a case or a list of samples."
 
 ENSEMBL_RESOURCE_CLIENT: Dict[str, Callable] = {
     "genes": fetch_ensembl_genes,

--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -12,6 +12,7 @@ MULTIPLE_PARAMS_NOT_SUPPORTED_MSG = "Interval query contains too many filter par
 MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG = (
     "Please provide either Ensembl gene IDs, HGNC gene IDS or HGNC gene symbols."
 )
+AMBIGUOUS_SAMPLES_INPUT = "Please provide either a name of a case or a list of samples."
 
 ENSEMBL_RESOURCE_CLIENT: Dict[str, Callable] = {
     "genes": fetch_ensembl_genes,

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -11,7 +11,7 @@ from chanjo2.constants import (
     SAMPLE_NOT_FOUND,
 )
 from chanjo2.crud.intervals import get_genes
-from chanjo2.crud.samples import get_samples_by_name, get_case_samples
+from chanjo2.crud.samples import get_samples_by_name
 from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_bed import parse_bed
 from chanjo2.meta.handle_d4 import (
@@ -93,18 +93,14 @@ def d4_intervals_coverage(coverage_file_path: str, bed_file: bytes = File(...)):
 
 
 def get_samples_coverage_file(
-    db: Session, samples: Optional[List[str]], case: Optional[str]
+    db: Session, samples: List[str]
 ) -> Union[List[Tuple[str, D4File]], JSONResponse]:
     """Return a list of sample names with relative D4 coverage files."""
 
     samples_d4_files: List[Tuple[str, D4File]] = []
-    sql_samples: List[SQLSample] = (
-        get_samples_by_name(db=db, sample_names=samples)
-        if samples
-        else get_case_samples(db=db, case_name=case)
-    )
+    sql_samples: List[SQLSample] = get_samples_by_name(db=db, sample_names=samples)
 
-    if samples and len(sql_samples) < len(samples) or not sql_samples:
+    if len(sql_samples) < len(samples):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=SAMPLE_NOT_FOUND,
@@ -131,7 +127,7 @@ async def samples_genes_coverage(
     """Returns coverage over a list of genes (entire gene) for a given sample in the database."""
 
     samples_d4_files: Tuple[str, D4File] = get_samples_coverage_file(
-        db=db, samples=query.samples, case=query.case
+        db=db, samples=query.samples
     )
 
     genes: List[SQLGene] = get_genes(
@@ -159,7 +155,7 @@ async def samples_transcripts_coverage(
     """Returns coverage over a list of genes (transcripts intervals only) for a given sample in the database."""
 
     samples_d4_files: Tuple[str, D4File] = get_samples_coverage_file(
-        db=db, samples=query.samples, case=query.case
+        db=db, samples=query.samples
     )
 
     genes: List[SQLGene] = get_genes(
@@ -187,7 +183,7 @@ async def samples_exons_coverage(
     """Returns coverage over a list of genes (exons intervals only) for a given sample in the database."""
 
     samples_d4_files: Tuple[str, D4File] = get_samples_coverage_file(
-        db=db, samples=query.samples, case=query.case
+        db=db, samples=query.samples
     )
 
     genes: List[SQLGene] = get_genes(

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -11,7 +11,7 @@ from chanjo2.constants import (
     SAMPLE_NOT_FOUND,
 )
 from chanjo2.crud.intervals import get_genes
-from chanjo2.crud.samples import get_samples_by_name
+from chanjo2.crud.samples import get_samples_by_name, get_case_samples
 from chanjo2.dbutil import get_session
 from chanjo2.meta.handle_bed import parse_bed
 from chanjo2.meta.handle_d4 import (

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -93,14 +93,18 @@ def d4_intervals_coverage(coverage_file_path: str, bed_file: bytes = File(...)):
 
 
 def get_samples_coverage_file(
-    db: Session, samples: List[str]
+    db: Session, samples: Optional[List[str]], case: Optional[str]
 ) -> Union[List[Tuple[str, D4File]], JSONResponse]:
     """Return a list of sample names with relative D4 coverage files."""
 
     samples_d4_files: List[Tuple[str, D4File]] = []
-    sql_samples: List[SQLSample] = get_samples_by_name(db=db, sample_names=samples)
+    sql_samples: List[SQLSample] = (
+        get_samples_by_name(db=db, sample_names=samples)
+        if samples
+        else get_case_samples(db=db, case_name=case)
+    )
 
-    if len(sql_samples) < len(samples):
+    if samples and len(sql_samples) < len(samples) or not sql_samples:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=SAMPLE_NOT_FOUND,
@@ -127,7 +131,7 @@ async def samples_genes_coverage(
     """Returns coverage over a list of genes (entire gene) for a given sample in the database."""
 
     samples_d4_files: Tuple[str, D4File] = get_samples_coverage_file(
-        db=db, samples=query.samples
+        db=db, samples=query.samples, case=query.case
     )
 
     genes: List[SQLGene] = get_genes(
@@ -155,7 +159,7 @@ async def samples_transcripts_coverage(
     """Returns coverage over a list of genes (transcripts intervals only) for a given sample in the database."""
 
     samples_d4_files: Tuple[str, D4File] = get_samples_coverage_file(
-        db=db, samples=query.samples
+        db=db, samples=query.samples, case=query.case
     )
 
     genes: List[SQLGene] = get_genes(
@@ -183,7 +187,7 @@ async def samples_exons_coverage(
     """Returns coverage over a list of genes (exons intervals only) for a given sample in the database."""
 
     samples_d4_files: Tuple[str, D4File] = get_samples_coverage_file(
-        db=db, samples=query.samples
+        db=db, samples=query.samples, case=query.case
     )
 
     genes: List[SQLGene] = get_genes(

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, validator, Field, root_validator
 from chanjo2.constants import (
     WRONG_COVERAGE_FILE_MSG,
     MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG,
+    AMBIGUOUS_SAMPLES_INPUT,
 )
 
 

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel, validator, Field, root_validator
 from chanjo2.constants import (
     WRONG_COVERAGE_FILE_MSG,
     MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG,
-    AMBIGUOUS_SAMPLES_INPUT,
 )
 
 
@@ -165,13 +164,4 @@ class SampleGeneIntervalQuery(BaseModel):
                 nr_provided_gene_lists += 1
         if nr_provided_gene_lists != 1:
             raise ValueError(MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG)
-        return values
-
-    @root_validator(pre=True)
-    def check_sample_input(cls, values):
-        case = values.get("case", "") != ""
-        samples = bool(values.get("samples", []))
-        if case == samples:
-            raise ValueError(AMBIGUOUS_SAMPLES_INPUT)
-
         return values

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -165,3 +165,12 @@ class SampleGeneIntervalQuery(BaseModel):
         if nr_provided_gene_lists != 1:
             raise ValueError(MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG)
         return values
+
+    @root_validator(pre=True)
+    def check_sample_input(cls, values):
+        case = values.get("case", "") != ""
+        samples = bool(values.get("samples", []))
+        if case == samples:
+            raise ValueError(AMBIGUOUS_SAMPLES_INPUT)
+
+        return values


### PR DESCRIPTION
### This PR adds | fixes:
- Allow user to specify a case name or a list of samples (not both)

### How to test:
- Check coverage for the cases of a sample on genes, transcripts and exons

### Expected outcome:
- [x] The coverage data should be returned for all samples of the specified case

### Review:
- [ ] Code approved by
- [x] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
