### PR TITLE
Replace deprecated pkg_resources lib with importlib_resources lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,4 @@
 - Validate sample coverage queries so that only one gene list format can be provided
 - Speed up queries by optimizing Genes, Transcripts and Exons tables and indexes
 - Custom algorithm to speed up coverage completeness thresholds calculation
+- Replaced deprecated `pkg_resources` lib with `importlib_resources` lib

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -1,9 +1,10 @@
-import pkg_resources
+from importlib_resources import files
 
-# Files
-gene_panel_file = "demo/109_green.bed"
-d4_demo_file = "demo/panelapp_109_example.d4"
+BASE_PATH = "chanjo2.demo"
+
+gene_panel_file = "109_green.bed"
+d4_demo_file = "panelapp_109_example.d4"
 
 # Paths
-gene_panel_path = pkg_resources.resource_filename("chanjo2", gene_panel_file)
-d4_demo_path = pkg_resources.resource_filename("chanjo2", d4_demo_file)
+gene_panel_path = str(files(BASE_PATH).joinpath(gene_panel_file))
+d4_demo_path = str(files(BASE_PATH).joinpath(d4_demo_file))

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -1,9 +1,9 @@
 from importlib_resources import files
 
-BASE_PATH = "chanjo2.demo"
+BASE_PATH: str = "chanjo2.demo"
 
-gene_panel_file = "109_green.bed"
-d4_demo_file = "panelapp_109_example.d4"
+GENE_PANEL_FILE: str = "109_green.bed"
+D4_DEMO_FILE: str = "panelapp_109_example.d4"
 
 # Paths
 gene_panel_path = str(files(BASE_PATH).joinpath(gene_panel_file))

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -6,5 +6,5 @@ GENE_PANEL_FILE: str = "109_green.bed"
 D4_DEMO_FILE: str = "panelapp_109_example.d4"
 
 # Paths
-gene_panel_path = str(files(BASE_PATH).joinpath(gene_panel_file))
-d4_demo_path = str(files(BASE_PATH).joinpath(d4_demo_file))
+gene_panel_path = str(files(BASE_PATH).joinpath(GENE_PANEL_FILE))
+d4_demo_path = str(files(BASE_PATH).joinpath(D4_DEMO_FILE))

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -12,7 +12,7 @@ from chanjo2.constants import (
     MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG,
     AMBIGUOUS_SAMPLES_INPUT,
 )
-from chanjo2.demo import gene_panel_file, gene_panel_path
+from chanjo2.demo import gene_panel_path, GENE_PANEL_FILE
 from chanjo2.models.pydantic_models import (
     CoverageInterval,
     Builds,
@@ -109,7 +109,7 @@ def test_d4_intervals_coverage_d4_not_found(
 
     # GIVEN a valid BED file containing genomic intervals
     files = [
-        ("bed_file", (gene_panel_file, open(gene_panel_path, "rb"))),
+        ("bed_file", (GENE_PANEL_FILE, open(gene_panel_path, "rb"))),
     ]
 
     # WHEN using a query for genomic intervals with a D4 not present on disk
@@ -164,7 +164,7 @@ def test_d4_intervals_coverage(
 
     # GIVEN a valid BED file containing genomic intervals
     files = [
-        ("bed_file", (gene_panel_file, open(gene_panel_path, "rb"))),
+        ("bed_file", (GENE_PANEL_FILE, open(gene_panel_path, "rb"))),
     ]
 
     # THEN a request to the endpoint should return HTTP 200


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #118 

### How to test:
- Run GitHub actions

### Expected outcome:
- [x] Tests should all pass

### Review:
- [ ] Code approved by
- [x] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
