### PR TITLE
Share samples across cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,4 @@
 - Replaced deprecated `pkg_resources` lib with `importlib_resources` lib
 - Modified Python version in Dockerfile from 3.8 to 3.11
 - Introduced a "track_name" key in sample database objects to be used in multitrack D4 files analysis
+- One sample can belong to more than one case

--- a/src/chanjo2/crud/cases.py
+++ b/src/chanjo2/crud/cases.py
@@ -1,6 +1,8 @@
 import logging
 from typing import List
 
+from sqlalchemy import delete
+from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.orm import Session, query
 
 from chanjo2.models.pydantic_models import Case, CaseCreate
@@ -16,7 +18,6 @@ def filter_cases_by_name(cases: query.Query, case_name: str) -> SQLCase:
 
 def get_cases(db: Session, limit: int = 100) -> List[SQLCase]:
     """Return all cases."""
-    LOG.warning(db.query(SQLCase).limit(limit).all())
     return db.query(SQLCase).limit(limit).all()
 
 
@@ -43,7 +44,6 @@ def count_cases(db: Session) -> int:
 
 def delete_case(db: Session, case_name: str) -> int:
     """Delete a case with the supplied name."""
-    nr_cases_before_deletion = count_cases(db=db)
-    db.delete(get_case(db=db, case_name=case_name))
-    db.commit()
-    return nr_cases_before_deletion - count_cases(db=db)
+    delete_stmt: Delete = delete(SQLCase).where(SQLCase.name == case_name)
+    result: CursorResult = db.execute(delete_stmt)
+    return result.rowcount

--- a/src/chanjo2/crud/cases.py
+++ b/src/chanjo2/crud/cases.py
@@ -1,9 +1,12 @@
+import logging
 from typing import List
 
 from sqlalchemy.orm import Session, query
 
 from chanjo2.models.pydantic_models import Case, CaseCreate
 from chanjo2.models.sql_models import Case as SQLCase
+
+LOG = logging.getLogger("uvicorn.access")
 
 
 def filter_cases_by_name(cases: query.Query, case_name: str) -> SQLCase:
@@ -13,12 +16,12 @@ def filter_cases_by_name(cases: query.Query, case_name: str) -> SQLCase:
 
 def get_cases(db: Session, limit: int = 100) -> List[SQLCase]:
     """Return all cases."""
+    LOG.warning(db.query(SQLCase).limit(limit).all())
     return db.query(SQLCase).limit(limit).all()
 
 
 def get_case(db: Session, case_name: str) -> Case:
     """Return a specific case by providing its name."""
-
     pipeline = {"filter_cases": filter_cases_by_name}
     query = db.query(SQLCase)
 

--- a/src/chanjo2/crud/cases.py
+++ b/src/chanjo2/crud/cases.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List, Union
 
 from sqlalchemy import delete
@@ -9,8 +8,6 @@ from chanjo2.models.pydantic_models import Case, CaseCreate
 from chanjo2.models.sql_models import Case as SQLCase
 from chanjo2.models.sql_models import CaseSample
 from chanjo2.models.sql_models import Sample as SQLSample
-
-LOG = logging.getLogger("uvicorn.access")
 
 
 def filter_cases_by_name(cases: query.Query, case_name: str) -> SQLCase:
@@ -58,7 +55,6 @@ def delete_case(db: Session, case_name: str) -> int:
 
     # Delete samples linked uniquely to this case
     for db_sample in db_case.samples:
-        LOG.warning(type(db_sample))
         nr_linked_cases: int = (
             db.query(CaseSample).where(CaseSample.c.sample_id == db_sample.id).count()
         )

--- a/src/chanjo2/crud/cases.py
+++ b/src/chanjo2/crud/cases.py
@@ -42,7 +42,7 @@ def count_cases(db: Session) -> int:
 
 
 def delete_entry(db: Session, table: Union[SQLCase, SQLSample], id: int) -> int:
-    """Deletes a Sample or Case entry from the database"""
+    """Deletes a Sample or Case entry from the database."""
     delete_stmt: Delete = delete(table).where(table.id == id)
     result: CursorResult = db.execute(delete_stmt)
     db.commit()

--- a/src/chanjo2/crud/cases.py
+++ b/src/chanjo2/crud/cases.py
@@ -68,12 +68,11 @@ def delete_case(db: Session, case_name: str) -> int:
         nr_linked_cases: int = (
             db.query(CaseSample).where(CaseSample.c.sample_id == db_sample.id).count()
         )
+        # Remove case-sample association in CaseSample table:
+        delete_case_sample_ref(db=db, case_id=db_case.id, sample_id=db_sample.id)
 
         if nr_linked_cases == 1:  # Sample linked only to this case
             delete_entry(db=db, table=SQLSample, id=db_sample.id)
-
-        # Remove case-sample association in CaseSample table:
-        delete_case_sample_ref(db=db, case_id=db_case.id, sample_id=db_sample.id)
 
     # Delete case
     return delete_entry(db=db, table=SQLCase, id=db_case.id)

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List, Optional
 
 from sqlalchemy import delete
@@ -10,8 +9,6 @@ from chanjo2.models.pydantic_models import SampleCreate
 from chanjo2.models.sql_models import Case as SQLCase
 from chanjo2.models.sql_models import CaseSample
 from chanjo2.models.sql_models import Sample as SQLSample
-
-LOG = logging.getLogger("uvicorn.access")
 
 
 def _filter_samples_by_name(
@@ -38,7 +35,6 @@ def get_case_samples(db: Session, case_name: str) -> List[SQLSample]:
 
     db_case: SQLCase = db.query(SQLCase).where(SQLCase.name == case_name).first()
     if db_case:
-        LOG.warning(db_case)
         return db_case.samples
     return []
 

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -22,14 +22,6 @@ def _filter_samples_by_name(
     return samples.filter(SQLSample.name.in_(sample_names))
 
 
-def _filter_samples_by_case(
-    samples: query.Query,
-    case_name: str,
-) -> List[SQLSample]:
-    """Filter samples by case name."""
-    return samples.filter(SQLCase.name == case_name).all()
-
-
 def get_samples(db: Session, limit: int = 100) -> List[SQLSample]:
     """Return all samples."""
     return db.query(SQLSample).limit(limit).all()
@@ -44,10 +36,11 @@ def get_samples_by_name(db: Session, sample_names: List[str]) -> List[SQLSample]
 def get_case_samples(db: Session, case_name: str) -> List[SQLSample]:
     """Return all samples for a given case name."""
 
-    pipeline = {"filter_samples_by_case": _filter_samples_by_case}
-    query = db.query(SQLSample).join(SQLCase)
-
-    return pipeline["filter_samples_by_case"](query, case_name)
+    db_case: SQLCase = db.query(SQLCase).where(SQLCase.name == case_name).first()
+    if db_case:
+        LOG.warning(db_case)
+        return db_case.samples
+    return []
 
 
 def get_sample(db: Session, sample_name: str) -> SQLSample:

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -68,9 +68,7 @@ def create_sample_in_case(db: Session, sample: SampleCreate) -> Optional[SQLSamp
     # Insert new sample
     db_sample = SQLSample(
         name=sample.name,
-        display_name=sample.display_name,
         track_name=sample.track_name,
-        case_id=case_obj.id,
         coverage_file_path=sample.coverage_file_path,
     )
     db.add(db_sample)

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -15,16 +15,16 @@ LOG = logging.getLogger("uvicorn.access")
 
 
 def _filter_samples_by_name(
-        samples: query.Query,
-        sample_names: List[str],
+    samples: query.Query,
+    sample_names: List[str],
 ) -> query.Query:
     """Filter samples by sample name."""
     return samples.filter(SQLSample.name.in_(sample_names))
 
 
 def _filter_samples_by_case(
-        samples: query.Query,
-        case_name: str,
+    samples: query.Query,
+    case_name: str,
 ) -> List[SQLSample]:
     """Filter samples by case name."""
     return samples.filter(SQLCase.name == case_name).all()

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -15,16 +15,16 @@ LOG = logging.getLogger("uvicorn.access")
 
 
 def _filter_samples_by_name(
-    samples: query.Query,
-    sample_names: List[str],
+        samples: query.Query,
+        sample_names: List[str],
 ) -> query.Query:
     """Filter samples by sample name."""
     return samples.filter(SQLSample.name.in_(sample_names))
 
 
 def _filter_samples_by_case(
-    samples: query.Query,
-    case_name: str,
+        samples: query.Query,
+        case_name: str,
 ) -> List[SQLSample]:
     """Filter samples by case name."""
     return samples.filter(SQLCase.name == case_name).all()
@@ -72,6 +72,7 @@ def create_sample_in_case(db: Session, sample: SampleCreate) -> Optional[SQLSamp
     # Insert new sample
     db_sample = SQLSample(
         name=sample.name,
+        display_name=sample.display_name,
         track_name=sample.track_name,
         coverage_file_path=sample.coverage_file_path,
     )

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -31,7 +31,7 @@ def get_samples_by_name(db: Session, sample_names: List[str]) -> List[SQLSample]
     return _filter_samples_by_name(samples=query, sample_names=sample_names).all()
 
 
-def get_case_samples(db: Session, case_name: str) -> List[SQLSample]:
+def get_case_samples(db: Session, case_name: str) -> List:
     """Return all samples for a given case name."""
 
     db_case: SQLCase = db.query(SQLCase).where(SQLCase.name == case_name).first()

--- a/src/chanjo2/endpoints/samples.py
+++ b/src/chanjo2/endpoints/samples.py
@@ -1,4 +1,3 @@
-import logging
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -13,8 +12,6 @@ from chanjo2.crud.samples import (
 )
 from chanjo2.dbutil import get_session
 from chanjo2.models.pydantic_models import Sample, SampleCreate
-
-LOG = logging.getLogger("uvicorn.access")
 
 router = APIRouter()
 

--- a/src/chanjo2/endpoints/samples.py
+++ b/src/chanjo2/endpoints/samples.py
@@ -22,13 +22,12 @@ def create_sample_for_case(
     db: Session = Depends(get_session),
 ):
     """Add a sample to a case in the database."""
-    db_sample = create_sample_in_case(db=db, sample=sample)
-    if db_sample is None:
+    result: Union[SQLSample, str] = create_sample_in_case(db=db, sample=sample)
+    if isinstance(result, str):
         raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Could not find a case with name: {sample.case_name}",
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=result
         )
-    return db_sample
+    return result
 
 
 @router.get("/samples/", response_model=List[Sample])

--- a/src/chanjo2/endpoints/samples.py
+++ b/src/chanjo2/endpoints/samples.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -12,6 +13,8 @@ from chanjo2.crud.samples import (
 )
 from chanjo2.dbutil import get_session
 from chanjo2.models.pydantic_models import Sample, SampleCreate
+
+LOG = logging.getLogger("uvicorn.access")
 
 router = APIRouter()
 

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -58,7 +58,6 @@ class SampleCreate(SampleBase):
 
 
 class Sample(SampleBase):
-    case_id: int
     created_at: datetime
     id: int
 
@@ -68,7 +67,7 @@ class Sample(SampleBase):
 
 class Case(CaseBase):
     id: int
-    samples: List[Sample] = []
+    samples: List = []
 
     class Config:
         orm_mode = True

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -54,7 +54,7 @@ class SampleBase(BaseModel):
 
 
 class SampleCreate(SampleBase):
-    case_name: str
+    pass
 
 
 class Sample(SampleBase):

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -54,7 +54,7 @@ class SampleBase(BaseModel):
 
 
 class SampleCreate(SampleBase):
-    pass
+    case_name: str
 
 
 class Sample(SampleBase):

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -6,14 +6,16 @@ from chanjo2.dbutil import Base
 from chanjo2.models.pydantic_models import Builds
 
 CaseSample = Table(
-    "ItemDetail",
+    "case_sample",
     Base.metadata,
-    Column("case_Id", Integer, ForeignKey("cases.id"), primary_key=True),
-    Column("sample_Id", Integer, ForeignKey("samples.id"), primary_key=True),
+    Column("case_id", Integer, ForeignKey("cases.id"), primary_key=True),
+    Column("sample_id", Integer, ForeignKey("samples.id"), primary_key=True),
 )
 
 
 class Case(Base):
+    """Used to define a case containing samples."""
+
     __tablename__ = "cases"
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(64), nullable=False, unique=True, index=True)
@@ -22,6 +24,8 @@ class Case(Base):
 
 
 class Sample(Base):
+    """Used to define a single sample belonging to a Case."""
+
     __tablename__ = "samples"
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(64), nullable=False, unique=True, index=True)

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -1,37 +1,35 @@
-from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String, Index
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String, Index, Table
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from chanjo2.dbutil import Base
 from chanjo2.models.pydantic_models import Builds
 
+CaseSample = Table(
+    "ItemDetail",
+    Base.metadata,
+    Column("case_Id", Integer, ForeignKey("cases.id"), primary_key=True),
+    Column("sample_Id", Integer, ForeignKey("samples.id"), primary_key=True),
+)
+
 
 class Case(Base):
-    """Used to define a group of samples."""
-
     __tablename__ = "cases"
-
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(64), nullable=False, unique=True, index=True)
     display_name = Column(String(64), nullable=True, unique=False)
-
-    samples = relationship("Sample", cascade="all,delete", backref="case")
+    samples = relationship("Sample", secondary=CaseSample, backref="Case")
 
 
 class Sample(Base):
-    """Used to define a single sample belonging to a Case"""
-
     __tablename__ = "samples"
-
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(64), nullable=False, unique=True, index=True)
     display_name = Column(String(64), nullable=True, unique=False)
     track_name = Column(String(64), nullable=True, unique=False)
-    case_id = Column(
-        Integer, ForeignKey("cases.id", ondelete="CASCADE"), nullable=False
-    )
     coverage_file_path = Column(String(512), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+    cases = relationship("Case", secondary=CaseSample, backref="Sample")
 
 
 class Interval(Base):

--- a/src/chanjo2/populate_demo.py
+++ b/src/chanjo2/populate_demo.py
@@ -29,6 +29,7 @@ DEMO_SAMPLE: Dict[str, str] = {
     "name": "ADM1059A2",
     "display_name": "NA12882",
     "track_name": "ADM1059A2",
+    "case_name": DEMO_CASE["name"],
     "coverage_file_path": d4_demo_path,
 }
 BUILD_GENES_RESOURCE: List[Tuple[Builds, str]] = [

--- a/src/chanjo2/populate_demo.py
+++ b/src/chanjo2/populate_demo.py
@@ -29,7 +29,6 @@ DEMO_SAMPLE: Dict[str, str] = {
     "name": "ADM1059A2",
     "display_name": "NA12882",
     "track_name": "ADM1059A2",
-    "case_name": DEMO_CASE["name"],
     "coverage_file_path": d4_demo_path,
 }
 BUILD_GENES_RESOURCE: List[Tuple[Builds, str]] = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,8 +141,8 @@ def raw_sample(raw_case) -> Dict[str, str]:
     return {
         "name": SAMPLE_NAME,
         "display_name": SAMPLE_DISPLAY_NAME,
-        "case_name": raw_case["name"],
         "track_name": SAMPLE_TRACK_NAME,
+        "case_name": raw_case["name"],
     }
 
 

--- a/tests/src/chanjo2/endpoints/test_cases.py
+++ b/tests/src/chanjo2/endpoints/test_cases.py
@@ -66,14 +66,19 @@ def test_remove_case(
 ):
     """Test the endpoint that allows removing a case using its name."""
 
-    # GIVEN a database with a case containing a sample
+    # GIVEN a database with a case containing a case
     client.post(endpoints.CASES, json=raw_case).json()
+    assert client.get(f"{endpoints.CASES}{raw_case['name']}").json()
+
+    # and a sample belonnging to this case
     raw_sample["coverage_file_path"] = str(coverage_path)
-    client.post(endpoints.SAMPLES, json=raw_sample)
+    client.post(endpoints.SAMPLES, json=raw_sample["name"])
+    assert client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()
 
-    case = client.get(f"{endpoints.CASES}{raw_case['name']}").json()
-    assert case["samples"]
-
+    # assert case == "sdk"
+    # assert case["samples"]
+    """
+    
     # GIVEN a request to delete the case
     url = f"{endpoints.CASES_DELETE}{raw_case['name']}"
     response = client.delete(url)
@@ -88,3 +93,4 @@ def test_remove_case(
 
     result = client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()
     assert result["detail"] == "Sample not found"
+    """

--- a/tests/src/chanjo2/endpoints/test_cases.py
+++ b/tests/src/chanjo2/endpoints/test_cases.py
@@ -66,19 +66,21 @@ def test_remove_case(
 ):
     """Test the endpoint that allows removing a case using its name."""
 
-    # GIVEN a database with a case containing a case
+    # GIVEN a database with a case
     client.post(endpoints.CASES, json=raw_case).json()
-    assert client.get(f"{endpoints.CASES}{raw_case['name']}").json()
+    assert (
+        client.get(f"{endpoints.CASES}{raw_case['name']}").json()["name"]
+        == raw_case["name"]
+    )
 
-    # and a sample belonnging to this case
+    # AND a sample belonging to this case
     raw_sample["coverage_file_path"] = str(coverage_path)
-    client.post(endpoints.SAMPLES, json=raw_sample["name"])
-    assert client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()
+    client.post(endpoints.SAMPLES, json=raw_sample)
+    assert (
+        client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()["name"]
+        == raw_sample["name"]
+    )
 
-    # assert case == "sdk"
-    # assert case["samples"]
-    """
-    
     # GIVEN a request to delete the case
     url = f"{endpoints.CASES_DELETE}{raw_case['name']}"
     response = client.delete(url)
@@ -93,4 +95,3 @@ def test_remove_case(
 
     result = client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()
     assert result["detail"] == "Sample not found"
-    """


### PR DESCRIPTION
### This PR adds | fixes:
- Modify database so that samples can belong to various cases (fix #122 )

### How to test:
- Using the test database or a local database, create a case that is connected to 2 samples
- Delete one fo these samples and make sure that case is till there
- Delete the other sample and verify that now the sample is gone

### Expected outcome:
- [x] The functionality should be working as described

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
