### PR TITLE
Fix Case-Sample database relationship using back_populates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Format of Build field in genes, transcripts and exons tables
 - Increased size of allowed HGNC symbols in the MySQL gene model
 - Remove old exons and transcripts data when updating genes
+- Test warnings regarding Case-Sample database relationship
 
 ### Changed
 

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -20,7 +20,7 @@ class Case(Base):
     id = Column(Integer, primary_key=True, index=True)
     name = Column(String(64), nullable=False, unique=True, index=True)
     display_name = Column(String(64), nullable=True, unique=False)
-    samples = relationship("Sample", secondary=CaseSample, backref="Case")
+    samples = relationship("Sample", secondary=CaseSample, back_populates="cases")
 
 
 class Sample(Base):
@@ -33,7 +33,7 @@ class Sample(Base):
     track_name = Column(String(64), nullable=True, unique=False)
     coverage_file_path = Column(String(512), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
-    cases = relationship("Case", secondary=CaseSample, backref="Sample")
+    cases = relationship("Case", secondary=CaseSample, back_populates="samples")
 
 
 class Interval(Base):


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #124 - Credit to [stackoverflow](https://stackoverflow.com/questions/66009247/sqlalchemy-warning-for-many-to-many-relation-with-association-table)

### How to test:
- Run automatic tests

### Expected outcome:
- [x] Tests should not get warnings

### Review:
- [ ] Code approved by
- [x] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
