### PR TITLE
Extend tests covering Case-Sample association

### DIFF
--- a/tests/src/chanjo2/endpoints/test_cases.py
+++ b/tests/src/chanjo2/endpoints/test_cases.py
@@ -110,8 +110,8 @@ def test_remove_case_shared_sample(
     # GIVEN a database with 2 cases
     raw_case_2: dict = copy.deepcopy(raw_case)
     CASE_2_NAME = "456"
-    raw_case2["name"] = CASE_2_NAME
-    for case in [raw_case, raw_case2]:
+    raw_case_2["name"] = CASE_2_NAME
+    for case in [raw_case, raw_case_2]:
         client.post(endpoints.CASES, json=case).json()
         assert (
             client.get(f"{endpoints.CASES}{case['name']}").json()["name"]

--- a/tests/src/chanjo2/endpoints/test_cases.py
+++ b/tests/src/chanjo2/endpoints/test_cases.py
@@ -108,7 +108,7 @@ def test_remove_case_shared_sample(
     """Test the endpoint that allows removing a case using its name when it shares a sample with other cases."""
 
     # GIVEN a database with 2 cases
-    raw_case2: dict = copy.deepcopy(raw_case)
+    raw_case_2: dict = copy.deepcopy(raw_case)
     CASE_2_NAME = "456"
     raw_case2["name"] = CASE_2_NAME
     for case in [raw_case, raw_case2]:

--- a/tests/src/chanjo2/endpoints/test_cases.py
+++ b/tests/src/chanjo2/endpoints/test_cases.py
@@ -127,10 +127,10 @@ def test_remove_case_shared_sample(
             == raw_sample["name"]
         )
 
-    # THEN removing case 1
-    url: str = f"{endpoints.CASES_DELETE}{raw_case['name']}"
+    # THEN removing case 2
+    url: str = f"{endpoints.CASES_DELETE}{CASE_2_NAME}"
     client.delete(url)
-    result = client.get(f"{endpoints.CASES}{raw_case['name']}").json()
+    result = client.get(f"{endpoints.CASES}{CASE_2_NAME}").json()
     assert result["detail"] == "Case not found"
 
     # SHOULD NOT remove shared sample

--- a/tests/src/chanjo2/endpoints/test_cases.py
+++ b/tests/src/chanjo2/endpoints/test_cases.py
@@ -105,7 +105,7 @@ def test_remove_case_shared_sample(
     coverage_path,
     endpoints: Type,
 ):
-    """Test the endpoint that allows removing a case using its name when it shares sample with other cases."""
+    """Test the endpoint that allows removing a case using its name when it shares a sample with other cases."""
 
     # GIVEN a database with 2 cases
     raw_case2: dict = copy.deepcopy(raw_case)

--- a/tests/src/chanjo2/endpoints/test_cases.py
+++ b/tests/src/chanjo2/endpoints/test_cases.py
@@ -26,8 +26,8 @@ def test_create_case(client: TestClient, raw_case: Dict[str, str], endpoints: Ty
 
 
 def test_read_cases(
-        demo_client: TestClient,
-        endpoints: Type,
+    demo_client: TestClient,
+    endpoints: Type,
 ):
     """Test the endpoint returning all cases found in the database."""
 
@@ -41,8 +41,8 @@ def test_read_cases(
 
 
 def test_read_case(
-        demo_client: TestClient,
-        endpoints: Type,
+    demo_client: TestClient,
+    endpoints: Type,
 ):
     """Test the endpoint that returns a specific case."""
 
@@ -59,27 +59,27 @@ def test_read_case(
 
 
 def test_remove_case_with_sampke(
-        client: TestClient,
-        raw_case: Dict[str, str],
-        raw_sample: Dict[str, str],
-        coverage_path,
-        endpoints: Type,
+    client: TestClient,
+    raw_case: Dict[str, str],
+    raw_sample: Dict[str, str],
+    coverage_path,
+    endpoints: Type,
 ):
     """Test the endpoint that allows removing a case with a sample uniquely associated to this case using case name."""
 
     # GIVEN a database with a case
     client.post(endpoints.CASES, json=raw_case).json()
     assert (
-            client.get(f"{endpoints.CASES}{raw_case['name']}").json()["name"]
-            == raw_case["name"]
+        client.get(f"{endpoints.CASES}{raw_case['name']}").json()["name"]
+        == raw_case["name"]
     )
 
     # AND a sample belonging to this case
     raw_sample["coverage_file_path"] = str(coverage_path)
     client.post(endpoints.SAMPLES, json=raw_sample)
     assert (
-            client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()["name"]
-            == raw_sample["name"]
+        client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()["name"]
+        == raw_sample["name"]
     )
 
     # GIVEN a request to delete the case
@@ -99,11 +99,11 @@ def test_remove_case_with_sampke(
 
 
 def test_remove_case_shared_sample(
-        client: TestClient,
-        raw_case: Dict[str, str],
-        raw_sample: Dict[str, str],
-        coverage_path,
-        endpoints: Type,
+    client: TestClient,
+    raw_case: Dict[str, str],
+    raw_sample: Dict[str, str],
+    coverage_path,
+    endpoints: Type,
 ):
     """Test the endpoint that allows removing a case using its name when it shares a sample with other cases."""
 
@@ -114,8 +114,8 @@ def test_remove_case_shared_sample(
     for case in [raw_case, raw_case2]:
         client.post(endpoints.CASES, json=case).json()
         assert (
-                client.get(f"{endpoints.CASES}{case['name']}").json()["name"]
-                == case["name"]
+            client.get(f"{endpoints.CASES}{case['name']}").json()["name"]
+            == case["name"]
         )
 
         # AND ONE sample associated with both
@@ -123,8 +123,8 @@ def test_remove_case_shared_sample(
         raw_sample["coverage_file_path"] = str(coverage_path)
         client.post(endpoints.SAMPLES, json=raw_sample)
         assert (
-                client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()["name"]
-                == raw_sample["name"]
+            client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()["name"]
+            == raw_sample["name"]
         )
 
     # THEN removing case 2

--- a/tests/src/chanjo2/endpoints/test_cases.py
+++ b/tests/src/chanjo2/endpoints/test_cases.py
@@ -26,8 +26,8 @@ def test_create_case(client: TestClient, raw_case: Dict[str, str], endpoints: Ty
 
 
 def test_read_cases(
-    demo_client: TestClient,
-    endpoints: Type,
+        demo_client: TestClient,
+        endpoints: Type,
 ):
     """Test the endpoint returning all cases found in the database."""
 
@@ -41,8 +41,8 @@ def test_read_cases(
 
 
 def test_read_case(
-    demo_client: TestClient,
-    endpoints: Type,
+        demo_client: TestClient,
+        endpoints: Type,
 ):
     """Test the endpoint that returns a specific case."""
 
@@ -58,28 +58,28 @@ def test_read_case(
     assert Case(**result).name == DEMO_CASE["name"]
 
 
-def test_remove_case_unique_sample(
-    client: TestClient,
-    raw_case: Dict[str, str],
-    raw_sample: Dict[str, str],
-    coverage_path,
-    endpoints: Type,
+def test_remove_case_with_sampke(
+        client: TestClient,
+        raw_case: Dict[str, str],
+        raw_sample: Dict[str, str],
+        coverage_path,
+        endpoints: Type,
 ):
-    """Test the endpoint that allows removing a case and one associated sample using its name."""
+    """Test the endpoint that allows removing a case with a sample uniquely associated to this case using case name."""
 
     # GIVEN a database with a case
     client.post(endpoints.CASES, json=raw_case).json()
     assert (
-        client.get(f"{endpoints.CASES}{raw_case['name']}").json()["name"]
-        == raw_case["name"]
+            client.get(f"{endpoints.CASES}{raw_case['name']}").json()["name"]
+            == raw_case["name"]
     )
 
     # AND a sample belonging to this case
     raw_sample["coverage_file_path"] = str(coverage_path)
     client.post(endpoints.SAMPLES, json=raw_sample)
     assert (
-        client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()["name"]
-        == raw_sample["name"]
+            client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()["name"]
+            == raw_sample["name"]
     )
 
     # GIVEN a request to delete the case
@@ -99,11 +99,11 @@ def test_remove_case_unique_sample(
 
 
 def test_remove_case_shared_sample(
-    client: TestClient,
-    raw_case: Dict[str, str],
-    raw_sample: Dict[str, str],
-    coverage_path,
-    endpoints: Type,
+        client: TestClient,
+        raw_case: Dict[str, str],
+        raw_sample: Dict[str, str],
+        coverage_path,
+        endpoints: Type,
 ):
     """Test the endpoint that allows removing a case using its name when it shares a sample with other cases."""
 
@@ -114,8 +114,8 @@ def test_remove_case_shared_sample(
     for case in [raw_case, raw_case2]:
         client.post(endpoints.CASES, json=case).json()
         assert (
-            client.get(f"{endpoints.CASES}{case['name']}").json()["name"]
-            == case["name"]
+                client.get(f"{endpoints.CASES}{case['name']}").json()["name"]
+                == case["name"]
         )
 
         # AND ONE sample associated with both
@@ -123,8 +123,8 @@ def test_remove_case_shared_sample(
         raw_sample["coverage_file_path"] = str(coverage_path)
         client.post(endpoints.SAMPLES, json=raw_sample)
         assert (
-            client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()["name"]
-            == raw_sample["name"]
+                client.get(f"{endpoints.SAMPLES}{raw_sample['name']}").json()["name"]
+                == raw_sample["name"]
         )
 
     # THEN removing case 2


### PR DESCRIPTION
### This PR adds | fixes:
- Extend the testing covering Case-Sample association

### How to test:
- Automatic tests

### Expected outcome:
- [x] All tests should pass

### Review:
- [x] Code approved by HS
- [x] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
