### PR TITLE
Fix site url for mkdocs deployment

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Chanjo2
-site_url: https://clinicalgenomics.github.io/chanjo2
+site_url: https://clinical-genomics.github.io/chanjo2
 repo_url: https://github.com/Clinical-Genomics/chanjo2/
 
 theme: readthedocs


### PR DESCRIPTION
Fix site url for mkdocs deployment

### This PR adds | fixes:
- Fix site url for mkdocs deployment

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
