### PR TITLE
Docs on loading and displaying genomic intervals (genes, transcripts and exons)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Created the basic structure of the howto using mkdocs
 - Created a GitHub action for publishing the documentation on the GitHub pages
 - Documentation on how to load cases and samples into the database
+- Documentation on hw to load genes, transcripts and exons into the database
 
 ### Fixed
 

--- a/docs/usage/data-loading.md
+++ b/docs/usage/data-loading.md
@@ -1,1 +1,0 @@
-## Loading genetic intervals: genes, transcripts and exons into the database

--- a/docs/usage/loading-intervals.md
+++ b/docs/usage/loading-intervals.md
@@ -1,0 +1,111 @@
+## Loading genetic intervals: genes, transcripts and exons into the database
+
+Genes, transcripts and exons should be loaded and updated at regular intervals of time. Depending on the type of sequencing data analysed med chanjo2, <strong>loading of transcripts and exons might not be required.</strong>
+For instance, gene coordinates should be enough for whole genome sequencing (WGS) experiments, while transcripts and exons data are necessary to return statistics from transcripts and exons-based experiments.
+
+Genes, transcripts and exons are retrieved from the [Ensembl Biomart][ensembl-biomart] using the [Schug][shug] library and loaded into the database in three distinct tables.
+
+<strong>Genes should be loaded into the database before transcripts and exons intervals.</strong> Depending on the hardware in use and the html connection speed, the process of loading these intervals might take some time. For this reason requests sent to these endpoints are asynchronous, so that they don't time out while processing the information.
+
+
+### Loading/updating database genes
+
+Loading of genes in a given genome build can be achieved by sending a POST request to the `/intervals/load/genes/{<genome-build}` endpoint:
+
+
+``` shell
+curl -X 'POST' \
+  'http://localhost:8000/intervals/load/genes/GRCh38' \
+  -H 'accept: application/json' \
+  -d ''
+```
+
+Please note that the process of <strong>loading genes into the database will erase eventual transcripts ane exons with the same genome build</strong> that are already present in the database. This ensures that transcripts and exons intervals will be up-to-date with the latest definitions of the genes loaded into the database.
+
+### Loading/updating transcripts 
+
+Transcripts can be loaded/updated by using the `/intervals/load/transcripts/{<genome-build}` endpoint:
+
+``` shell
+curl -X 'POST' \
+  'http://localhost:8000/intervals/load/transcripts/GRCh38' \
+  -H 'accept: application/json' \
+  -d ''
+```
+
+### Loading/updating exons:
+
+As for the previous endpoints, exons are loaded by sending a POST request to the `/intervals/load/exons/{<genome-build}` endpoint.
+
+``` shell
+curl -X 'POST' \
+  'http://localhost:8000/intervals/load/transcripts/GRCh38' \
+  -H 'accept: application/json' \
+  -d ''
+```
+
+### Genes, transcripts and exons queries
+
+Once the database is populated with genomic intervals data, it is possible to run queries to retrieve its content.
+
+Genomic intervals can be queried using genes definitions. Genes can be provided as a parameter to the query in the following formats
+ 
+- Ensembl gene IDs (use parameter `ensembl_ids`)
+- HGNC ids (use parameter `hgnc_ids`)
+- HGNC symbols (use parameter `hgnc_symbols`)
+
+Genome build is always a required parameter in these queries.
+
+Examples:
+
+* Send a POST request to Retrieve information on a list of <strong>genes</strong> using HGNC symbols:
+
+``` shell
+{
+  "build": "GRCh37",
+  "hgnc_symbols": ["LAMA1","LAMA2"]
+}
+```
+
+* Retrieve transcripts available for one of more genes described by Ensembl IDs:
+
+``` shell
+curl -X 'POST' \
+  'http://localhost:8000/intervals/transcripts' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "build": "GRCh37",
+  "ensembl_gene_ids": [
+    "ENSG00000101680", "ENSG00000196569"
+  ]
+}'
+```
+
+* Retrieve all exons for genes with HGNC IDs: 6481 and 6482:
+
+``` shell
+curl -X 'POST' \
+  'http://localhost:8000/intervals/exons' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "build": "GRCh37",
+  "hgnc_ids": [
+    6481, 6482
+  ]
+}'
+```
+
+Whenever ensembl_ids, hgnc_ids, hgnc_symbols parameter is not provided, these endpoints will a list of 100 default genes, transcripts or exons. To increase the number of returned entries you can specify a custom value for the query `limit` parameter.
+
+
+
+
+[ensembl-biomart]: http://useast.ensembl.org/info/data/biomart/index.html
+[schug]: https://github.com/Clinical-Genomics/schug
+
+
+
+
+

--- a/docs/usage/loading-intervals.md
+++ b/docs/usage/loading-intervals.md
@@ -97,7 +97,7 @@ curl -X 'POST' \
 }'
 ```
 
-Whenever ensembl_ids, hgnc_ids, hgnc_symbols parameter is not provided, these endpoints will a list of 100 default genes, transcripts or exons. To increase the number of returned entries you can specify a custom value for the query `limit` parameter.
+Whenever ensembl_ids, hgnc_ids, hgnc_symbols parameter is not provided, these endpoints will return a list of 100 default genes, transcripts or exons. To increase the number of returned entries you can specify a custom value for the query `limit` parameter.
 
 
 

--- a/docs/usage/loading-samples.md
+++ b/docs/usage/loading-samples.md
@@ -1,4 +1,4 @@
-## Loading cases and samples into the database
+## Cases and samples
 
 When used in connection with a database, Chanjo2 can be used to store information relative to collections of samples (cases).
 

--- a/docs/usage/loading-samples.md
+++ b/docs/usage/loading-samples.md
@@ -15,6 +15,28 @@ Cases might include one or more related samples (different individuals of a trio
   }
 ```
 
+### Displaying available cases
+
+Cases available in the database can be displayed by sending a <strong>GET</strong> request using the `/cases/` ensdpoint. The endpoint accepts a limit parameter, corresponding to the maximum number of cases to return:
+
+``` shell
+curl -X 'GET' \
+  'http://localhost:8000/cases/?limit=100' \
+  -H 'accept: application/json'
+```
+
+### Displaying a specific case
+
+To display the info relative to one specific case, send a <strong>GET</strong> request to the server, `/cases/(<case-name>` endpoint, containing the case `name`:
+
+
+``` shell
+curl -X 'GET' \
+  'http://localhost:8000/cases/intenval_id' \
+  -H 'accept: application/json'
+```
+
+
 ### Creating a new case
 
 The only two parameters that should be provided when creating a case are `display_name` and `name`.
@@ -60,6 +82,36 @@ A sample describes a sequencing analysis and has the following structure
 ```
 * Please note that Chanjo2 is not yet supporting multi-track d4 coverage files, so the track name value is only used to store this value until the functionality is in place.
 
+### Displaying available samples
+
+Cases available in the database can be displayed by sending a <strong>GET</strong> request using the `/samples/` ensdpoint. The endpoint accepts a limit parameter, corresponding to the maximum number of cases to return:
+
+``` shell
+curl -X 'GET' \
+  'http://localhost:8000/samples/?limit=100' \
+  -H 'accept: application/json'
+```
+
+### Displaying a specific sample
+
+To display the info relative to one specific sample, send a <strong>GET</strong> request to the server, `/sample/(<sample-name>` endpoint, containing the sample `name`:
+
+
+``` shell
+curl -X 'GET' \
+  'http://localhost:8000/samples/intenval_id' \
+  -H 'accept: application/json'
+```
+
+### Displaying all samples for a case
+
+In order to retrieve a list of all samples associated to a case, send a GET reqtest to the `/<case-name>/samples` endpoint. Example:
+
+``` shell
+curl -X 'GET' \
+  'http://localhost:8000/internal_id/samples/' \
+  -H 'accept: application/json'
+```
 
 ### Creating a new sample
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,7 +10,7 @@ nav:
       - Deployment using Docker: "deployment/docker-deployment.md"
       - Installation on a virtual environment: "deployment/installation.md"
     - Usage:
-        - Loading genes, transcripts and exons in the database: "usage/loading-intervals.md"
+        - Loading and displaying genes, transcripts and exons: "usage/loading-intervals.md"
         - Interval queries: "usage/interval-queries.md"
         - Cases and samples: "usage/loading-samples.md"
         - Coverage:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,9 +10,9 @@ nav:
       - Deployment using Docker: "deployment/docker-deployment.md"
       - Installation on a virtual environment: "deployment/installation.md"
     - Usage:
-        - Loading genes, transcripts and exons in the database: "usage/data-loading.md"
+        - Loading genes, transcripts and exons in the database: "usage/loading-intervals.md"
         - Interval queries: "usage/interval-queries.md"
-        - Creating Cases and samples: "usage/loading-samples.md"
+        - Cases and samples: "usage/loading-samples.md"
         - Coverage:
             - Simple coverage queries: "usage/quick-coverage.md"
             - Coverage and coverage completeness queries on sample data: "usage/sample-coverage.md"


### PR DESCRIPTION
### This PR adds | fixes:
- Add documentation on how to load and display genes, transcripts and exons

### How to test:
-Run mkdocs serve and make sure the page is displayed

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
