### PR TITLE
Fix format of mean coverage and coverage completeness in results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@
 - Remove old exons and transcripts data when updating genes
 - Test warnings regarding Case-Sample database relationship
 - Error when removing a case that is not found in the database
-- Format of coverage completeness returned in responses
+- Format of mean coverage and coverage completeness returned in responses
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - Remove old exons and transcripts data when updating genes
 - Test warnings regarding Case-Sample database relationship
 - Error when removing a case that is not found in the database
+- Format of coverage completeness returned in responses
 
 ### Changed
 

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -130,15 +130,12 @@ def get_genes_coverage_completeness(
             samples_cov_completeness.append(
                 (
                     sample,
-                    (
-                        sample,
-                        get_intervals_completeness(
-                            d4_file=d4_file,
-                            intervals=gene_coords,
-                            completeness_threholds=completeness_threholds,
-                        ),
+                    get_intervals_completeness(
+                        d4_file=d4_file,
+                        intervals=gene_coords,
+                        completeness_threholds=completeness_threholds,
                     ),
-                )
+                ),
             )
 
         genes_cov.append(

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -52,7 +52,7 @@ def intervals_coverage(
                 chromosome=interval[0],
                 start=interval[1],
                 end=interval[2],
-                mean_coverage=[("D4File", d4_file.mean(interval))],
+                mean_coverage={"D4File": d4_file.mean(interval)},
             )
         )
     return intervals_cov
@@ -115,30 +115,18 @@ def get_genes_coverage_completeness(
             (gene.chromosome, gene.start, gene.stop)
         ]
 
-        samples_mean_coverage: List[Tuple[str, float]] = []
-        samples_cov_completeness: List[Tuple[str, Decimal]] = []
+        samples_mean_coverage: dict = {}
+        samples_cov_completeness: dict = {}
 
         for sample, d4_file in samples_d4_files:
-            samples_mean_coverage.append(
-                (
-                    sample,
-                    get_intervals_mean_coverage(d4_file=d4_file, intervals=gene_coords)[
-                        0
-                    ],
-                )
-            )
-            samples_cov_completeness.append(
-                (
-                    sample,
-                    (
-                        sample,
-                        get_intervals_completeness(
-                            d4_file=d4_file,
-                            intervals=gene_coords,
-                            completeness_threholds=completeness_threholds,
-                        ),
-                    ),
-                )
+            samples_mean_coverage[sample] = get_intervals_mean_coverage(
+                d4_file=d4_file, intervals=gene_coords
+            )[0]
+
+            samples_cov_completeness[sample] = get_intervals_completeness(
+                d4_file=d4_file,
+                intervals=gene_coords,
+                completeness_threholds=completeness_threholds,
             )
 
         genes_cov.append(
@@ -181,33 +169,19 @@ def get_gene_interval_coverage_completeness(
             intervals=sql_intervals
         )
 
-        samples_mean_coverage: List[Tuple[str, float]] = []
-        samples_cov_completeness: List[Tuple[str, Decimal]] = []
+        samples_mean_coverage: dict = {}
+        samples_cov_completeness: dict = {}
 
         if intervals:
             for sample, d4_file in samples_d4_files:
-                samples_mean_coverage.append(
-                    (
-                        sample,
-                        mean(
-                            get_intervals_mean_coverage(
-                                d4_file=d4_file, intervals=intervals
-                            )
-                        ),
-                    )
+                samples_mean_coverage[sample] = mean(
+                    get_intervals_mean_coverage(d4_file=d4_file, intervals=intervals)
                 )
-
-                samples_cov_completeness.append(
-                    (
-                        sample,
-                        get_intervals_completeness(
-                            d4_file=d4_file,
-                            intervals=intervals,
-                            completeness_threholds=completeness_threholds,
-                        ),
-                    )
+                samples_cov_completeness[sample] = get_intervals_completeness(
+                    d4_file=d4_file,
+                    intervals=intervals,
+                    completeness_threholds=completeness_threholds,
                 )
-
         intervals_cov.append(
             CoverageInterval(
                 ensembl_gene_id=gene.ensembl_id,

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Dict
 
 import validators
 from pydantic import BaseModel, validator, Field, root_validator
@@ -134,13 +134,13 @@ class Exon(IntervalBase):
 
 class CoverageInterval(BaseModel):
     chromosome: str
-    completeness: List[Tuple] = Field(default_factory=list)
+    completeness: Dict = Field(default_factory=dict)
     ensembl_gene_id: Optional[str]
     end: Optional[int]
     hgnc_id: Optional[int]
     hgnc_symbol: Optional[str]
     interval_id: Optional[int]
-    mean_coverage: List[Tuple] = Field(default_factory=list)
+    mean_coverage: Dict = Field(default_factory=dict)
     start: Optional[int]
 
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #138 
- Fix format of completeness and mean_coverage in responses (from list of tuples to dictionaries, having sample names as keys)

Example with coverage thresholds 30 and 20 over one gene for a sample

Main branch:
```

[
  {
    "chromosome": "18",
    "completeness": [
      [
        "sample1",
        [
          "sample1",
          [
            [
              30,
              0.18597148861248367
            ],
            [
              20,
              0.764161981030272
            ]
          ]
        ]
      ]
    ],
    "ensembl_gene_id": "ENSG00000101680",
    "end": 7117813,
    "hgnc_id": 6481,
    "hgnc_symbol": "LAMA1",
    "interval_id": null,
    "mean_coverage": [
      [
        "sample1",
        24.059834156869428
      ]
    ],
    "start": 6941743
  }
]
```

This branch:

```
[
  {
    "chromosome": "18",
    "completeness": {
      "sample1": [
        [
          30,
          0.18597148861248367
        ],
        [
          20,
          0.764161981030272
        ]
      ]
    },
    "ensembl_gene_id": "ENSG00000101680",
    "end": 7117813,
    "hgnc_id": 6481,
    "hgnc_symbol": "LAMA1",
    "interval_id": null,
    "mean_coverage": {
      "sample1": 24.059834156869428
    },
    "start": 6941743
  }
]
```

### How to test:
- Run a query with coverage completeness thresholds

### Expected outcome:
- [x] Error should be fixed

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
