### PR TITLE
Improved docs for connecting to a real database using custom .env file params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - Documentation on how to load cases and samples into the database
 - Documentation on how to query the server for coverage stats
 - Documentation on how to load genes, transcripts and exons into the database
+- Improve documentation on how to customise the .env file to use a production database
 
 ### Fixed
 

--- a/docs/deployment/docker-deployment.md
+++ b/docs/deployment/docker-deployment.md
@@ -21,7 +21,7 @@ The endpoints of the app will be now reachable from any web browser: http://0.0.
 An example of this setup is provided in the `docker-compose-mysql.yml` file.
 Here we connect the app to a MySQL (MariaDB) and provide the connection settings to use it.
 
-Note that a file containing enviromnent variables is required to run this setup. The `template.env` file offers an example of the required variables and can be customised according to your local settings.
+Note that a file containing environmnent variables is required to run this setup. The `template.env` file offers an example of the required variables and can be customised according to your local settings.
 
 To check the configuration (env variables passed to the docker-compose file) run:
 
@@ -42,6 +42,11 @@ docker-compose -f docker-compose-mysql.yml --env-file template.env up
 The endpoints of the app will be now reachable from any web browser: http://0.0.0.0:8000/docs or http://localhost:8000/docs
 
 
+### Production settings and .env file
+
+Keep in mind that the Chanjo2 collects the variables necessary for connecting to the database from a default [.env file](https://github.com/Clinical-Genomics/chanjo2/blob/main/.env). 
+If you run a dockerized version of Chanjo2 you'd need to create a volume to replace the default .env file with a custom environment file containing the correct settings to connect to a local MySQL database. 
+The last line present on the .env file (`DEMO=Y`) should be removed or commented out.
 
 [docker-hub-chanjo2]: https://hub.docker.com/repository/docker/clinicalgenomics/chanjo2-stage/general
 [dockerfile-link]: https://github.com/Clinical-Genomics/chanjo2/blob/main/Dockerfile

--- a/docs/deployment/docker-deployment.md
+++ b/docs/deployment/docker-deployment.md
@@ -44,7 +44,7 @@ The endpoints of the app will be now reachable from any web browser: http://0.0.
 
 ### Production settings and .env file
 
-Keep in mind that the Chanjo2 collects the variables necessary for connecting to the database from a default [.env file](https://github.com/Clinical-Genomics/chanjo2/blob/main/.env). 
+Keep in mind that  Chanjo2 collects the variables necessary for connecting to the database from a default [.env file](https://github.com/Clinical-Genomics/chanjo2/blob/main/.env). 
 If you run a dockerized version of Chanjo2 you'd need to create a volume to replace the default .env file with a custom environment file containing the correct settings to connect to a local MySQL database. 
 The last line present on the .env file (`DEMO=Y`) should be removed or commented out.
 

--- a/docs/deployment/docker-deployment.md
+++ b/docs/deployment/docker-deployment.md
@@ -44,9 +44,24 @@ The endpoints of the app will be now reachable from any web browser: http://0.0.
 
 ### Production settings and .env file
 
-Keep in mind that  Chanjo2 collects the variables necessary for connecting to the database from a default [.env file](https://github.com/Clinical-Genomics/chanjo2/blob/main/.env). 
-If you run a dockerized version of Chanjo2 you'd need to create a volume to replace the default .env file with a custom environment file containing the correct settings to connect to a local MySQL database. 
+Keep in mind that Chanjo2 reads the variables necessary for connecting to the database from a default [.env file](https://github.com/Clinical-Genomics/chanjo2/blob/main/.env). 
+If you run a dockerized version of Chanjo2 and want to connect to a real database, you'll need to replace the default .env file with a custom environment file containing the correct settings to connect to your MySQL database. 
 The last line present on the .env file (`DEMO=Y`) should be removed or commented out.
+
+Given a local database running on localhost and port 3306, a custom .env file like this:
+
+```
+MYSQL_ROOT_PASSWORD=RootPassword
+MYSQL_DATABASE_NAME=chanjo2_test
+MYSQL_HOST_NAME=host.docker.internal
+MYSQL_PORT=3306
+```
+
+Should suffice to override the parameters present in the default .env file of Chanjo2:
+
+``` shell
+docker run -d --rm -v $(pwd)/.env:/home/worker/app/.env  -p 8000:8000 --expose 8000 clinicalgenomics/chanjo2-stage:latest
+```
 
 [docker-hub-chanjo2]: https://hub.docker.com/repository/docker/clinicalgenomics/chanjo2-stage/general
 [dockerfile-link]: https://github.com/Clinical-Genomics/chanjo2/blob/main/Dockerfile

--- a/docs/deployment/installation.md
+++ b/docs/deployment/installation.md
@@ -29,4 +29,18 @@ uvicorn src.chanjo2.main:app --reload
 The server will run on localhost and default port 8000 (http://0.0.0.0:8000)
 
 
+### Custom settings and the .env file
+
+The demo server is connecting to a SQLite database whose temporary tables are destroyed and re-created every time the server is started.
+In order to connect to a permanent MYSQL database instance, you'd need to customise the settings present on the [`.env`](https://github.com/Clinical-Genomics/chanjo2/blob/main/.env) file:
+
+```
+MYSQL_ROOT_PASSWORD=RootPassword
+MYSQL_DATABASE_NAME=chanjo2_test
+MYSQL_HOST_NAME=localhost
+MYSQL_PORT=3306
+```
+
+The last line present on this file (`DEMO=Y`) should be removed or commented out.
+
 [rust]: https://www.rust-lang.org/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,4 @@ nav:
     - Usage:
         - Loading and displaying genes, transcripts and exons: "usage/loading-intervals.md"
         - Cases and samples: "usage/loading-samples.md"
-        - Loading genes, transcripts and exons in the database: "usage/data-loading.md"
-        - Creating Cases and samples: "usage/loading-samples.md"
         - Coverage and coverage completeness queries: "usage/sample-coverage.md"


### PR DESCRIPTION
### This PR adds | fixes:
- Improved docs for connecting to a real database both from docker instance or conda-based software

### How to test:
- Docker command tested locally

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
