### PR TITLE
Fix documentation to point to prod Docker image instead of the stage one

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ single d4 files or samples stored in the database with associated d4 files.
 A demo REST server connected with a temporary SQLite database can be launched using Docker:
 
 ``` shell
-docker run -d --rm  -p 8000:8000 --expose 8000 clinicalgenomics/chanjo2-stage:latest
+docker run -d --rm  -p 8000:8000 --expose 8000 clinicalgenomics/chanjo2:latest
 ```
 
 The endpoints of the app will be now reachable and described from any web browser: http://0.0.0.0:8000/docs or http://localhost:8000/docs

--- a/docs/deployment/docker-deployment.md
+++ b/docs/deployment/docker-deployment.md
@@ -63,5 +63,5 @@ Should suffice to override the parameters present in the default .env file of Ch
 docker run -d --rm -v $(pwd)/.env:/home/worker/app/.env  -p 8000:8000 --expose 8000 clinicalgenomics/chanjo2:latest
 ```
 
-[docker-hub-chanjo2]: https://hub.docker.com/r/clinicalgenomics/chanjo2
+[docker-hub-chanjo2]: https://hub.docker.com/repository/docker/clinicalgenomics/chanjo2/general
 [dockerfile-link]: https://github.com/Clinical-Genomics/chanjo2/blob/main/Dockerfile

--- a/docs/deployment/docker-deployment.md
+++ b/docs/deployment/docker-deployment.md
@@ -10,7 +10,7 @@ The file named `Dockerfile` is a generic Docker file to run the application. Whe
 To start the demo via docker, run:
 
 ```
-docker run -d --rm  -p 8000:8000 --expose 8000 clinicalgenomics/chanjo2-stage:latest
+docker run -d --rm  -p 8000:8000 --expose 8000 clinicalgenomics/chanjo2:latest
 ```
 
 The endpoints of the app will be now reachable from any web browser: http://0.0.0.0:8000/docs or http://localhost:8000/docs
@@ -60,8 +60,8 @@ MYSQL_PORT=3306
 Should suffice to override the parameters present in the default .env file of Chanjo2:
 
 ``` shell
-docker run -d --rm -v $(pwd)/.env:/home/worker/app/.env  -p 8000:8000 --expose 8000 clinicalgenomics/chanjo2-stage:latest
+docker run -d --rm -v $(pwd)/.env:/home/worker/app/.env  -p 8000:8000 --expose 8000 clinicalgenomics/chanjo2:latest
 ```
 
-[docker-hub-chanjo2]: https://hub.docker.com/repository/docker/clinicalgenomics/chanjo2-stage/general
+[docker-hub-chanjo2]: https://hub.docker.com/r/clinicalgenomics/chanjo2
 [dockerfile-link]: https://github.com/Clinical-Genomics/chanjo2/blob/main/Dockerfile

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,19 +15,19 @@ Chanjo2 image contains [d4tools][d4tools-tool] and can be used to directly retri
 ### Executing d4tools
 
 ``` shell
-docker run --entrypoint d4tools --rm  clinicalgenomics/chanjo2-stage:latest
+docker run --entrypoint d4tools --rm  clinicalgenomics/chanjo2:latest
 ```
 
 ### Calculating coverage on specific genomic intervals of a d4 file using d4tools
 
 ``` shell
-docker run --entrypoint d4tools --rm  -v <path-to-local-d4-files-folder>:/home/worker/infiles clinicalgenomics/chanjo2-stage:latest view /home/worker/infiles/<d4file.d4> 1:1234560-1234580 X:1234560-1234580
+docker run --entrypoint d4tools --rm  -v <path-to-local-d4-files-folder>:/home/worker/infiles clinicalgenomics/chanjo2:latest view /home/worker/infiles/<d4file.d4> 1:1234560-1234580 X:1234560-1234580
 ```
 
 Please note that the d4 file containing the <strong>coverage data can be also stored on a remote server</strong>. In this case the command above could be replaced by this one:
 
 ``` shell
-docker run --entrypoint d4tools --rm clinicalgenomics/chanjo2-stage:latest view <url-to-remote-d4-file.d4> 1:1234560-1234580 X:1234560-1234580
+docker run --entrypoint d4tools --rm clinicalgenomics/chanjo2:latest view <url-to-remote-d4-file.d4> 1:1234560-1234580 X:1234560-1234580
 ```
 
 The coverage computation on a file hosted on a remote server, will be consistently slower than when hosting the file on a local server. 


### PR DESCRIPTION
### This PR adds | fixes:
- Time to wrap this up before create release version 1!

### Review:
- [x] Code approved by HS

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
