### PR TITLE
Fix Dockerfile name in Docker prod push GitHub action

### DIFF
--- a/.github/workflows/docker_build_on_release.yml
+++ b/.github/workflows/docker_build_on_release.yml
@@ -29,6 +29,6 @@ jobs:
        uses: docker/build-push-action@v4
        with:
          context: ./
-         file: ./Dockerfile-api
+         file: ./Dockerfile
          push: true
          tags: "clinicalgenomics/chanjo2:${{github.event.release.tag_name}}, clinicalgenomics/chanjo2:latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [unreleased]
+
+### Fixed
+
+- docker_build_on_release GitHub action
+
 ## [1.0.0]
 
 ### Added


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #145 

### How to test:
- The action should be fixed and push the release tag to Docker Hub when a new release os created

### Expected outcome:
- [ ]

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
