### PR TITLE
Modified interval coverage from d4 file to return coverage completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [unreleased]
 ### Added
-- `d4_interval_coverage`modified to accept POST requests with new `completeness_thresholds` parameter
+- `/coverage/d4/interval/` modified to accept POST requests with new `completeness_thresholds` parameter
 
 ## [1.0.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [unreleased]
 ### Added
-- `d4_interval_coverage` modified to accept POST requests with new `completeness_thresholds` parameter
+- `d4_interval_coverage`modified to accept POST requests with new `completeness_thresholds` parameter
 
 ## [1.0.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
+## [unreleased]
+### Added
+- `d4_interval_coverage` modified to accept POST requests with new `completeness_thresholds` parameter
+
 ## [1.0.1]
-
 ### Fixed
-
 - docker_build_on_release GitHub action
 
 ## [1.0.0]
-
 ### Added
-
 - Instructions on how to install and run the app on a Conda environment
 - Test for heartbeat endpoint
 - Automated tests GitHub workflow
@@ -42,7 +42,6 @@
 - Improve documentation on how to customise the .env file to use a production database
 
 ### Fixed
-
 - Bugs preventing the gunicorn app to launch
 - Code to compose DB url to work when app is invoked from docker-compose
 - Dockerfile building error due to missing d4tools lib
@@ -56,7 +55,6 @@
 - Format of mean coverage and coverage completeness returned in responses
 
 ### Changed
-
 - Renamed root endpoint to heartbeat
 - Use a multi-stage build in Dockerfile to reduce its size
 - SQLite database launched instead of MySQL as the default demo database

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -25,6 +25,7 @@ from chanjo2.meta.handle_d4 import (
 from chanjo2.models.pydantic_models import (
     CoverageInterval,
     SampleGeneIntervalQuery,
+    FileCoverageQuery,
 )
 from chanjo2.models.sql_models import Exon as SQLExon
 from chanjo2.models.sql_models import Gene as SQLGene
@@ -33,20 +34,15 @@ from chanjo2.models.sql_models import Transcript as SQLTranscript
 router = APIRouter()
 
 
-@router.get("/coverage/d4/interval/", response_model=CoverageInterval)
-def d4_interval_coverage(
-    coverage_file_path: str,
-    chromosome: str,
-    start: Optional[int] = None,
-    end: Optional[int] = None,
-):
+@router.post("/coverage/d4/interval/", response_model=CoverageInterval)
+def d4_interval_coverage(query: FileCoverageQuery):
     """Return coverage on the given interval for a D4 resource located on the disk or on a remote server."""
 
     interval: Tuple[str, Optional[int], Optional[int]] = set_interval(
-        chrom=chromosome, start=start, end=end
+        chrom=query.chromosome, start=query.start, end=query.end
     )
     try:
-        d4_file: D4File = get_d4_file(coverage_file_path)
+        d4_file: D4File = get_d4_file(query.coverage_file_path)
     except Exception:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -54,9 +50,9 @@ def d4_interval_coverage(
         )
 
     return CoverageInterval(
-        chromosome=chromosome,
-        start=start,
-        end=end,
+        chromosome=query.chromosome,
+        start=query.start,
+        end=query.end,
         interval=interval,
         mean_coverage=[
             (

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -21,6 +21,7 @@ from chanjo2.meta.handle_d4 import (
     set_interval,
     get_genes_coverage_completeness,
     get_gene_interval_coverage_completeness,
+    get_intervals_completeness,
 )
 from chanjo2.models.pydantic_models import (
     CoverageInterval,
@@ -60,6 +61,11 @@ def d4_interval_coverage(query: FileCoverageQuery):
                 get_intervals_mean_coverage(d4_file=d4_file, intervals=[interval])[0],
             )
         ],
+        completeness=get_intervals_completeness(
+            d4_file=d4_file,
+            intervals=[interval],
+            completeness_threholds=query.completeness_thresholds,
+        ),
     )
 
 

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -98,7 +98,6 @@ def get_intervals_completeness(
                 else 0,
             )
         )
-
     return completeness_values
 
 

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -144,6 +144,17 @@ class CoverageInterval(BaseModel):
     start: Optional[int]
 
 
+class FileCoverageBaseQuery(BaseModel):
+    coverage_file_path: str
+    chromosome: str
+
+
+class FileCoverageQuery(FileCoverageBaseQuery):
+    completeness_thresholds: Optional[List[int]]
+    start: Optional[int] = None
+    end: Optional[int] = None
+
+
 class SampleGeneIntervalQuery(BaseModel):
     build: Builds
     completeness_thresholds: Optional[List[int]]

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -150,9 +150,9 @@ class FileCoverageBaseQuery(BaseModel):
 
 
 class FileCoverageQuery(FileCoverageBaseQuery):
+    start: Optional[int]
+    end: Optional[int]
     completeness_thresholds: Optional[List[int]]
-    start: Optional[int] = None
-    end: Optional[int] = None
 
 
 class SampleGeneIntervalQuery(BaseModel):

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -59,6 +59,7 @@ def test_d4_interval_coverage(
 
     # WHEN using a query for the coverage over a genomic interval in a local D4 file
     interval_query["coverage_file_path"] = real_coverage_path
+    interval_query["completeness_thresholds"] = COVERAGE_COMPLETENESS_THRESHOLDS
 
     # THEN a request to the read_single_interval should be successful
     response = client.post(endpoints.INTERVAL_COVERAGE, json=interval_query)
@@ -73,6 +74,11 @@ def test_d4_interval_coverage(
     assert coverage_data.chromosome
     assert coverage_data.start
     assert coverage_data.end
+    # THEN mean coverage value should be returned
+    assert coverage_data.mean_coverage["D4File"] > 0
+    # THEN coverage completeness should be returned for each of the provided thresholds
+    for cov_threshold in COVERAGE_COMPLETENESS_THRESHOLDS:
+        assert coverage_data.completeness[str(cov_threshold)] > 0
 
 
 def test_d4_interval_coverage_single_chromosome(

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -41,7 +41,7 @@ def test_d4_interval_coverage_d4_not_found(
     interval_query["coverage_file_path"] = mock_coverage_file
 
     # THEN a request to the read_single_interval should return 404 error
-    response = client.get(endpoints.INTERVAL_COVERAGE, params=interval_query)
+    response = client.post(endpoints.INTERVAL_COVERAGE, json=interval_query)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
     # THEN show a meaningful message
@@ -61,7 +61,7 @@ def test_d4_interval_coverage(
     interval_query["coverage_file_path"] = real_coverage_path
 
     # THEN a request to the read_single_interval should be successful
-    response = client.get(endpoints.INTERVAL_COVERAGE, params=interval_query)
+    response = client.post(endpoints.INTERVAL_COVERAGE, json=interval_query)
     assert response.status_code == status.HTTP_200_OK
 
     # THEN the mean coverage over the interval should be returned
@@ -88,7 +88,7 @@ def test_d4_interval_coverage_single_chromosome(
     interval_query["coverage_file_path"] = real_coverage_path
 
     # THEN a request to the read_single_intervalshould be successful
-    response = client.get(endpoints.INTERVAL_COVERAGE, params=interval_query)
+    response = client.post(endpoints.INTERVAL_COVERAGE, json=interval_query)
     assert response.status_code == status.HTTP_200_OK
 
     # AND the mean coverage over the entire chromosome should be present in the result


### PR DESCRIPTION
### This PR adds | fixes:
- Fixes partially #141

### How to test:
- Use the `d4_interval_coverage` with a local or remove d4 file to retrieve coverage and coverage completeness (different coverage thresholds) for a genomic interval of choice

### Expected outcome:
- [x] Results should return coverage completeness

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
