### PR TITLE
Return coverage completeness for queries with d4 file and bed file containing intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [unreleased]
 ### Added
 - Created a woke-language-check GitHub action
-- `/coverage/d4/interval/` modified to accept POST requests with new `completeness_thresholds` parameter
+- `/coverage/d4/interval/` and `/coverage/d4/interval_file/` modified to accept POST requests with new `completeness_thresholds` parameter
 
 ## [1.0.1]
 ### Fixed

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -94,7 +94,11 @@ def d4_intervals_coverage(query: FileCoverageIntervalsFileQuery):
             detail=WRONG_BED_FILE_MSG,
         )
 
-    return intervals_coverage(d4_file=d4_file, intervals=intervals)
+    return intervals_coverage(
+        d4_file=d4_file,
+        intervals=intervals,
+        completeness_threholds=query.completeness_thresholds,
+    )
 
 
 def get_samples_coverage_file(

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -86,7 +86,7 @@ def d4_intervals_coverage(query: FileCoverageIntervalsFileQuery):
         with open(query.intervals_bed_path, "rb") as bed_file:
             bed_file_content = f.read()
             intervals: List[Tuple[str, Optional[int], Optional[int]]] = parse_bed(
-                bed_file=bed_content
+                bed_file_content=bed_file_content
             )
     except Exception:
         raise HTTPException(

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -83,7 +83,7 @@ def d4_intervals_coverage(query: FileCoverageIntervalsFileQuery):
         )
 
     try:
-        with open(query.intervals_bed_path, "rb") as f:
+        with open(query.intervals_bed_path, "rb") as bed_file:
             bed_content = f.read()
             intervals: List[Tuple[str, Optional[int], Optional[int]]] = parse_bed(
                 bed_file=bed_content

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -84,7 +84,7 @@ def d4_intervals_coverage(query: FileCoverageIntervalsFileQuery):
 
     try:
         with open(query.intervals_bed_path, "rb") as bed_file:
-            bed_content = f.read()
+            bed_file_content = f.read()
             intervals: List[Tuple[str, Optional[int], Optional[int]]] = parse_bed(
                 bed_file=bed_content
             )

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -84,7 +84,7 @@ def d4_intervals_coverage(query: FileCoverageIntervalsFileQuery):
 
     try:
         with open(query.intervals_bed_path, "rb") as bed_file:
-            bed_file_content = f.read()
+            bed_file_content = bed_file.read()
             intervals: List[Tuple[str, Optional[int], Optional[int]]] = parse_bed(
                 bed_file_content=bed_file_content
             )

--- a/src/chanjo2/meta/handle_bed.py
+++ b/src/chanjo2/meta/handle_bed.py
@@ -1,10 +1,10 @@
 from typing import List, Tuple
 
 
-def parse_bed(bed_file: bytes) -> List[Tuple[str, int, int]]:
+def parse_bed(bed_file_content: bytes) -> List[Tuple[str, int, int]]:
     """Parses a bed file containing genomic coordinates."""
     intervals: List[Tuple[str, int, int]] = []
-    for line_byte in bed_file.rsplit(b"\n"):
+    for line_byte in bed_file_content.rsplit(b"\n"):
         if len(line_byte) > 0 and not line_byte.startswith(b"#"):
             intervals.append(bed_line_to_region(bytes_line=line_byte))
     return intervals

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -37,12 +37,14 @@ def get_intervals_coords_list(
 def get_intervals_mean_coverage(
     d4_file: D4File, intervals: List[Tuple[str, int, int]]
 ) -> List[float]:
-    """Return the mean value over a list of intervals of a D4 file."""
+    """Return the mean value over a list of intervals of a d4 file."""
     return d4_file.mean(intervals)
 
 
 def intervals_coverage(
-    d4_file: D4File, intervals: List[Tuple[str, int, int]]
+    d4_file: D4File,
+    intervals: List[Tuple[str, int, int]],
+    completeness_threholds: Optional[List[int]],
 ) -> List[CoverageInterval]:
     """Return coverage over a list of intervals."""
     intervals_cov: List[CoverageInterval] = []
@@ -53,6 +55,11 @@ def intervals_coverage(
                 start=interval[1],
                 end=interval[2],
                 mean_coverage={"D4File": d4_file.mean(interval)},
+                completeness=get_intervals_completeness(
+                    d4_file=d4_file,
+                    intervals=[interval],
+                    completeness_threholds=completeness_threholds,
+                ),
             )
         )
     return intervals_cov

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -146,13 +146,18 @@ class CoverageInterval(BaseModel):
 
 class FileCoverageBaseQuery(BaseModel):
     coverage_file_path: str
-    chromosome: str
 
 
 class FileCoverageQuery(FileCoverageBaseQuery):
+    chromosome: str
     start: Optional[int]
     end: Optional[int]
     completeness_thresholds: Optional[List[int]]
+
+
+class FileCoverageIntervalsFileQuery(FileCoverageBaseQuery):
+    completeness_thresholds: Optional[List[int]]
+    intervals_bed_path: str
 
 
 class SampleGeneIntervalQuery(BaseModel):

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -156,7 +156,6 @@ class FileCoverageQuery(FileCoverageBaseQuery):
 
 
 class FileCoverageIntervalsFileQuery(FileCoverageBaseQuery):
-    completeness_thresholds: Optional[List[int]]
     intervals_bed_path: str
     completeness_thresholds: Optional[List[int]]
 

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -158,6 +158,7 @@ class FileCoverageQuery(FileCoverageBaseQuery):
 class FileCoverageIntervalsFileQuery(FileCoverageBaseQuery):
     completeness_thresholds: Optional[List[int]]
     intervals_bed_path: str
+    completeness_thresholds: Optional[List[int]]
 
 
 class SampleGeneIntervalQuery(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,17 +185,6 @@ def coverage_path(tmp_path) -> PosixPath:
     return tmp_coverage_file
 
 
-@pytest.fixture(name="bed_path_malformed")
-def bed_path_malformed(tmp_path) -> PosixPath:
-    """Return malformed BED file."""
-
-    tmp_bed_file: PosixPath = tmp_path / BED_FILE
-    tmp_bed_file.touch()
-    tmp_bed_file.write_text(CONTENT)
-
-    return tmp_bed_file
-
-
 @pytest.fixture(name="real_coverage_path")
 def real_coverage_path() -> str:
     """Returns the string path to a demo D4 file present on disk."""


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #141 -> Return completeness for query using a d4 file and a bed file with genomic intervals. Right now it is returned only mean coverage over the intervals

### How to test:
- On a local instance, run a query with a d4 file and a bed file containing genomic intervals. Provide also coverage threshold to make sure coverage completeness is computed

### Expected outcome:
- [x] Completeness stats should be returned in response

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
