### PR TITLE
Load transcripts from pre-downloaded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Added
+- Load genes and transcripts using pre-downloaded bed files
+
 ## [1.1.0]
 ### Added
 - Created a woke-language-check GitHub action

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -87,14 +87,22 @@ async def genes(
 
 @router.post("/intervals/load/transcripts/{build}")
 async def load_transcripts(
-    build: Builds, session: Session = Depends(get_session)
+    build: Builds,
+    file_path: Optional[str] = None,
+    session: Session = Depends(get_session),
 ) -> Union[Response, HTTPException]:
     """Load transcripts in the given genome build."""
 
     try:
-        nr_loaded_transcripts: int = await update_transcripts(
-            build=build, session=session
-        )
+        if file_path:
+            transcripts_lines: Iterator[str] = resource_lines(file_path=file_path)
+            nr_loaded_transcripts: int = await update_transcripts(
+                build=build, lines=transcripts_lines, session=session
+            )
+        else:
+            nr_loaded_transcripts: int = await update_transcripts(
+                build=build, session=session
+            )
         return JSONResponse(
             content={
                 "detail": f"{nr_loaded_transcripts} transcripts loaded into the database"

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -229,7 +229,7 @@ def test_load_transcripts_from_file(
     # GIVEN a number of transcripts contained in the demo file
     nr_transcripts: int = len(list(resource_lines(path))) - 1
 
-    # WHEN sending a request to the load_genes with genome build and path to the file containing the transcripts definitoons
+    # WHEN sending a request to the load_transcripts with genome build and path to the file containing the transcripts definitoons
     response: Response = client.post(
         f"{endpoints.LOAD_TRANSCRIPTS}{build}?file_path={path}"
     )

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -217,6 +217,32 @@ def test_load_transcripts(
     )
 
 
+@pytest.mark.parametrize("build, path", BUILD_TRANSCRIPTS_RESOURCE)
+def test_load_transcripts_from_file(
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
+):
+    """Test the endpoint that adds genes to the database in a given genome build."""
+
+    # GIVEN a number of transcripts contained in the demo file
+    nr_transcripts: int = len(list(resource_lines(path))) - 1
+
+    # WHEN sending a request to the load_genes with genome build and path to the file containing the transcripts definitoons
+    response: Response = client.post(
+        f"{endpoints.LOAD_TRANSCRIPTS}{build}?file_path={path}"
+    )
+    # THEN it should return success
+    assert response.status_code == status.HTTP_200_OK
+    # THEN all transcripts should be loaded
+    assert (
+        response.json()["detail"]
+        == f"{nr_transcripts} transcripts loaded into the database"
+    )
+
+
 @pytest.mark.parametrize("build", Builds.get_enum_values())
 def test_transcripts_multiple_filters(
     build: str,

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -223,9 +223,8 @@ def test_load_transcripts_from_file(
     path: str,
     client: TestClient,
     endpoints: Type,
-    mocker: MockerFixture,
 ):
-    """Test the endpoint that adds genes to the database in a given genome build."""
+    """Test the endpoint that adds genes to the database from a bed file in a given genome build."""
 
     # GIVEN a number of transcripts contained in the demo file
     nr_transcripts: int = len(list(resource_lines(path))) - 1


### PR DESCRIPTION
### This PR adds | fixes:
- Partial fix for #104, similar to the PR to load genes from pre-downloaded files

### How to test:
1. Download the transcripts file in a genome build of choice using schug (see instructions [here](https://github.com/Clinical-Genomics/schug#ready-to-use-endpoints))
1. Start chanjo2 and use the endpoint to load transcripts by providing the path to the downloaded file and genome build 

### Expected outcome:
- [x] Transcripts should be loaded correctly

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
