### PR TITLE
Load exons from pre-downloaded bed file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Added
+- Load genes, transcripts and exons from pre-downloaded files
+
 ## [1.1.0]
 ### Added
 - Created a woke-language-check GitHub action

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -140,12 +140,20 @@ async def transcripts(
 
 @router.post("/intervals/load/exons/{build}")
 async def load_exons(
-    build: Builds, session: Session = Depends(get_session)
+    build: Builds,
+    file_path: Optional[str] = None,
+    session: Session = Depends(get_session),
 ) -> Union[Response, HTTPException]:
     """Load exons in the given genome build."""
 
     try:
-        nr_loaded_exons: int = await update_exons(build=build, session=session)
+        if file_path:
+            exons_lines: Iterator[str] = resource_lines(file_path=file_path)
+            nr_loaded_exons: int = await update_exons(
+                build=build, lines=exons_lines, session=session
+            )
+        else:
+            nr_loaded_exons: int = await update_exons(build=build, session=session)
         return JSONResponse(
             content={"detail": f"{nr_loaded_exons} exons loaded into the database"}
         )

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -383,6 +383,28 @@ def test_load_exons(
     assert response.json()["detail"] == f"{nr_exons} exons loaded into the database"
 
 
+@pytest.mark.parametrize("build, path", BUILD_EXONS_RESOURCE)
+def test_load_exons_from_file(
+    build: str,
+    path: str,
+    client: TestClient,
+    endpoints: Type,
+    mocker: MockerFixture,
+):
+    """Test the endpoint that adds exons to the database from bed file in a given genome build."""
+
+    # GIVEN a number of exons contained in the demo file
+    nr_exons: int = len(list(resource_lines(path))) - 1
+
+    # WHEN sending a request to the load_exons endpoint with genome build ans path to the exons definitions
+    response: Response = client.post(f"{endpoints.LOAD_EXONS}{build}?file_path={path}")
+
+    # THEN it should return success
+    assert response.status_code == status.HTTP_200_OK
+    # THEN all exons should be loaded
+    assert response.json()["detail"] == f"{nr_exons} exons loaded into the database"
+
+
 @pytest.mark.parametrize("build", Builds.get_enum_values())
 def test_exons_multiple_filters(
     build: str,

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -395,7 +395,7 @@ def test_load_exons_from_file(
     # GIVEN a number of exons contained in the demo file
     nr_exons: int = len(list(resource_lines(path))) - 1
 
-    # WHEN sending a request to the load_exons endpoint with genome build ans path to the exons definitions
+    # WHEN sending a request to the load_exons endpoint with genome build and path to the exons definitions
     response: Response = client.post(f"{endpoints.LOAD_EXONS}{build}?file_path={path}")
 
     # THEN it should return success

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -389,7 +389,6 @@ def test_load_exons_from_file(
     path: str,
     client: TestClient,
     endpoints: Type,
-    mocker: MockerFixture,
 ):
     """Test the endpoint that adds exons to the database from bed file in a given genome build."""
 


### PR DESCRIPTION
### This PR adds | fixes:
- Partial fix for https://github.com/Clinical-Genomics/chanjo2/issues/104, similar to the PR to load genes and transcripts from pre-downloaded files

### How to test:
1. Download the exons file in a genome build of choice using schug (see instructions [here](https://github.com/Clinical-Genomics/schug#ready-to-use-endpoints))
1. Start chanjo2 and use the endpoint to load exons by providing the path to the downloaded file and genome build 

### Expected outcome:
- [x] Exons should be loaded correctly

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
