### PR TITLE
Move helper function from endpoints to crud module so it ca be reused when creating reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [unreleased]
 ### Added
 - Load genes, transcripts and exons from pre-downloaded files
+### Changed
+- Moved helper function from endpoints coverage to crud samples
 ### Fixed
 - Bump certifi from 2022.12.7 to 2023.7.22
 

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -1,11 +1,15 @@
-from typing import List, Optional
+from typing import List, Optional, Union, Tuple
 
+from fastapi import HTTPException, status
+from pyd4 import D4File
 from sqlalchemy import delete
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, query
 from sqlalchemy.sql.expression import Delete
 
+from chanjo2.constants import SAMPLE_NOT_FOUND, WRONG_COVERAGE_FILE_MSG
 from chanjo2.crud.cases import filter_cases_by_name
+from chanjo2.meta.handle_d4 import get_d4_file
 from chanjo2.models.pydantic_models import SampleCreate
 from chanjo2.models.sql_models import Case as SQLCase
 from chanjo2.models.sql_models import CaseSample
@@ -13,8 +17,8 @@ from chanjo2.models.sql_models import Sample as SQLSample
 
 
 def _filter_samples_by_name(
-    samples: query.Query,
-    sample_names: List[str],
+        samples: query.Query,
+        sample_names: List[str],
 ) -> query.Query:
     """Filter samples by sample name."""
     return samples.filter(SQLSample.name.in_(sample_names))
@@ -48,6 +52,38 @@ def get_sample(db: Session, sample_name: str) -> SQLSample:
     return pipeline["filter_samples_by_name"](
         samples=query, sample_names=[sample_name]
     ).first()
+
+
+def get_samples_coverage_file(
+        db: Session, samples: Optional[List[str]], case: Optional[str]
+) -> Union[List[Tuple[str, D4File]]]:
+    """Return a list of sample names with relative D4 coverage files."""
+
+    samples_d4_files: List[Tuple[str, D4File]] = []
+    sql_samples: List[SQLSample] = (
+        get_samples_by_name(db=db, sample_names=samples)
+        if samples
+        else get_case_samples(db=db, case_name=case)
+    )
+
+    if samples and len(sql_samples) < len(samples) or not sql_samples:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=SAMPLE_NOT_FOUND,
+        )
+    for sqlsample in sql_samples:
+        try:
+            d4_file: D4File = get_d4_file(
+                coverage_file_path=sqlsample.coverage_file_path
+            )
+            samples_d4_files.append((sqlsample.name, d4_file))
+        except Exception:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=WRONG_COVERAGE_FILE_MSG,
+            )
+
+    return samples_d4_files
 
 
 def create_sample_in_case(db: Session, sample: SampleCreate) -> Optional[SQLSample]:

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -17,8 +17,8 @@ from chanjo2.models.sql_models import Sample as SQLSample
 
 
 def _filter_samples_by_name(
-        samples: query.Query,
-        sample_names: List[str],
+    samples: query.Query,
+    sample_names: List[str],
 ) -> query.Query:
     """Filter samples by sample name."""
     return samples.filter(SQLSample.name.in_(sample_names))
@@ -55,7 +55,7 @@ def get_sample(db: Session, sample_name: str) -> SQLSample:
 
 
 def get_samples_coverage_file(
-        db: Session, samples: Optional[List[str]], case: Optional[str]
+    db: Session, samples: Optional[List[str]], case: Optional[str]
 ) -> Union[List[Tuple[str, D4File]]]:
     """Return a list of sample names with relative D4 coverage files."""
 

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -101,7 +101,7 @@ def d4_intervals_coverage(query: FileCoverageIntervalsFileQuery):
 
 @router.post("/coverage/samples/genes_coverage", response_model=List[CoverageInterval])
 async def samples_genes_coverage(
-        query: SampleGeneIntervalQuery, db: Session = Depends(get_session)
+    query: SampleGeneIntervalQuery, db: Session = Depends(get_session)
 ):
     """Returns coverage over a list of genes (entire gene) for a given sample in the database."""
 
@@ -129,7 +129,7 @@ async def samples_genes_coverage(
     "/coverage/samples/transcripts_coverage", response_model=List[CoverageInterval]
 )
 async def samples_transcripts_coverage(
-        query: SampleGeneIntervalQuery, db: Session = Depends(get_session)
+    query: SampleGeneIntervalQuery, db: Session = Depends(get_session)
 ):
     """Returns coverage over a list of genes (transcripts intervals only) for a given sample in the database."""
 
@@ -157,7 +157,7 @@ async def samples_transcripts_coverage(
 
 @router.post("/coverage/samples/exons_coverage", response_model=List[CoverageInterval])
 async def samples_exons_coverage(
-        query: SampleGeneIntervalQuery, db: Session = Depends(get_session)
+    query: SampleGeneIntervalQuery, db: Session = Depends(get_session)
 ):
     """Returns coverage over a list of genes (exons intervals only) for a given sample in the database."""
 


### PR DESCRIPTION
### This PR adds | fixes:
- I'm writing the code to create coverage reports (report endpoint) and I've realised that I need in there a function that is under another endpoint (coverage). This PR moves this helper function under crud/samples so it can be invoked by both endpoints

### How to test:
- Automatic tests should pass

### Expected outcome:
- [x] All automatic tests should pass

### Review:
- [x] Code approved by HS 
- [x] Tests executed by GitHub actions


This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
