### PR TITLE
Compute coverage over sex chromosomes and predicted sex from a d4 file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Added
 - Created a woke-language-check GitHub action
 - `/coverage/d4/interval/` and `/coverage/d4/interval_file/` modified to accept POST requests with new `completeness_thresholds` parameter
+- A new endpoint `/coverage/samples/predicted_sex` that returns mean coverage over X and Y and predicted sex of the sample
 ### Changed
 - Modified documentation pages to reflect changes in the `/coverage/d4/interval/` and `/coverage/d4/interval_file/` endpoints
 

--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -101,7 +101,3 @@ EXONS_FILE_HEADER: Dict[str, List[str]] = {
         "Exon rank in transcript",
     ],
 }
-
-PREDICTED_MALE = "male"
-PREDICTED_FEMALE = "female"
-PREDICTED_UNKNOWN = "unknown"

--- a/src/chanjo2/constants.py
+++ b/src/chanjo2/constants.py
@@ -101,3 +101,7 @@ EXONS_FILE_HEADER: Dict[str, List[str]] = {
         "Exon rank in transcript",
     ],
 }
+
+PREDICTED_MALE = "male"
+PREDICTED_FEMALE = "female"
+PREDICTED_UNKNOWN = "unknown"

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -101,7 +101,7 @@ def d4_intervals_coverage(query: FileCoverageIntervalsFileQuery):
 
 
 @router.get("/coverage/samples/predicted_sex", response_model=Dict)
-async def samples_sex_info(coverage_file_path: str):
+async def get_samples_predicted_sex(coverage_file_path: str):
     try:
         d4_file: D4File = get_d4_file(coverage_file_path=coverage_file_path)
     except Exception:

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -20,7 +20,7 @@ from chanjo2.meta.handle_d4 import (
     get_genes_coverage_completeness,
     get_gene_interval_coverage_completeness,
     get_intervals_completeness,
-    get_samples_sex_info,
+    get_samples_sex_metrics,
 )
 from chanjo2.models.pydantic_models import (
     CoverageInterval,
@@ -109,7 +109,7 @@ async def get_samples_predicted_sex(coverage_file_path: str):
             status_code=status.HTTP_404_NOT_FOUND,
             detail=WRONG_COVERAGE_FILE_MSG,
         )
-    return get_samples_sex_info(d4_file=d4_file)
+    return get_samples_sex_metrics(d4_file=d4_file)
 
 
 @router.post("/coverage/samples/genes_coverage", response_model=List[CoverageInterval])

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Dict
 
 from fastapi import APIRouter, HTTPException, status, Depends
 from pyd4 import D4File
@@ -20,6 +20,7 @@ from chanjo2.meta.handle_d4 import (
     get_genes_coverage_completeness,
     get_gene_interval_coverage_completeness,
     get_intervals_completeness,
+    get_samples_sex_info,
 )
 from chanjo2.models.pydantic_models import (
     CoverageInterval,
@@ -97,6 +98,18 @@ def d4_intervals_coverage(query: FileCoverageIntervalsFileQuery):
         intervals=intervals,
         completeness_threholds=query.completeness_thresholds,
     )
+
+
+@router.get("/coverage/samples/predicted_sex", response_model=Dict)
+async def samples_sex_info(coverage_file_path: str):
+    try:
+        d4_file: D4File = get_d4_file(coverage_file_path=coverage_file_path)
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=WRONG_COVERAGE_FILE_MSG,
+        )
+    return get_samples_sex_info(d4_file=d4_file)
 
 
 @router.post("/coverage/samples/genes_coverage", response_model=List[CoverageInterval])

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -5,9 +5,8 @@ from typing import List, Optional, Tuple, Union, Dict
 from pyd4 import D4File
 from sqlmodel import Session
 
-from chanjo2.constants import PREDICTED_MALE, PREDICTED_FEMALE, PREDICTED_UNKNOWN
 from chanjo2.crud.intervals import get_gene_intervals
-from chanjo2.models.pydantic_models import CoverageInterval
+from chanjo2.models.pydantic_models import CoverageInterval, Sex
 from chanjo2.models.sql_models import Exon as SQLExon
 from chanjo2.models.sql_models import Gene as SQLGene
 from chanjo2.models.sql_models import Transcript as SQLTranscript
@@ -207,17 +206,17 @@ def get_gene_interval_coverage_completeness(
 def predict_sex(x_cov: float, y_cov: float) -> str:
     """Return predict sex based on sex chromosomes coverage - this code is taken from the old chanjo."""
     if y_cov == 0:
-        return PREDICTED_FEMALE
+        return Sex.FEMALE
     else:
         ratio: float = x_cov / y_cov
         if x_cov == 0 or (ratio > 12 and ratio < 100):
-            return PREDICTED_UNKNOWN
+            return Sex.UNKNOWN
         elif ratio <= 12:
             # this is the entire prediction, it's usually very obvious
-            return PREDICTED_MALE
+            return Sex.MALE
         else:
             # the few reads mapping to the Y chromosomes are artifacts
-            return PREDICTED_FEMALE
+            return Sex.FEMALE
 
 
 def get_samples_sex_metrics(d4_file: D4File) -> Dict:

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -209,7 +209,7 @@ def predict_sex(x_cov: float, y_cov: float) -> str:
     if y_cov == 0:
         return PREDICTED_FEMALE
     else:
-        ratio = x_cov / y_cov
+        ratio: float = x_cov / y_cov
         if x_cov == 0 or (ratio > 12 and ratio < 100):
             return PREDICTED_UNKNOWN
         elif ratio <= 12:

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -220,7 +220,7 @@ def predict_sex(x_cov: float, y_cov: float) -> str:
             return PREDICTED_FEMALE
 
 
-def get_samples_sex_info(d4_file: D4File) -> Dict:
+def get_samples_sex_metrics(d4_file: D4File) -> Dict:
     """Compute coverage over sex chromosomes and predicted sex."""
 
     sex_chroms_coverage: List[float] = get_intervals_mean_coverage(

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -205,7 +205,7 @@ def get_gene_interval_coverage_completeness(
 
 
 def predict_sex(x_cov: float, y_cov: float) -> str:
-    """Predict sex based on sex chromosomes coverage - this code is taken from the old chanjo."""
+    """Return predict sex based on sex chromosomes coverage - this code is taken from the old chanjo."""
     if y_cov == 0:
         return PREDICTED_FEMALE
     else:

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -30,6 +30,12 @@ class IntervalType(str, Enum):
     CUSTOM = "custom_intervals"
 
 
+class Sex(str, Enum):
+    FEMALE = "female"
+    MALE = "male"
+    UNKNOWN = "unknown"
+
+
 class CaseBase(BaseModel):
     display_name: Optional[str] = None
     name: str

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,7 +59,7 @@ class Endpoints(str):
     EXONS = "/intervals/exons"
     INTERVAL_COVERAGE = "/coverage/d4/interval/"
     INTERVALS_FILE_COVERAGE = "/coverage/d4/interval_file/"
-    SAMPLE_SEX_INFO = "/coverage/samples/predicted_sex"
+    GET_SAMPLES_PREDICTED_SEX = "/coverage/samples/predicted_sex"
     SAMPLE_GENES_COVERAGE = "/coverage/samples/genes_coverage"
     SAMPLE_TRANSCRIPTS_COVERAGE = "/coverage/samples/transcripts_coverage"
     SAMPLE_EXONS_COVERAGE = "/coverage/samples/exons_coverage"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,7 @@ class Endpoints(str):
     EXONS = "/intervals/exons"
     INTERVAL_COVERAGE = "/coverage/d4/interval/"
     INTERVALS_FILE_COVERAGE = "/coverage/d4/interval_file/"
+    SAMPLE_SEX_INFO = "/coverage/samples/predicted_sex"
     SAMPLE_GENES_COVERAGE = "/coverage/samples/genes_coverage"
     SAMPLE_TRANSCRIPTS_COVERAGE = "/coverage/samples/transcripts_coverage"
     SAMPLE_EXONS_COVERAGE = "/coverage/samples/exons_coverage"

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -10,13 +10,9 @@ from chanjo2.constants import (
     WRONG_BED_FILE_MSG,
     MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG,
     AMBIGUOUS_SAMPLES_INPUT,
-    PREDICTED_FEMALE,
 )
 from chanjo2.demo import gene_panel_path
-from chanjo2.models.pydantic_models import (
-    CoverageInterval,
-    Builds,
-)
+from chanjo2.models.pydantic_models import CoverageInterval, Builds, Sex
 from chanjo2.populate_demo import DEMO_SAMPLE, DEMO_CASE
 
 COVERAGE_COMPLETENESS_THRESHOLDS: List[int] = [10, 20, 30]
@@ -209,7 +205,7 @@ def test_samples_sex_info(
     assert isinstance(sex_info["y_coverage"], float)
 
     # AND a predicted sex as a string
-    assert sex_info["predicted_sex"] == PREDICTED_FEMALE
+    assert sex_info["predicted_sex"] == Sex.FEMALE
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -10,6 +10,7 @@ from chanjo2.constants import (
     WRONG_BED_FILE_MSG,
     MULTIPLE_GENE_LISTS_NOT_SUPPORTED_MSG,
     AMBIGUOUS_SAMPLES_INPUT,
+    PREDICTED_FEMALE,
 )
 from chanjo2.demo import gene_panel_path
 from chanjo2.models.pydantic_models import (
@@ -185,6 +186,30 @@ def test_d4_intervals_coverage(
         # And coverage completeness for each of the specified thresholds
         for cov_threshold in COVERAGE_COMPLETENESS_THRESHOLDS:
             assert coverage_data.completeness[str(cov_threshold)] > 0
+
+
+def test_samples_sex_info(
+    real_coverage_path: str,
+    client: TestClient,
+    endpoints: Type,
+):
+    """Test the function that returns coverage over sex chromosomes as well as predicted sex."""
+
+    # GIVEN a query to the predicted_sex endpoint with the path to a d4 file
+    response = client.get(
+        f"{endpoints.SAMPLE_SEX_INFO}?coverage_file_path={real_coverage_path}"
+    )
+
+    # THEN the request should be successful
+    assert response.status_code == status.HTTP_200_OK
+    sex_info = response.json()
+
+    # WITH mean coverage over the sex chromosomes
+    assert isinstance(sex_info["x_coverage"], float)
+    assert isinstance(sex_info["y_coverage"], float)
+
+    # AND a predicted sex as a string
+    assert sex_info["predicted_sex"] == PREDICTED_FEMALE
 
 
 @pytest.mark.parametrize("build", Builds.get_enum_values())

--- a/tests/src/chanjo2/endpoints/test_coverage.py
+++ b/tests/src/chanjo2/endpoints/test_coverage.py
@@ -184,7 +184,7 @@ def test_d4_intervals_coverage(
             assert coverage_data.completeness[str(cov_threshold)] > 0
 
 
-def test_samples_sex_info(
+def test_get_samples_predicted_sex(
     real_coverage_path: str,
     client: TestClient,
     endpoints: Type,
@@ -193,7 +193,7 @@ def test_samples_sex_info(
 
     # GIVEN a query to the predicted_sex endpoint with the path to a d4 file
     response = client.get(
-        f"{endpoints.SAMPLE_SEX_INFO}?coverage_file_path={real_coverage_path}"
+        f"{endpoints.GET_SAMPLES_PREDICTED_SEX}?coverage_file_path={real_coverage_path}"
     )
 
     # THEN the request should be successful

--- a/tests/src/chanjo2/meta/test_d4.py
+++ b/tests/src/chanjo2/meta/test_d4.py
@@ -1,0 +1,23 @@
+from chanjo2.meta.handle_d4 import predict_sex
+from chanjo2.models.pydantic_models import Sex
+
+
+def test_predict_sex_male():
+    """Test the function that computes sex from coverage data from coverage file of a male sample."""
+    # GIVEN a coverage of chromosome Y which is roughly half of chromosome X
+    # THEN the predicted sex should be Male
+    assert predict_sex(x_cov=12.568, y_cov=6.605) == Sex.MALE
+
+
+def test_predict_sex_female():
+    """Test the function that computes sex from coverage data from coverage file of a female sample."""
+    # GIVEN a coverage of chromosome Y almost null
+    # THEN the predicted sex should be female
+    assert predict_sex(x_cov=22.81, y_cov=0.007) == Sex.FEMALE
+
+
+def test_predict_sex_unknown():
+    """Test the function that computes sex from coverage when it is not possible to establish the sex."""
+    # GIVEN a coverage of chromosome Y almost null
+    # THEN the predicted sex should be female
+    assert predict_sex(x_cov=0, y_cov=6.605) == Sex.UNKNOWN


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #163 

This PR contains the code to compute coverage over X and Y and predict sex according to it.  Could have been a background function but **I've added also an endpoint to it**, so it can be used and tested by itself.

### How to test:
- give a real d4 file use the new endpoint to computer sex info about the sample

### Expected outcome:
- [x] The endpoint should return the expected stats

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
