### PR TITLE
Optionally display incompletely covered genes in report cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Demo coverage report endpoint in new `report` module
 - Coverage completeness lines in HTML coverage report
 - Default threshold level coverage lines in HTML coverage report
+- Hidden table cell showing incompletely covered genes in coverage report
 ### Changed
 - Moved helper function from endpoints coverage to crud samples
 - Deleted unused `src/chanjo2/meta/handle_query_intervals.py` file

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -40,6 +40,6 @@ DEMO_COVERAGE_QUERY_DATA = {
     "interval_type": "transcripts",
     "ensembl_gene_ids": [],
     "hgnc_gene_ids": [],
-    "hgnc_gene_symbols": ["MTHFR", "DHFR", "FOLR1", "SLC46A1"],
+    "hgnc_gene_symbols": ["MTHFR", "DHFR", "FOLR1", "SLC46A1", "LAMA1"],
     "default_level": 20,
 }

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -96,7 +96,7 @@ def get_report_level_completeness_rows(
     for sample, genes_stats in samples_coverage_stats.items():
         nr_inner_intervals: int = 0
         covered_inner_intervals: int = 0
-        uncovered_genes: Set[str] = set()
+        incompletely_covered_genes: Set[str] = set()
         for gene_stats in genes_stats:
             intervals = gene_stats.inner_intervals or [gene_stats]
             for interval in intervals:

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -1,7 +1,7 @@
 import logging
 from collections import OrderedDict
 from statistics import mean
-from typing import List, Dict, Tuple, Union
+from typing import List, Dict, Tuple, Union, Set
 
 from pyd4 import D4File
 from sqlmodel import Session
@@ -89,7 +89,7 @@ def get_report_data(query: ReportQuery, session: Session) -> Dict:
 
 def get_report_level_completeness_rows(
     samples_coverage_stats: Dict[str, List[GeneCoverage]], level: int
-) -> List[Tuple[str, float, str, List[str]]]:
+) -> List[Tuple[str, float, str, Set[str]]]:
     """Create and return the contents of the coverage stats row at the default threshold level."""
     default_level_rows: List[Tuple[str, float, str]] = []
 

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -119,7 +119,7 @@ def get_report_level_completeness_rows(
                 sample,
                 intervals_covered_percent,
                 nr_not_covered_intervals,
-                uncovered_genes,
+                sorted(uncovered_genes),
             )
         )
 

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -104,8 +104,7 @@ def get_report_level_completeness_rows(
                 if interval.mean_coverage >= level:
                     covered_inner_intervals += 1
                 else:
-                    LOG.warning(gene_stats)
-                    uncovered_genes.add("hello bicthes")
+                    uncovered_genes.add(gene_stats.hgnc_symbol or gene_stats.hgnc_id)
 
         intervals_covered_percent: float = (
             round((covered_inner_intervals / nr_inner_intervals * 100), 2)

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -89,7 +89,7 @@ def get_report_data(query: ReportQuery, session: Session) -> Dict:
 
 def get_report_level_completeness_rows(
     samples_coverage_stats: Dict[str, List[GeneCoverage]], level: int
-) -> List[Tuple[str, float, str, Set[str]]]:
+) -> List[Tuple[str, float, str, List[str]]]:
     """Create and return the contents of the coverage stats row at the default threshold level."""
     default_level_rows: List[Tuple[str, float, str]] = []
 

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -90,7 +90,7 @@ def get_report_data(query: ReportQuery, session: Session) -> Dict:
 def get_report_level_completeness_rows(
     samples_coverage_stats: Dict[str, List[GeneCoverage]], level: int
 ) -> List[Tuple[str, float, str, List[str]]]:
-    """Create and return the contents of the coverage stats row at the default threshold level."""
+    """Create and return the contents of the coverage stats row at the default threshold level and incompletely covered genes."""
     default_level_rows: List[Tuple[str, float, str]] = []
 
     for sample, genes_stats in samples_coverage_stats.items():

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -104,7 +104,9 @@ def get_report_level_completeness_rows(
                 if interval.mean_coverage >= level:
                     covered_inner_intervals += 1
                 else:
-                    uncovered_genes.add(gene_stats.hgnc_symbol or gene_stats.hgnc_id)
+                    incompletely_covered_genes.add(
+                        gene_stats.hgnc_symbol or gene_stats.hgnc_id
+                    )
 
         intervals_covered_percent: float = (
             round((covered_inner_intervals / nr_inner_intervals * 100), 2)
@@ -119,7 +121,7 @@ def get_report_level_completeness_rows(
                 sample,
                 intervals_covered_percent,
                 nr_not_covered_intervals,
-                sorted(uncovered_genes),
+                sorted(incompletely_covered_genes),
             )
         )
 

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -89,19 +89,23 @@ def get_report_data(query: ReportQuery, session: Session) -> Dict:
 
 def get_report_level_completeness_rows(
     samples_coverage_stats: Dict[str, List[GeneCoverage]], level: int
-) -> List[Tuple[str, float, str]]:
+) -> List[Tuple[str, float, str, List[str]]]:
     """Create and return the contents of the coverage stats row at the default threshold level."""
     default_level_rows: List[Tuple[str, float, str]] = []
 
     for sample, genes_stats in samples_coverage_stats.items():
         nr_inner_intervals: int = 0
         covered_inner_intervals: int = 0
+        uncovered_genes: Set[str] = set()
         for gene_stats in genes_stats:
             intervals = gene_stats.inner_intervals or [gene_stats]
             for interval in intervals:
                 nr_inner_intervals += 1
                 if interval.mean_coverage >= level:
                     covered_inner_intervals += 1
+                else:
+                    LOG.warning(gene_stats)
+                    uncovered_genes.add("hello bicthes")
 
         intervals_covered_percent: float = (
             round((covered_inner_intervals / nr_inner_intervals * 100), 2)
@@ -112,7 +116,12 @@ def get_report_level_completeness_rows(
             f"{nr_inner_intervals - covered_inner_intervals}/{nr_inner_intervals}"
         )
         default_level_rows.append(
-            (sample, intervals_covered_percent, nr_not_covered_intervals)
+            (
+                sample,
+                intervals_covered_percent,
+                nr_not_covered_intervals,
+                uncovered_genes,
+            )
         )
 
     return default_level_rows

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -232,14 +232,12 @@
     	{
     		for (var i = 0; i < ids.length; i++) {
     			var e = document.getElementById(ids[i]);
-    
     			if (e.style.display == 'block'){
     				e.style.display = 'none';
     			}
     			else {
     				e.style.display = 'block';
     			}
-
 			}
     	}
     	</script>

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -228,18 +228,18 @@
 		<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 
 		<script>
-		function toggle_visibility(ids)
-    	{
-    		for (var i = 0; i < ids.length; i++) {
-    			var e = document.getElementById(ids[i]);
-    			if (e.style.display == 'block'){
-    				e.style.display = 'none';
-    			}
-    			else {
-    				e.style.display = 'block';
-    			}
+			function toggle_visibility(ids)
+			{
+				for (var i = 0; i < ids.length; i++) {
+					var e = document.getElementById(ids[i]);
+					if (e.style.display == 'block'){
+						e.style.display = 'none';
+					}
+					else {
+						e.style.display = 'block';
+					}
+				}
 			}
-    	}
     	</script>
 
 	{% endblock %}

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -140,7 +140,7 @@
           <tr>
 			  <td>{{data[0]}}</td>
 			  {% if data[1] == 100.00 %}
-			  	<td colspan="3">
+			  	<td colspan="2">
 				  No incompletely covered intervals.
 				</td>
 			  {% else %}

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -38,7 +38,7 @@
 
 					<div class="col-xs-3">
 					  <label class="control-label">Show genes</label>
-					  <div><input type="checkbox" name="show_genes" {% if extras.show_genes %}checked{% endif %}></div>
+					  <div><input type="checkbox" name="show_genes" onclick="toggle_visibility(['uncoveredGenesHeader', 'uncoveredGenesCell']);"></div>
 					</div>
 
 					<div class="col-xs-2">
@@ -125,13 +125,14 @@
 {% endmacro %}
 
 {% macro default_level_metrics() %}
- <table class="table table-bordered table-hover">
+<table class="table table-bordered table-hover">
 	 <caption>Genes/Transcripts/Exons coverage at default coverage threshold</caption>
       <thead>
         <tr>
           <th>Sample</th>
           <th>Fully covered {{ interval_type }} [%]</th>
           <th>Incompletely covered {{ interval_type }}</th>
+		  <th id="uncoveredGenesHeader"  style="display: none;">Incompletely covered genes</th>
         </tr>
       </thead>
       <tbody>
@@ -139,17 +140,21 @@
           <tr>
 			  <td>{{data[0]}}</td>
 			  {% if data[1] == 100.00 %}
-			  	<td colspan="2">
+			  	<td colspan="3">
 				  No incompletely covered intervals.
 				</td>
 			  {% else %}
 				<td class="text-right">{{ data[1] }}</td>
 				<td class="text-center">{{ data[2] }}</td>
+			  	<td id="uncoveredGenesCell" class="text-center" style="display: none;">
+					{{ data[3]|join(", ") }}
+				</td>
 			  {% endif %}
           </tr>
         {% endfor %}
       </tbody>
-    </table>
+ </table>
+
 {% endmacro %}
 
 
@@ -173,19 +178,11 @@
 		<!-- Oldish compiled and minified CSS -->
 		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 
-		<!-- Optional theme -->
-		<link rel="stylesheet" href="https://bootswatch.com/simplex/bootstrap.min.css">
-
 		<!-- Customizations -->
 		<link rel="stylesheet" type="text/css" href="{{ url_for('static', path='main.css') }}">
 	{% endblock %}
 
 	{% block css_style %}{% endblock %}
-
-	{% block js_top %}
-		<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-	{% endblock %}
 
 </head>
 <body>
@@ -219,15 +216,34 @@
 
 		{{ default_level_metrics() }}
 
-
 		<!--End of Quality report -->
 
 	</div>
 
 
-	{% block js_btm %}
+	{% block js_code %}
+		<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 		<!-- Oldish compiled and minified JavaScript -->
 		<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+		<script>
+		function toggle_visibility(ids)
+    	{
+    		for (var i = 0; i < ids.length; i++) {
+    			var e = document.getElementById(ids[i]);
+    
+    			if (e.style.display == 'block'){
+    				e.style.display = 'none';
+    			}
+    			else {
+    				e.style.display = 'block';
+    			}
+
+			}
+    	}
+    	</script>
+
 	{% endblock %}
 </body>
 </html>

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -230,8 +230,8 @@
 		<script>
 			function toggle_visibility(ids)
 			{
-				for (var i = 0; i < ids.length; i++) {
-					var e = document.getElementById(ids[i]);
+				for (let id of ids) {
+					var e = document.getElementById(id);
 					if (e.style.display == 'block'){
 						e.style.display = 'none';
 					}

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -38,7 +38,7 @@
 
 					<div class="col-xs-3">
 					  <label class="control-label">Show genes</label>
-					  <div><input type="checkbox" name="show_genes" onclick="toggle_visibility(['uncoveredGenesHeader', 'uncoveredGenesCell']);"></div>
+					  <div><input type="checkbox" name="show_genes" onclick="toggle_visibility(['incompletelyCoveredGenesHeader', 'incompletelyCoveredGenesCell']);"></div>
 					</div>
 
 					<div class="col-xs-2">
@@ -132,7 +132,7 @@
           <th>Sample</th>
           <th>Fully covered {{ interval_type }} [%]</th>
           <th>Incompletely covered {{ interval_type }}</th>
-		  <th id="uncoveredGenesHeader"  style="display: none;">Incompletely covered genes</th>
+		  <th id="incompletelyCoveredGenesHeader"  style="display: none;">Incompletely covered genes</th>
         </tr>
       </thead>
       <tbody>
@@ -146,7 +146,7 @@
 			  {% else %}
 				<td class="text-right">{{ data[1] }}</td>
 				<td class="text-center">{{ data[2] }}</td>
-			  	<td id="uncoveredGenesCell" class="text-center" style="display: none;">
+			  	<td id="incompletelyCoveredGenesCell" class="text-center" style="display: none;">
 					{{ data[3]|join(", ") }}
 				</td>
 			  {% endif %}

--- a/tests/src/chanjo2/meta/test_handle_report_contents.py
+++ b/tests/src/chanjo2/meta/test_handle_report_contents.py
@@ -45,12 +45,12 @@ def test_get_report_level_completeness_rows(
         sample,
         mean_cov_intervals,
         incompletely_covered_intervals,
-        uncovered_genes,
+        incompletely_covered_genes,
     ) in default_level_samples_coverage_stats:
         assert isinstance(sample, str)
         assert isinstance(mean_cov_intervals, float) or mean_cov_intervals == 0
-        assert isinstance(uncovered_intervals, str)
-        assert isinstance(uncovered_genes, list)
+        assert isinstance(incompletely_covered_intervals, str)
+        assert isinstance(incompletely_covered_genes, list)
 
 
 def test_get_report_completeness_rows(

--- a/tests/src/chanjo2/meta/test_handle_report_contents.py
+++ b/tests/src/chanjo2/meta/test_handle_report_contents.py
@@ -44,11 +44,13 @@ def test_get_report_level_completeness_rows(
     for (
         sample,
         mean_cov_intervals,
-        not_covered_intervals,
+        uncovered_intervals,
+        uncovered_genes,
     ) in default_level_samples_coverage_stats:
         assert isinstance(sample, str)
         assert isinstance(mean_cov_intervals, float) or mean_cov_intervals == 0
-        assert isinstance(not_covered_intervals, str)
+        assert isinstance(uncovered_intervals, str)
+        assert isinstance(uncovered_genes, list)
 
 
 def test_get_report_completeness_rows(

--- a/tests/src/chanjo2/meta/test_handle_report_contents.py
+++ b/tests/src/chanjo2/meta/test_handle_report_contents.py
@@ -44,7 +44,7 @@ def test_get_report_level_completeness_rows(
     for (
         sample,
         mean_cov_intervals,
-        uncovered_intervals,
+        incompletely_covered_intervals,
         uncovered_genes,
     ) in default_level_samples_coverage_stats:
         assert isinstance(sample, str)


### PR DESCRIPTION
### This PR adds | fixes:
- Add info on incompletely covered genes in a hidden cell that can be shown by clicking on this checkbox, once you expand the filters:

<img width="1005" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/75ca4844-e435-4628-b934-9b6af564e4df">


**How to prepare for test**:
- Deploy in cg-vm1 stage
-  Click on the "show genes" checkbox

### Expected outcome:
- [x] The incompletely covered genes should be shown down in the `Transcript coverage at ?x` table

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
