### PR TITLE
Display case display name on report when provided in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Coverage completeness lines in HTML coverage report
 - Default threshold level coverage lines in HTML coverage report
 - Hidden table cell showing incompletely covered genes in coverage report
+- Display optional case name on gene coverage report
 ### Changed
 - Moved helper function from endpoints coverage to crud samples
 - Deleted unused `src/chanjo2/meta/handle_query_intervals.py` file

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -36,6 +36,7 @@ DEMO_COVERAGE_QUERY_DATA = {
             "analysis_date": "2023-04-23T10:20:30.400+02:30",
         }
     ],
+    "case_display_name": "643594",
     "gene_panel": "A test Panel 1.0",
     "interval_type": "transcripts",
     "ensembl_gene_ids": [],

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -72,6 +72,7 @@ def get_report_data(query: ReportQuery, session: Session) -> Dict:
         "extras": {
             "panel_name": query.panel_name,
             "default_level": query.default_level,
+            "case_name": query.case_display_name,
         },
         "sex_rows": get_report_sex_rows(
             samples=query.samples, samples_d4_files=samples_d4_files

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -223,6 +223,7 @@ class ReportQuery(BaseModel):
     default_level: int = 10
 
     samples: List[ReportQuerySample]
+    case_display_name: Optional[str]
 
 
 class SampleSexRow(BaseModel):

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -200,7 +200,12 @@
 
 		{{ report_filters() }}
 
+		{% if extras.case_name %}
+			<h2>Case name: {{extras.case_name}}</h2>
+		{% endif %}
+
 		<!-- Quality report -->
+
 		<h2>Quality report: clinical sequencing</h2>
 		{% if extras.panel_name %}
 			<p>Based on gene panel: <strong>{{ extras.panel_name }}</strong></p>


### PR DESCRIPTION
### This PR adds | fixes:
- Option to provided a case display name to be displayed on coverage report (fix #177) - the fix was originally requested in chanjo1 (https://github.com/Clinical-Genomics/scout/issues/2871)

### How to test:
- Deploy locally or on stage and make sure that the new report contains case name

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
