### PR TITLE
Display an error message when one or more genes present in the query are not found in database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Coverage completeness lines in HTML coverage report
 - Default threshold level coverage lines in HTML coverage report
 - Hidden table cell showing incompletely covered genes in coverage report
+- Display error in coverage report when query genes are not found in the database
 ### Changed
 - Moved helper function from endpoints coverage to crud samples
 - Deleted unused `src/chanjo2/meta/handle_query_intervals.py` file

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -40,6 +40,6 @@ DEMO_COVERAGE_QUERY_DATA = {
     "interval_type": "transcripts",
     "ensembl_gene_ids": [],
     "hgnc_gene_ids": [],
-    "hgnc_gene_symbols": ["MTHFR", "DHFR", "FOLR1", "SLC46A1", "LAMA1"],
+    "hgnc_gene_symbols": ["MTHFR", "DHFR", "FOLR1", "SLC46A1", "LAMA1", "PIPPI6"],
     "default_level": 20,
 }

--- a/src/chanjo2/endpoints/report.py
+++ b/src/chanjo2/endpoints/report.py
@@ -42,5 +42,6 @@ async def demo_report(request: Request, db: Session = Depends(get_session)):
                 "default_level_completeness_rows"
             ],
             "interval_type": report_query.interval_type.value,
+            "errors": report_content["errors"],
         },
     )

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -1,7 +1,7 @@
 import logging
 from collections import OrderedDict
 from statistics import mean
-from typing import List, Dict, Tuple, Union, Set
+from typing import List, Dict, Tuple, Union, Set, Optional
 
 from pyd4 import D4File
 from sqlmodel import Session
@@ -67,7 +67,7 @@ def get_report_data(query: ReportQuery, session: Session) -> Dict:
         for sample, d4_file in samples_d4_files
     }
 
-    data: Dicr = {
+    data: Dict = {
         "levels": get_ordered_levels(threshold_levels=query.completeness_thresholds),
         "extras": {
             "panel_name": query.panel_name,
@@ -83,8 +83,37 @@ def get_report_data(query: ReportQuery, session: Session) -> Dict:
         "default_level_completeness_rows": get_report_level_completeness_rows(
             samples_coverage_stats=samples_coverage_stats, level=query.default_level
         ),
+        "errors": [
+            get_missing_genes_from_db(
+                sql_genes=genes,
+                ensembl_ids=query.ensembl_gene_ids,
+                hgnc_ids=query.hgnc_gene_ids,
+                hgnc_symbols=query.hgnc_gene_symbols,
+            )
+        ],
     }
     return data
+
+
+def get_missing_genes_from_db(
+    sql_genes: List[SQLGene],
+    ensembl_ids: Optional[List[str]] = [],
+    hgnc_ids: Optional[List[int]] = [],
+    hgnc_symbols: Optional[List[str]] = [],
+) -> Tuple[str, List[Union[str, int]]]:
+    """Return queried genes that are not found in the database."""
+
+    if ensembl_ids:
+        sql_genes_ids = [gene.ensembl_id for gene in sql_genes]
+    elif hgnc_ids:
+        sql_genes_ids = [gene.hgnc_id for gene in sql_genes]
+    else:
+        sql_genes_ids = [gene.hgnc_symbol for gene in sql_genes]
+
+    query_ids: List[Union[str, int]] = ensembl_ids or hgnc_ids or hgnc_symbols
+    return "Gene IDs not found in the database", list(
+        set(query_ids) - set(sql_genes_ids)
+    )
 
 
 def get_report_level_completeness_rows(

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -1,3 +1,11 @@
+{% macro errors_block() %}
+	{% for error_description, error_content in errors %}
+		{% if error_content %}
+			<span class="alert alert-danger">{{error_description}}: {{error_content|join(", ")}}</span>
+		{% endif %}
+	{% endfor %}
+{% endmacro %}
+
 {% macro report_filters() %}
 <div class="panel-group hidden-print" id="filter-accordion">
 	<div class="panel panel-default">
@@ -201,6 +209,9 @@
 		{{ report_filters() }}
 
 		<!-- Quality report -->
+
+		{{ missing_genes_error }}
+
 		<h2>Quality report: clinical sequencing</h2>
 		{% if extras.panel_name %}
 			<p>Based on gene panel: <strong>{{ extras.panel_name }}</strong></p>
@@ -215,7 +226,8 @@
 		<h3> Transcript coverage at {{ extras.default_level }}x</h3>
 
 		{{ default_level_metrics() }}
-
+		<hr>
+		{{ errors_block() }}
 		<!--End of Quality report -->
 
 	</div>

--- a/tests/src/chanjo2/meta/test_handle_report_contents.py
+++ b/tests/src/chanjo2/meta/test_handle_report_contents.py
@@ -3,11 +3,13 @@ from typing import List, Tuple, Dict
 from sqlalchemy.orm import sessionmaker
 
 from chanjo2.constants import DEFAULT_COMPLETENESS_LEVELS
+from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA
 from chanjo2.meta.handle_d4 import D4File
 from chanjo2.meta.handle_d4 import get_sample_interval_coverage
 from chanjo2.meta.handle_report_contents import (
     get_report_level_completeness_rows,
     get_report_completeness_rows,
+    get_missing_genes_from_db,
 )
 from chanjo2.models.sql_models import Gene as SQLGene
 from chanjo2.models.sql_models import Transcript as SQLTranscript
@@ -84,3 +86,19 @@ def test_get_report_completeness_rows(
         assert sample == samples_d4_list[0][0]
         for level in DEFAULT_COMPLETENESS_LEVELS:
             assert f"completeness_{level}" in stats
+
+
+def test_get_missing_genes_from_db(
+    demo_session: sessionmaker, demo_genes_37: List[SQLGene]
+):
+    """Test function that returns queried genes that are not present in the database."""
+
+    # WHEN coverage query contains gene symbols that are not present in the database
+    missing_gene_error: Tuple[str, List[Union[int, str]]] = get_missing_genes_from_db(
+        sql_genes=demo_genes_37,
+        hgnc_symbols=DEMO_COVERAGE_QUERY_DATA["hgnc_gene_symbols"],
+    )
+
+    # THEN the get_missing_genes_from_db function should return the expected error, containing description and missing IDs
+    assert missing_gene_error[0] == "Gene IDs not found in the database"
+    assert missing_gene_error[1]


### PR DESCRIPTION
### This PR adds | fixes:
Display a red warning when queried genes are not found in the database:

<img width="1110" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/e99c4229-2c9a-4baa-869c-060edde80576">

### How to test:
- Deploy this branch locally or or stage and make sure that the error is shown on report demo

### Review:
- [x] Code approved by HS
- [x] Tests executed by 

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
