### PR TITLE
Coverage metrics explanation on report page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Coverage completeness lines in HTML coverage report
 - Default threshold level coverage lines in HTML coverage report
 - Hidden table cell showing incompletely covered genes in coverage report
+- Metrics explanation section on coverage report
 ### Changed
 - Moved helper function from endpoints coverage to crud samples
 - Deleted unused `src/chanjo2/meta/handle_query_intervals.py` file

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -72,6 +72,7 @@ def get_report_data(query: ReportQuery, session: Session) -> Dict:
         "extras": {
             "panel_name": query.panel_name,
             "default_level": query.default_level,
+            "interval_type": query.interval_type.value,
         },
         "sex_rows": get_report_sex_rows(
             samples=query.samples, samples_d4_files=samples_d4_files

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -124,7 +124,57 @@
 </div>
 
 {% endmacro %}
+<h4>{{ _('General') }}</h4>
+<p>
+  <a href="http://lomereiter.github.io/sambamba/" title="Sambamba">Sambamba</a>
+  {{ _('is used for coverage analysis based on read alignment.') }}
+  {{ _('Duplicates, reads with mapping quality less than 10 as well as bases with a base quality less than 10 are not included in the analysis.') }}
+  {{ _('Bases that overlap between read pairs are only counted once.') }}
 
+  {{ _('The parts of the genome that has been analyzed') }}
+  {{ _('is composed of all protein coding, exonic intervals defined in') }}
+  <a href="http://www.genenames.org/">HGNC</a>.
+
+  {% if includes_splice_sites %}
+	{{ _('Additionally, the data also includes spicing sites') }}
+	({{ _('donator and acceptor positions') }},
+	{{ splice_site_interval }}
+	{{ _('bases on either of each exon') }}).
+  {% endif %}
+</p>
+
+{% if config.CHANJO_PANEL %}
+  <p>
+	{{ _('Final coverage metrics were calculated for genes from the clinical panels') }}:
+	<code>{{ config.CHANJO_PANEL_NAME }}</code>.
+	{{ _('Note that estimations were made regarding coverage and completeness') }}
+	{{ _('on the level of transcripts') }}.
+  </p>
+{% endif %}
+
+<p>
+  <strong>{{ _('Completeness') }}</strong>:
+  {{ _('defined as the ratio of bases') }}
+  {{ _('sequenced deeper than a specified cutoff') }},
+  {{ _('e.g. 10x') }}.
+</p>
+
+<p>
+  <strong>{{ _('Transcript coverage') }}</strong>:
+  {{ _('defined as the ratio of transcripts that are fully covered') }},
+  {{ _('i.e. with a completeness of') }} 100% {{ _('at') }} {{ cutoff }}x.
+</p>
+
+<p>
+  <strong>{{ _('Gender prediction from data') }}</strong>:
+  {{ _('calculated by comparing relative chromosome coverage') }}
+  (X/Y).
+  {{ _('Some reads randomly map to the Y chromosome') }}.
+  {{ _('Therefore, a less than 10 fold difference is used to infer a "male" sample') }}.
+</p>
+{% macro explanations() %}
+
+{% enmacro %}
 
 <!DOCTYPE html>
 <head>
@@ -189,6 +239,12 @@
 		{{ important_metrics() }}
 
 		<!--End of Quality report -->
+
+		<h3>Explanations</h3>
+
+		{{ explanations() }}
+
+
 
 	</div>
 

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -160,26 +160,17 @@
 {% macro explanations() %}
 <h4>General</h4>
 <p>
-  <a href="https://github.com/Clinical-Genomics/chanjo2" title="chanjo2">Chanjo2</a>
-  Chanjo2 was used for coverage analysis based on read alignment.
+  <a href="https://github.com/Clinical-Genomics/chanjo2" target="_blank" rel="noopener" title="chanjo2">Chanjo2</a>
+  was used for coverage analysis based on reads alignment. Chanjo2 computes coverage and coverage completeness using an internal module based on <a href="https://github.com/38/d4-format" target="_blank" rel="noopener">d4tools</a>.
 
-  The parts of the genome that has been analyzed
-  is composed of all protein coding, exonic intervals defined in
-  <a href="http://www.genenames.org/">HGNC</a>.
-
-  {% if includes_splice_sites %}
-	Additionally, the data also includes spicing sites
-	donator and acceptor positions
-	{{ splice_site_interval }}
-	bases on either of each exon
-  {% endif %}
+  The genome has been analyzed at the {{ extras.interval_type }} level, for genes defined at <a href="http://www.genenames.org/" target="_blank" rel="noopener">HGNC</a>.
 </p>
 
-{% if CHANJO_PANEL %}
+{% if extras.panel_name %}
   <p>
-	Final coverage metrics were calculated for genes from the clinical panels
-	Note that estimations were made regarding coverage and completeness
-	on the level of transcripts
+	Final coverage metrics were calculated for genes from the clinical panels.
+	Note that <strong>estimations were made regarding coverage and completeness
+	  on the level of {{ extras.interval_type }}</strong>.
   </p>
 {% endif %}
 
@@ -191,17 +182,16 @@
 </p>
 
 <p>
-  <strong>Transcript coverage</strong>:
-  defined as the ratio of transcripts that are fully covered
-  ('i.e. with a completeness of') 100% 'at' {{ cutoff }}x.
+  <strong>Gene/Transcripts/Exons coverage</strong>:
+  defined as the ratio of these intervals are fully covered
+  ('i.e. with a completeness of') 100% 'at' {{ extras.default_level }}x.
 </p>
 
 <p>
   <strong>Gender prediction from data</strong>:
-  calculated by comparing relative chromosome coverage'
-  (X/Y).
+  calculated by comparing relative chromosome coverage (X/Y).
   Some reads randomly map to the Y chromosome.
-  Therefore, a less than 10 fold difference is used to infer a "male" sample
+  Therefore, a less than 10 fold difference is used to infer a "male" sample.
 </p>
 
 {% endmacro %}

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -124,57 +124,55 @@
 </div>
 
 {% endmacro %}
-<h4>{{ _('General') }}</h4>
-<p>
-  <a href="http://lomereiter.github.io/sambamba/" title="Sambamba">Sambamba</a>
-  {{ _('is used for coverage analysis based on read alignment.') }}
-  {{ _('Duplicates, reads with mapping quality less than 10 as well as bases with a base quality less than 10 are not included in the analysis.') }}
-  {{ _('Bases that overlap between read pairs are only counted once.') }}
 
-  {{ _('The parts of the genome that has been analyzed') }}
-  {{ _('is composed of all protein coding, exonic intervals defined in') }}
+{% macro explanations() %}
+<h4>General</h4>
+<p>
+  <a href="https://github.com/Clinical-Genomics/chanjo2" title="chanjo2">Chanjo2</a>
+  Chanjo2 was used for coverage analysis based on read alignment.
+
+  The parts of the genome that has been analyzed
+  is composed of all protein coding, exonic intervals defined in
   <a href="http://www.genenames.org/">HGNC</a>.
 
   {% if includes_splice_sites %}
-	{{ _('Additionally, the data also includes spicing sites') }}
-	({{ _('donator and acceptor positions') }},
+	Additionally, the data also includes spicing sites
+	donator and acceptor positions
 	{{ splice_site_interval }}
-	{{ _('bases on either of each exon') }}).
+	bases on either of each exon
   {% endif %}
 </p>
 
-{% if config.CHANJO_PANEL %}
+{% if CHANJO_PANEL %}
   <p>
-	{{ _('Final coverage metrics were calculated for genes from the clinical panels') }}:
-	<code>{{ config.CHANJO_PANEL_NAME }}</code>.
-	{{ _('Note that estimations were made regarding coverage and completeness') }}
-	{{ _('on the level of transcripts') }}.
+	Final coverage metrics were calculated for genes from the clinical panels
+	Note that estimations were made regarding coverage and completeness
+	on the level of transcripts
   </p>
 {% endif %}
 
 <p>
-  <strong>{{ _('Completeness') }}</strong>:
-  {{ _('defined as the ratio of bases') }}
-  {{ _('sequenced deeper than a specified cutoff') }},
-  {{ _('e.g. 10x') }}.
+  <strong>Completeness</strong>:
+  defined as the ratio of bases
+  sequenced deeper than a specified cutoff
+  e.g. 10x
 </p>
 
 <p>
-  <strong>{{ _('Transcript coverage') }}</strong>:
-  {{ _('defined as the ratio of transcripts that are fully covered') }},
-  {{ _('i.e. with a completeness of') }} 100% {{ _('at') }} {{ cutoff }}x.
+  <strong>Transcript coverage</strong>:
+  defined as the ratio of transcripts that are fully covered
+  ('i.e. with a completeness of') 100% 'at' {{ cutoff }}x.
 </p>
 
 <p>
-  <strong>{{ _('Gender prediction from data') }}</strong>:
-  {{ _('calculated by comparing relative chromosome coverage') }}
+  <strong>Gender prediction from data</strong>:
+  calculated by comparing relative chromosome coverage'
   (X/Y).
-  {{ _('Some reads randomly map to the Y chromosome') }}.
-  {{ _('Therefore, a less than 10 fold difference is used to infer a "male" sample') }}.
+  Some reads randomly map to the Y chromosome.
+  Therefore, a less than 10 fold difference is used to infer a "male" sample
 </p>
-{% macro explanations() %}
 
-{% enmacro %}
+{% endmacro %}
 
 <!DOCTYPE html>
 <head>


### PR DESCRIPTION
### This PR adds | fixes:
- Adds a metrics explanation in the end of the coverage report:

<img width="693" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/c1167a87-1c50-4307-b17c-8d4cdb8b637d">

### How to test:
- Deploy locally or on stage

### Expected outcome:
- [x] Make sure that the explanations are present

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
