### PR TITLE
Export to PDF button in report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Coverage completeness lines in HTML coverage report
 - Default threshold level coverage lines in HTML coverage report
 - Hidden table cell showing incompletely covered genes in coverage report
+- Export coverage report to PDF
 ### Changed
 - Moved helper function from endpoints coverage to crud samples
 - Deleted unused `src/chanjo2/meta/handle_query_intervals.py` file

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -52,9 +52,6 @@
 				  <input type="text" name="sample_id" value="{{ sample_id }}" hidden>
 				{% endfor %}
 
-				{% if hidden %}
-				  <button class="btn btn-link navbar-btn" type="submit">PDF</button>
-				{% endif %}
 				</div>
 				</form>
 			</div>
@@ -186,21 +183,21 @@
 
 </head>
 <body>
-	<nav class="navbar navbar-default">
-		<div class="container">
-			<div class="navbar-header">
-				<span class="navbar-brand">
-					Chanjo2 Report
-				</span>
-			</div>
-			<div class="nav navbar-nav navbar-right">
-				<span class="navbar"><button class="btn btn-default" onclick="createPDF()">PDF</button></span>
-			</div>
 
+	<nav class="navbar navbar-default">
+	  <div class="container">
+		<div class="navbar-header">
+		  <a class="navbar-brand" href="#">Chanjo2</a>
 		</div>
+		<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+		  <div class="nav navbar-nav navbar-right">
+			<button class="navbar-brand" onclick="window.print();">Create PDF</button>
+		  </div>
+		</div><!-- /.navbar-collapse -->
+	  </div><!-- /.container -->
 	</nav>
 
-	<div class="container">
+	<div class="container" id="dvContainer">
 
 		{{ report_filters() }}
 
@@ -221,7 +218,6 @@
 		{{ default_level_metrics() }}
 
 		<!--End of Quality report -->
-
 	</div>
 
 
@@ -230,9 +226,6 @@
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 		<!-- Oldish compiled and minified JavaScript -->
 		<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-		<!-- jsPDF is used to download the report as a PDF document -->
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-
 		<script>
 			function toggle_visibility(ids)
 			{
@@ -246,18 +239,6 @@
 					}
 				}
 			}
-
-			function createPDF()
-			{
-				import { jsPDF } from "jspdf";
-
-				// Default export is a4 paper, portrait, using millimeters for units
-				const doc = new jsPDF();
-				var html = document.getElementById("p").innerHTML;
-
-				doc.text(html, 10, 10);
-				doc.save("a4.pdf");
-    		}
     	</script>
 
 	{% endblock %}

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -187,13 +187,17 @@
 </head>
 <body>
 	<nav class="navbar navbar-default">
-			<div class="container">
-					<div class="navbar-header">
-						<span class="navbar-brand">
-							Chanjo2 Report
-						</span>
-					</div>
+		<div class="container">
+			<div class="navbar-header">
+				<span class="navbar-brand">
+					Chanjo2 Report
+				</span>
 			</div>
+			<div class="nav navbar-nav navbar-right">
+				<span class="navbar"><button class="btn btn-default" onclick="createPDF()">PDF</button></span>
+			</div>
+
+		</div>
 	</nav>
 
 	<div class="container">
@@ -226,6 +230,8 @@
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 		<!-- Oldish compiled and minified JavaScript -->
 		<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+		<!-- jsPDF is used to download the report as a PDF document -->
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 
 		<script>
 			function toggle_visibility(ids)
@@ -240,6 +246,18 @@
 					}
 				}
 			}
+
+			function createPDF()
+			{
+				import { jsPDF } from "jspdf";
+
+				// Default export is a4 paper, portrait, using millimeters for units
+				const doc = new jsPDF();
+				var html = document.getElementById("p").innerHTML;
+
+				doc.text(html, 10, 10);
+				doc.save("a4.pdf");
+    		}
     	</script>
 
 	{% endblock %}

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -197,7 +197,7 @@
 	  </div><!-- /.container -->
 	</nav>
 
-	<div class="container" id="dvContainer">
+	<div class="container">
 
 		{{ report_filters() }}
 
@@ -218,6 +218,7 @@
 		{{ default_level_metrics() }}
 
 		<!--End of Quality report -->
+
 	</div>
 
 
@@ -226,6 +227,7 @@
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 		<!-- Oldish compiled and minified JavaScript -->
 		<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
 		<script>
 			function toggle_visibility(ids)
 			{


### PR DESCRIPTION
### This PR adds | fixes:
- Button to export coverage report to PDF

<img width="810" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/9e68470a-b6ff-4a99-b976-7a75e8e10ff3">


### How to test:
- Deploy on stage: https://chanjo2-stage.scilifelab.se/report/demo

### Expected outcome:
- [x] Export the demo report to PDF

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
