### PR TITLE
 Customize coverage report by changing settings in the customize form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Export coverage report to PDF
 - Metrics explanation section on coverage report
 - Non-demo coverage report endpoint
+- Fixed coverage report filters to update report using other settings
 ### Changed
 - Moved helper function from endpoints coverage to crud samples
 - Deleted unused `src/chanjo2/meta/handle_query_intervals.py` file

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -41,6 +41,16 @@ def set_samples_coverage_files(session: Session, samples: List[ReportQuerySample
             sample.coverage_file_path = sql_sample.coverage_file_path
 
 
+def _serialize_sample(sample: ReportQuerySample) -> Dict[str, str]:
+    """Convert a ReportQuerySample object to an easily serialized dictionary."""
+    return {
+        "name": sample.name,
+        "case_name": sample.case_name,
+        "coverage_file_path": sample.coverage_file_path,
+        "analysis_date": str(sample.analysis_date),
+    }
+
+
 def get_report_data(query: ReportQuery, session: Session) -> Dict:
     """Return the information that will be displayed in the coverage report."""
 
@@ -78,6 +88,7 @@ def get_report_data(query: ReportQuery, session: Session) -> Dict:
             "hgnc_gene_ids": [gene.hgnc_id for gene in genes],
             "build": query.build.value,
             "completeness_thresholds": query.completeness_thresholds,
+            "samples": [_serialize_sample(sample) for sample in query.samples],
         },
         "sex_rows": get_report_sex_rows(
             samples=query.samples, samples_d4_files=samples_d4_files

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -226,10 +226,10 @@ class ReportQuery(BaseModel):
     case_display_name: Optional[str]
 
     @validator("samples", pre=True)
-    def samples_validator(cls, value):
-        if isinstance(value, str):
-            return json.loads(value)
-        return value
+    def samples_validator(cls, sample_list):
+        if isinstance(sample_list, str):
+            return json.loads(sample_list)
+        return sample_list
 
 
 class SampleSexRow(BaseModel):

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -225,6 +225,12 @@ class ReportQuery(BaseModel):
     samples: List[ReportQuerySample]
     case_display_name: Optional[str]
 
+    @validator("samples", pre=True)
+    def samples_validator(cls, value):
+        if isinstance(value, str):
+            return json.loads(value)
+        return value
+
 
 class SampleSexRow(BaseModel):
     sample: str

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -24,7 +24,7 @@
 					  <div class="row" {% if hidden %}hidden{% endif %}>
 						<div class="col-xs-6">
 						  <label class="control-label">Completeness cutoff</label>
-						  <select class="form-control" name="default_level">
+						  <select class="form-control" name="default_level" id="default_level">
 							{% for level, _ in levels.items() %}
 							  <option value="{{ level }}" {% if level == extras.level %} selected {% endif %}>{{ level }}x</option>
 							{% endfor %}
@@ -33,7 +33,7 @@
 
 					<div class="col-xs-6">
 					  <label class="control-label">Gene panel name to <i>display</i></label>
-					  <input class="form-control" name="panel_name" type="text" placeholder="Skeletal dysplasia 3.2" value="{{ extras.panel_name or '' }}">
+					  <input class="form-control" id="panel_name" type="text" placeholder="Skeletal dysplasia 3.2" value="{{ extras.panel_name or '' }}">
 					</div>
 				  </div>
 				</div>
@@ -319,8 +319,8 @@
 					'completeness_thresholds' : {{ extras.completeness_thresholds }},
 					'hgnc_gene_ids' : getFormGeneIDsAsList(),
 					'interval_type' : '{{ extras.interval_type }}',
-					'panel_name' : '{{ extras.panel_name }}',
-					'default_level' : {{ extras.default_level }},
+					'panel_name' : document.getElementById("panel_name").value,
+					'default_level' : document.getElementById("default_level").value,
 					'case_display_name' : '{{ extras.case_name }}',
 					'samples' : {{ extras.samples|safe }},
 				}

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -16,7 +16,6 @@
 		</div>
 		<div id="view-filters" class="panel-collapse collapse">
 			<div class="panel-body">
-				<form method="POST" action="{{ url_for('report') }}" id="coverageForm")>
 					<!-- hidden fields passed from previous query -->
 					<input type="hidden" id="build" name="build" value="{{extras.build}}">
 					<input type="hidden" id="interval_type" name="interval_type" value="{{extras.interval_type}}">
@@ -43,7 +42,7 @@
 				  <div class="row" {% if hidden %}hidden{% endif %}>
 					<div class="col-xs-7">
 					  <label class="control-label">Included genes</label>
-					  <div><input class="form-control" type="text" name="hgnc_gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="ADK,GIT"></div>
+					  <div><input class="form-control" type="text" name="hgnc_gene_ids" id ="hgnc_gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="ADK,GIT"></div>
 					</div>
 
 					<div class="col-xs-3">
@@ -53,7 +52,7 @@
 
 					<div class="col-xs-2">
 					  <label class="control-label">&nbsp;</label>
-					  <button class="btn btn-default form-control" type="submit">Update</button>
+					  <button class="btn btn-default form-control" type="button" onclick="submitAsJson();">Update</button>
 					</div>
 				  </div>
 				</div>
@@ -63,7 +62,6 @@
 				{% endfor %}
 
 				</div>
-				</form>
 			</div>
 		</div>
 	</div>
@@ -245,7 +243,7 @@
 	  </div><!-- /.container -->
 	</nav>
 
-	<div class="container">
+	<div class="container" id="reportContent">
 
 		{{ report_filters() }}
 
@@ -301,22 +299,31 @@
 				}
 			}
 
-			var form = document.getElementById('coverageForm');
-			form.addEventListener("submit", function(event)
+			// Extracts the content of the body element of an HTML page as a string
+			function updatedReportBody(html)
+			{
+				return /<body.*?>([\s\S]*)<\/body>/.exec(html)[1];
+			}
+
+			// Returns the list of HGNC genes present in the user query as a sring as a list of integers
+			function getFormGeneIDsAsList()
+			{
+				return document.getElementById("hgnc_gene_ids").value.replace(/\s/g, '').split(",").map(Number);
+			}
+
+			function submitAsJson()
 			{
 				event.preventDefault();
 				let formDict = {
 					'build' : '{{ extras.build }}',
 					'completeness_thresholds' : {{ extras.completeness_thresholds }},
-					'hgnc_gene_ids' : {{ extras.hgnc_gene_ids }},
+					'hgnc_gene_ids' : getFormGeneIDsAsList(),
 					'interval_type' : '{{ extras.interval_type }}',
 					'panel_name' : '{{ extras.panel_name }}',
 					'default_level' : {{ extras.default_level }},
 					'case_display_name' : '{{ extras.case_name }}',
 					'samples' : {{ extras.samples|safe }},
 				}
-
-				console.log(formDict);
 
 				fetch('/report', {
                         method: 'POST',
@@ -325,14 +332,14 @@
                         },
                         body: JSON.stringify(formDict)
                     })
-                    .then(resp => resp.text())  // or, resp.json(), etc.
-                    .then(data => {
-                    	console.log(data);
+                    .then(resp => resp.text())
+                    .then(html => {
+                    	document.body.innerHTML = updatedReportBody(html);
                     })
                     .catch(error => {
                         console.error(error);
-                    });
-			});
+                });
+			}
 
     	</script>
 

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -243,7 +243,7 @@
 	  </div><!-- /.container -->
 	</nav>
 
-	<div class="container" id="reportContent">
+	<div class="container">
 
 		{{ report_filters() }}
 

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -301,6 +301,39 @@
 				}
 			}
 
+			var form = document.getElementById('coverageForm');
+			form.addEventListener("submit", function(event)
+			{
+				event.preventDefault();
+				let formDict = {
+					'build' : '{{ extras.build }}',
+					'completeness_thresholds' : {{ extras.completeness_thresholds }},
+					'hgnc_gene_ids' : {{ extras.hgnc_gene_ids }},
+					'interval_type' : '{{ extras.interval_type }}',
+					'panel_name' : '{{ extras.panel_name }}',
+					'default_level' : {{ extras.default_level }},
+					'case_display_name' : '{{ extras.case_name }}',
+					'samples' : {{ extras.samples|safe }},
+				}
+
+				console.log(formDict);
+
+				fetch('/report', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify(formDict)
+                    })
+                    .then(resp => resp.text())  // or, resp.json(), etc.
+                    .then(data => {
+                    	console.log(data);
+                    })
+                    .catch(error => {
+                        console.error(error);
+                    });
+			});
+
     	</script>
 
 	{% endblock %}


### PR DESCRIPTION
### This PR adds | fixes:
- Update report by changing settings in the filter form **- FINAL THING FOR THE REPORT! -** fix #155

Fixed customize report form to send data to report endpoint as json:

<img width="1231" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/efd4e228-fdda-40fa-9c9d-90a3ec27bd4e">


**How to prepare for test**:
- Deploy on cg-vm1

### How to test:
- Go to the demo report and modify it by changing the settings in the customise window (gene list, panel name, default threshold values)

### Expected outcome:
- [x] The report should update

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
