### PR TITLE
First basic demo gene coverage overview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Export coverage report to PDF
 - Metrics explanation section on coverage report
 - Non-demo coverage report endpoint
+- Genes overview endpoint
 ### Changed
 - Moved helper function from endpoints coverage to crud samples
 - Deleted unused `src/chanjo2/meta/handle_query_intervals.py` file

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -24,6 +24,7 @@ DEMO_SAMPLE: Dict[str, str] = {
 }
 
 HTTP_SERVER_D4_file = "https://d4-format-testing.s3.us-west-1.amazonaws.com/hg002.d4"
+DEMO_HGNC_GENE_SYMBOLS = ["MTHFR", "DHFR", "FOLR1", "SLC46A1", "LAMA1", "PIPPI6"]
 
 # Data for generating a demo coverage report
 DEMO_COVERAGE_QUERY_DATA = {
@@ -41,6 +42,21 @@ DEMO_COVERAGE_QUERY_DATA = {
     "interval_type": "transcripts",
     "ensembl_gene_ids": [],
     "hgnc_gene_ids": [],
-    "hgnc_gene_symbols": ["MTHFR", "DHFR", "FOLR1", "SLC46A1", "LAMA1", "PIPPI6"],
+    "hgnc_gene_symbols": DEMO_HGNC_GENE_SYMBOLS,
+    "default_level": 20,
+}
+
+DEMO_OVERVIEW_QUERY_DATA = {
+    "build": BUILD_37,
+    "samples": [
+        {
+            "name": DEMO_SAMPLE["name"],
+            "coverage_file_path": d4_demo_path,
+        }
+    ],
+    "interval_type": "transcripts",
+    "ensembl_gene_ids": [],
+    "hgnc_gene_ids": [],
+    "hgnc_gene_symbols": DEMO_HGNC_GENE_SYMBOLS,
     "default_level": 20,
 }

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -31,7 +31,6 @@ async def demo_overview(request: Request, db: Session = Depends(get_session)):
         "overview.html",
         {
             "request": request,
-            "levels": overview_content["levels"],
             "extras": overview_content["extras"],
         },
     )

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -15,7 +15,7 @@ def get_templates_path() -> str:
     return path.join(APP_ROOT, "templates")
 
 
-templates: Jinja2Templates = Jinja2Templates(directory=get_templates_path())
+templates = Jinja2Templates(directory=get_templates_path())
 router = APIRouter()
 
 

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -24,7 +24,7 @@ async def demo_overview(request: Request):
     """Return a demo genes overview page over a list of genes for a list of samples."""
 
     overview_query = GeneralReportQuery(**DEMO_OVERVIEW_QUERY_DATA)
-    overview_content: Dict = get_overview_data(query=overview_query)
+    overview_content: dict = get_overview_data(query=overview_query)
     return templates.TemplateResponse(
         "overview.html",
         {

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -1,0 +1,37 @@
+from os import path
+
+from fastapi import APIRouter, Request, Depends
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
+from sqlmodel import Session
+
+from chanjo2.dbutil import get_session
+from chanjo2.demo import DEMO_OVERVIEW_QUERY_DATA
+from chanjo2.meta.handle_overview_content import get_overview_data
+from chanjo2.models.pydantic_models import GeneralReportQuery
+
+
+def get_templates_path() -> str:
+    """Returns the absolute path to the templates folder of this app."""
+    APP_ROOT: str = path.abspath(path.join(path.dirname(__file__), ".."))
+    return path.join(APP_ROOT, "templates")
+
+
+templates: Jinja2Templates = Jinja2Templates(directory=get_templates_path())
+router = APIRouter()
+
+
+@router.get("/overview/demo", response_class=HTMLResponse)
+async def demo_overview(request: Request, db: Session = Depends(get_session)):
+    """Return a demo genes overview page over a list of genes for a list of samples."""
+
+    overview_query = GeneralReportQuery(**DEMO_OVERVIEW_QUERY_DATA)
+    overview_content: Dict = get_overview_data(query=overview_query, session=db)
+    return templates.TemplateResponse(
+        "overview.html",
+        {
+            "request": request,
+            "levels": overview_content["levels"],
+            "extras": overview_content["extras"],
+        },
+    )

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -1,11 +1,9 @@
 from os import path
 
-from fastapi import APIRouter, Request, Depends
+from fastapi import APIRouter, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
-from sqlmodel import Session
 
-from chanjo2.dbutil import get_session
 from chanjo2.demo import DEMO_OVERVIEW_QUERY_DATA
 from chanjo2.meta.handle_overview_content import get_overview_data
 from chanjo2.models.pydantic_models import GeneralReportQuery
@@ -22,11 +20,11 @@ router = APIRouter()
 
 
 @router.get("/overview/demo", response_class=HTMLResponse)
-async def demo_overview(request: Request, db: Session = Depends(get_session)):
+async def demo_overview(request: Request):
     """Return a demo genes overview page over a list of genes for a list of samples."""
 
     overview_query = GeneralReportQuery(**DEMO_OVERVIEW_QUERY_DATA)
-    overview_content: Dict = get_overview_data(query=overview_query, session=db)
+    overview_content: Dict = get_overview_data(query=overview_query)
     return templates.TemplateResponse(
         "overview.html",
         {

--- a/src/chanjo2/main.py
+++ b/src/chanjo2/main.py
@@ -8,7 +8,7 @@ from fastapi.staticfiles import StaticFiles
 
 from chanjo2 import __version__
 from chanjo2.dbutil import engine
-from chanjo2.endpoints import cases, intervals, samples, coverage, report
+from chanjo2.endpoints import cases, intervals, samples, coverage, report, overview
 from chanjo2.models.sql_models import Base
 from chanjo2.populate_demo import load_demo_data
 
@@ -19,6 +19,7 @@ APP_ROUTER_TAGS: List[Tuple] = [
     (cases.router, "cases"),
     (samples.router, "samples"),
     (report.router, "report"),
+    (overview.router, "overview"),
 ]
 
 

--- a/src/chanjo2/meta/handle_overview_content.py
+++ b/src/chanjo2/meta/handle_overview_content.py
@@ -3,7 +3,7 @@ from typing import Dict
 from chanjo2.models.pydantic_models import GeneralReportQuery
 
 
-def get_overview_data(query: GeneralReportQuery) -> Dict:
+def get_overview_data(query: GeneralReportQuery) -> dict:
     """Return the information that will be displayed in the coverage overview page."""
 
     return {

--- a/src/chanjo2/meta/handle_overview_content.py
+++ b/src/chanjo2/meta/handle_overview_content.py
@@ -1,11 +1,9 @@
 from typing import Dict
 
-from sqlmodel import Session
-
 from chanjo2.models.pydantic_models import GeneralReportQuery
 
 
-def get_overview_data(query: GeneralReportQuery, session: Session) -> Dict:
+def get_overview_data(query: GeneralReportQuery) -> Dict:
     """Return the information that will be displayed in the coverage overview page."""
 
     data: Dict = {

--- a/src/chanjo2/meta/handle_overview_content.py
+++ b/src/chanjo2/meta/handle_overview_content.py
@@ -1,0 +1,23 @@
+from typing import Dict
+
+from sqlmodel import Session
+
+from chanjo2.meta.handle_report_contents import get_ordered_levels
+from chanjo2.models.pydantic_models import GeneralReportQuery
+
+
+def get_overview_data(query: GeneralReportQuery, session: Session) -> Dict:
+    """Return the information that will be displayed in the coverage overview page."""
+
+    data: Dict = {
+        "levels": get_ordered_levels(threshold_levels=query.completeness_thresholds),
+        "extras": {
+            "default_level": query.default_level,
+            "interval_type": query.interval_type.value,
+            "samples": [
+                {"name": sample.name, "coverage_file_path": sample.coverage_file_path}
+                for sample in query.samples
+            ],
+        },
+    }
+    return data

--- a/src/chanjo2/meta/handle_overview_content.py
+++ b/src/chanjo2/meta/handle_overview_content.py
@@ -2,7 +2,6 @@ from typing import Dict
 
 from sqlmodel import Session
 
-from chanjo2.meta.handle_report_contents import get_ordered_levels
 from chanjo2.models.pydantic_models import GeneralReportQuery
 
 
@@ -10,9 +9,7 @@ def get_overview_data(query: GeneralReportQuery, session: Session) -> Dict:
     """Return the information that will be displayed in the coverage overview page."""
 
     data: Dict = {
-        "levels": get_ordered_levels(threshold_levels=query.completeness_thresholds),
         "extras": {
-            "default_level": query.default_level,
             "interval_type": query.interval_type.value,
             "samples": [
                 {"name": sample.name, "coverage_file_path": sample.coverage_file_path}

--- a/src/chanjo2/meta/handle_overview_content.py
+++ b/src/chanjo2/meta/handle_overview_content.py
@@ -6,7 +6,7 @@ from chanjo2.models.pydantic_models import GeneralReportQuery
 def get_overview_data(query: GeneralReportQuery) -> Dict:
     """Return the information that will be displayed in the coverage overview page."""
 
-    data: Dict = {
+    return {
         "extras": {
             "interval_type": query.interval_type.value,
             "samples": [
@@ -15,4 +15,3 @@ def get_overview_data(query: GeneralReportQuery) -> Dict:
             ],
         },
     }
-    return data

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -202,28 +202,37 @@ class SampleGeneIntervalQuery(BaseModel):
         return values
 
 
-### Coverage report - related models ###
+## Coverage overview report - related models ###
 
 
-class ReportQuerySample(BaseModel):
+class GeneralReportQuerySample(BaseModel):
     name: str
-    case_name: Optional[str]
     coverage_file_path: Optional[str]
-    analysis_date: Optional[datetime] = datetime.now()
 
 
-class ReportQuery(BaseModel):
+class GeneralReportQuery(BaseModel):
     build: Builds
     completeness_thresholds: Optional[List[int]] = DEFAULT_COMPLETENESS_LEVELS
     ensembl_gene_ids: Optional[List[str]]
     hgnc_gene_ids: Optional[List[int]]
     hgnc_gene_symbols: Optional[List[str]]
     interval_type: IntervalType
-    panel_name: Optional[str] = "Custom panel"
     default_level: int = 10
+    samples: List[GeneralReportQuerySample]
 
-    samples: List[ReportQuerySample]
+
+### Coverage report - related models ###
+
+
+class ReportQuerySample(GeneralReportQuerySample):
+    case_name: Optional[str]
+    analysis_date: Optional[datetime] = datetime.now()
+
+
+class ReportQuery(GeneralReportQuery):
+    panel_name: Optional[str] = "Custom panel"
     case_display_name: Optional[str]
+    samples: List[ReportQuerySample]
 
 
 class SampleSexRow(BaseModel):

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+	<title>Chanjo2 genes coverage overview</title>
+
+	<meta name="description" content="Chanjo2 Report: coverage report generator">
+	<meta name="author" content="Chiara Rasi">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<!-- place 'favicon.ico' + 'apple-touch-icon.png' in the root directory -->
+	<link rel="Shortcut Icon"
+				href="#"
+				type="image/x-icon">
+
+	{% block css %}
+		<!-- Oldish compiled and minified CSS -->
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+
+		<!-- Customizations -->
+		<link rel="stylesheet" type="text/css" href="{{ url_for('static', path='main.css') }}">
+	{% endblock %}
+
+	{% block css_style %}{% endblock %}
+
+</head>
+<body>
+
+	<nav class="navbar navbar-default">
+	  <div class="container">
+		<div class="navbar-header">
+		  <a class="navbar-brand" href="#">Chanjo2 report</a>
+		</div>
+	  </div><!-- /.container -->
+	</nav>
+
+	<div class="container">
+		<div class="row">
+		<div class="col-md-12">
+			<div class="panel panel-default">
+				<div class="panel-heading">
+					<h4>Incomplete {{ extras.interval_type }}</h4>
+				</div>
+				<ul class="list-group">
+					<li class="list-group-item">
+						Samples:
+						{% for sample in extras.samples %}
+							<strong>{{ sample.name }}</strong>
+						{% endfor %}
+					</li>
+				</ul>
+			</div>
+		</div>
+	</div>
+	</div>
+
+
+	{% block js_code %}
+		<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+		<!-- Oldish compiled and minified JavaScript -->
+		<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+	{% endblock %}
+</body>
+</html>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ class Endpoints(str):
     SAMPLE_EXONS_COVERAGE = "/coverage/samples/exons_coverage"
     REPORT_DEMO = "/report/demo/"
     REPORT = "/report"
+    OVERVIEW_DEMO = "/overview/demo/"
 
 
 @pytest.fixture

--- a/tests/src/chanjo2/endpoints/test_overviiew.py
+++ b/tests/src/chanjo2/endpoints/test_overviiew.py
@@ -1,0 +1,18 @@
+from typing import Type
+
+from fastapi import status
+from fastapi.testclient import TestClient
+from requests.models import Response
+
+
+def test_demo_overview(client: TestClient, endpoints: Type):
+    """Test the endpoint that creates the genes coverage overview page for the demo sample."""
+
+    # GIVEN a query to the demo overview endpoint
+    response: Response = client.get(endpoints.OVERVIEW_DEMO)
+
+    # Then the request should be successful
+    assert response.status_code == status.HTTP_200_OK
+
+    # And return an HTML page
+    assert response.template.name == "overview.html"


### PR DESCRIPTION
### This PR adds | fixes:
- Adds a demo gene coverage overview page, so far without coverage stats:

<img width="1380" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/a27b62cd-364d-44d4-86ae-ada8188fb055">

This page will look like like this: https://scout-stage.scilifelab.se/reports/genes?level=10&sample_id=ADM1059A4&sample_id=ADM1059A5&sample_id=ADM1059A6

**How to prepare for test**:
- Deploy on cg-vm1 stage

### How to test:
- Go to the demo overview: https://chanjo2-stage.scilifelab.se/overview/demo

### Expected outcome:
- [x] The web page should show up

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
