### PR TITLE
Non-demo genes overview and change its stats when changing the coverage level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 - Metrics explanation section on coverage report
 - Non-demo coverage report endpoint
 - Fixed coverage report filters to update report using other settings
-- Demo genes overview endpoint
-- Incomplete intervals at different coverage thresholds on demo genes overview page
+- Demo and non-demo genes overview endpoint
+- Incomplete intervals at different coverage thresholds on genes overview page
 ### Changed
 - Moved helper function from endpoints coverage to crud samples
 - Deleted unused `src/chanjo2/meta/handle_query_intervals.py` file

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -38,3 +38,23 @@ async def demo_overview(request: Request, db: Session = Depends(get_session)):
             "incomplete_coverage_rows": overview_content["incomplete_coverage_rows"],
         },
     )
+
+
+@router.post("/overview", response_class=HTMLResponse)
+async def overview(
+    request: Request, report_query: ReportQuery, db: Session = Depends(get_session)
+):
+    """Return the genes overview page over a list of genes for a list of samples."""
+
+    overview_content: dict = get_report_data(
+        query=report_query, session=db, is_overview_report=True
+    )
+    return templates.TemplateResponse(
+        "overview.html",
+        {
+            "request": request,
+            "extras": overview_content["extras"],
+            "levels": overview_content["levels"],
+            "incomplete_coverage_rows": overview_content["incomplete_coverage_rows"],
+        },
+    )

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -4,7 +4,7 @@
 			<ul class="nav nav-pills">
 				{% for level_id, _ in levels.items() %}
 					<li {% if level_id == extras.default_level %}class="active"{% endif %}>
-						<a href="#" onclick="setDivVisibily({{level_id}});">
+						<a href="#" onclick="updateOverview({{level_id}});">
 							Completeness {{ level_id }}x
 						</a>
 					</li>
@@ -123,6 +123,42 @@
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 		<!-- Oldish compiled and minified JavaScript -->
 		<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+		<script>
+
+			// Extracts the content of the body element of an HTML page as a string
+			function updatedReportBody(html)
+			{
+				return /<body.*?>([\s\S]*)<\/body>/.exec(html)[1];
+			}
+
+			function updateOverview(customLevel)
+			{
+				let formDict = {
+					'build' : '{{ extras.build }}',
+					'completeness_thresholds' : {{ extras.completeness_thresholds }},
+					'hgnc_gene_ids' : {{ extras.hgnc_gene_ids }},
+					'interval_type' : '{{ extras.interval_type }}',
+					'default_level' : customLevel,
+					'samples' : {{ extras.samples|safe }},
+				}
+
+				fetch('{{url_for("overview")}}', {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify(formDict)
+                    })
+                    .then(resp => resp.text())
+                    .then(html => {
+                    	document.body.innerHTML = updatedReportBody(html);
+                    })
+                    .catch(error => {
+                        console.error(error);
+                });
+			}
+		</script>
 	{% endblock %}
 </body>
 </html>

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -143,7 +143,7 @@
 					'samples' : {{ extras.samples|safe }},
 				}
 
-				fetch('{{url_for("overview")}}', {
+				fetch('/overview', {
                         method: 'POST',
                         headers: {
                             'Content-Type': 'application/json'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ class Endpoints(str):
     SAMPLE_EXONS_COVERAGE = "/coverage/samples/exons_coverage"
     REPORT_DEMO = "/report/demo/"
     REPORT = "/report"
+    OVERVIEW = "/overview"
     OVERVIEW_DEMO = "/overview/demo/"
 
 

--- a/tests/src/chanjo2/endpoints/test_overview.py
+++ b/tests/src/chanjo2/endpoints/test_overview.py
@@ -4,12 +4,30 @@ from fastapi import status
 from fastapi.testclient import TestClient
 from requests.models import Response
 
+from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA
+
 
 def test_demo_overview(client: TestClient, endpoints: Type):
     """Test the endpoint that creates the genes coverage overview page for the demo sample."""
 
-    # GIVEN a query to the demo overview endpoint
+    # GIVEN a query to the demo genes coverage overview endpoint
     response: Response = client.get(endpoints.OVERVIEW_DEMO)
+
+    # Then the request should be successful
+    assert response.status_code == status.HTTP_200_OK
+
+    # And return an HTML page
+    assert response.template.name == "overview.html"
+
+
+def test_overview_json_data(client: TestClient, endpoints: Type):
+    """Test the endpoint that creates the genes coverage overview page by providing json data in POST request."""
+
+    # GIVEN a query with json data to the genes coverage overview endpoint
+    response: Response = client.post(
+        endpoints.OVERVIEW,
+        json=DEMO_COVERAGE_QUERY_DATA,
+    )
 
     # Then the request should be successful
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
### This PR adds | fixes:
- New genes overview (non-demo) page
- Try displaying different overview stats by changing the coverage completeness in these links:

<img width="987" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/8e009019-b88f-4bef-b9b9-cc9171d9e77f">


**How to prepare for test**:
- Deploy on stage 

### How to test:
- Go to demo page: https://chanjo2-stage.scilifelab.se/overview/demo
- Change coverage completeness level

### Expected outcome:
- [x] The page stats should update

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
