### PR TITLE
Gene overview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 - Metrics explanation section on coverage report
 - Non-demo coverage report endpoint
 - Fixed coverage report filters to update report using other settings
-- Demo and non-demo genes overview endpoint
+- Demo and non-demo genes coverage overview endpoint
 - Incomplete intervals at different coverage thresholds on genes overview page
+- Gene coverage overview endpoint
 ### Changed
 - Moved helper function from endpoints coverage to crud samples
 - Deleted unused `src/chanjo2/meta/handle_query_intervals.py` file

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -114,6 +114,16 @@ def bulk_insert_transcripts(db: Session, transcripts: List[TranscriptBase]):
     db.commit()
 
 
+def get_hgnc_gene(db: Session, build: Builds, hgnc_id: int) -> SQLGene:
+    """Return a gene object by its HGNC ID."""
+    gene_query: query.Query = (
+        db.query(SQLGene)
+        .filter(SQLGene.hgnc_id == hgnc_id)
+        .filter(SQLGene.build == build)
+    )
+    return gene_query.first()
+
+
 def get_gene_intervals(
     db: Session,
     build: Builds,

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -1,14 +1,18 @@
+import logging
 from os import path
 
 from fastapi import APIRouter, Request, Depends
+from fastapi import Form
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from sqlmodel import Session
 
 from chanjo2.dbutil import get_session
 from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA
-from chanjo2.meta.handle_report_contents import get_report_data
-from chanjo2.models.pydantic_models import ReportQuery
+from chanjo2.meta.handle_report_contents import get_report_data, get_gene_overview_data
+from chanjo2.models.pydantic_models import ReportQuery, GeneReportForm
+
+LOG = logging.getLogger("uvicorn.access")
 
 
 def get_templates_path() -> str:
@@ -56,5 +60,41 @@ async def overview(
             "extras": overview_content["extras"],
             "levels": overview_content["levels"],
             "incomplete_coverage_rows": overview_content["incomplete_coverage_rows"],
+        },
+    )
+
+
+@router.post("/gene-overview", response_class=HTMLResponse)
+async def gene_overview(
+    request: Request,
+    build: str = Form(...),
+    default_level: int = Form(...),
+    completeness_thresholds: str = Form(...),
+    samples: str = Form(...),
+    hgnc_gene_id: int = Form(...),
+    interval_type: str = Form(...),
+    db: Session = Depends(get_session),
+):
+    """Returns coverage overview stats for a group of samples over genomic intervals of a single gene."""
+
+    form_data = GeneReportForm(
+        build=build,
+        default_level=default_level,
+        completeness_thresholds=completeness_thresholds,
+        samples=samples,
+        hgnc_gene_id=hgnc_gene_id,
+        interval_type=interval_type,
+    )
+
+    gene_overview_content: dict = get_gene_overview_data(
+        form_data=form_data, session=db
+    )
+
+    LOG.warning(gene_overview_content)
+
+    return templates.TemplateResponse(
+        "gene-overview.html",
+        {
+            "request": request,
         },
     )

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -10,7 +10,7 @@ from sqlmodel import Session
 from chanjo2.dbutil import get_session
 from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA
 from chanjo2.meta.handle_report_contents import get_report_data, get_gene_overview_data
-from chanjo2.models.pydantic_models import ReportQuery, GeneReportForm
+from chanjo2.models.pydantic_models import ReportQuery, GeneReportForm, GeneCoverage
 
 LOG = logging.getLogger("uvicorn.access")
 
@@ -86,15 +86,19 @@ async def gene_overview(
         interval_type=interval_type,
     )
 
-    gene_overview_content: dict = get_gene_overview_data(
+    gene_overview_content: Dict[str, List[GeneCoverage]] = get_gene_overview_data(
         form_data=form_data, session=db
     )
-
-    LOG.warning(gene_overview_content)
 
     return templates.TemplateResponse(
         "gene-overview.html",
         {
             "request": request,
+            "interval_type": gene_overview_content["interval_type"],
+            "gene": gene_overview_content["gene"],
+            "interval_coverage_stats": gene_overview_content[
+                "samples_coverage_stats_by_interval"
+            ],
+            "levels": gene_overview_content["levels"],
         },
     )

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -65,7 +65,7 @@ async def overview(
     )
 
 
-@router.post("/gene-overview", response_class=HTMLResponse)
+@router.post("/gene_overview", response_class=HTMLResponse)
 async def gene_overview(
     request: Request,
     db: Session = Depends(get_session),
@@ -84,10 +84,10 @@ async def gene_overview(
         {
             "request": request,
             "interval_type": gene_overview_content["interval_type"],
-            "gene": gene_overview_content["gene"],
-            "interval_coverage_stats": gene_overview_content[
+            "gene": gene_overview_content.get("gene"),
+            "interval_coverage_stats": gene_overview_content.get(
                 "samples_coverage_stats_by_interval"
-            ],
+            ),
             "levels": gene_overview_content["levels"],
         },
     )

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -10,7 +10,10 @@ from starlette.datastructures import FormData
 
 from chanjo2.dbutil import get_session
 from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA
-from chanjo2.meta.handle_report_contents import get_report_data, get_gene_overview_data
+from chanjo2.meta.handle_report_contents import (
+    get_report_data,
+    get_gene_overview_coverage_stats,
+)
 from chanjo2.models.pydantic_models import ReportQuery, GeneReportForm, GeneCoverage
 
 LOG = logging.getLogger("uvicorn.access")
@@ -75,9 +78,9 @@ async def gene_overview(
     form_dict: dict = jsonable_encoder(form_data)
     validated_form = GeneReportForm(**form_dict)
 
-    gene_overview_content: Dict[str, List[GeneCoverage]] = get_gene_overview_data(
-        form_data=validated_form, session=db
-    )
+    gene_overview_content: Dict[
+        str, List[GeneCoverage]
+    ] = get_gene_overview_coverage_stats(form_data=validated_form, session=db)
 
     return templates.TemplateResponse(
         "gene-overview.html",

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -363,7 +363,7 @@ def get_gene_overview_data(form_data: GeneReportForm, session: Session):
 
 def get_gene_coverage_stats_by_interval(
     coverage_by_sample: Dict[str, List[GeneCoverage]]
-):
+) -> Dict[str, List[Tuple]]:
     """Arrange coverage stats by interval id instead of by sample."""
 
     intervals_stats: Dict[str, List] = {}

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -325,7 +325,7 @@ def get_genes_overview_incomplete_coverage_rows(
 #### Functions used to create a gene overview report ####
 
 
-def get_gene_overview_data(form_data: GeneReportForm, session: Session):
+def get_gene_overview_coverage_stats(form_data: GeneReportForm, session: Session):
     """Returns coverage stats over the intervals sof one gene for one or more samples."""
 
     gene_stats = {

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Tuple, Union, Set, Optional
 from pyd4 import D4File
 from sqlmodel import Session
 
-from chanjo2.crud.intervals import get_genes
+from chanjo2.crud.intervals import get_genes, get_hgnc_gene
 from chanjo2.crud.samples import get_sample
 from chanjo2.meta.handle_d4 import get_samples_sex_metrics, get_sample_interval_coverage
 from chanjo2.models.pydantic_models import (
@@ -15,6 +15,7 @@ from chanjo2.models.pydantic_models import (
     SampleSexRow,
     GeneCoverage,
     IntervalType,
+    GeneReportForm,
 )
 from chanjo2.models.sql_models import Exon as SQLExon
 from chanjo2.models.sql_models import Gene as SQLGene
@@ -262,11 +263,11 @@ def get_report_sex_rows(
 
 
 def _get_incomplete_gene_coverage_overview_line(
-    gene: Union[str, int], interval_id: str, sample: str, completeness: float
+    hgnc_symbol: str, hgnc_id: int, interval_id: str, sample: str, completeness: float
 ) -> Optional[Tuple[Union[str, int, float]]]:
     """Return a gene overview report line if the interval is not fully covered at the given threshold."""
     if completeness < 1:
-        return (str(gene), interval_id, sample, round(completeness, 2))
+        return (hgnc_symbol, hgnc_id, interval_id, sample, round(completeness, 2))
 
 
 def _remove_none_elements(tuple_list: List[Tuple] = []) -> List[Tuple]:
@@ -292,7 +293,8 @@ def get_genes_overview_incomplete_coverage_rows(
                 overview_line: Optional[
                     List[str]
                 ] = _get_incomplete_gene_coverage_overview_line(
-                    gene=gene_cov_stats.hgnc_symbol or gene_cov_stats.hgnc_id,
+                    hgnc_symbol=gene_cov_stats.hgnc_symbol,
+                    hgnc_id=gene_cov_stats.hgnc_id,
                     interval_id=gene_cov_stats.hgnc_id,
                     sample=sample_name,
                     completeness=completeness_at_level,
@@ -308,7 +310,8 @@ def get_genes_overview_incomplete_coverage_rows(
                     overview_line: Optional[
                         List[str]
                     ] = _get_incomplete_gene_coverage_overview_line(
-                        gene=gene_cov_stats.hgnc_symbol or gene_cov_stats.hgnc_id,
+                        hgnc_symbol=gene_cov_stats.hgnc_symbol,
+                        hgnc_id=gene_cov_stats.hgnc_id,
                         interval_id=inner_interval_stats.interval_id,
                         sample=sample_name,
                         completeness=completeness_at_level,
@@ -317,3 +320,33 @@ def get_genes_overview_incomplete_coverage_rows(
                     genes_overview_rows.append(overview_line)
 
     return _remove_none_elements(tuple_list=genes_overview_rows)
+
+
+#### Functions used to create a gene overview report ####
+
+
+def get_gene_overview_data(form_data: GeneReportForm, session: Session):
+    """Returns coverage stats over the intervals sof one gene for one or more samples."""
+
+    set_samples_coverage_files(session=session, samples=form_data.samples)
+
+    samples_d4_files: List[Tuple[str, D4File]] = [
+        (sample.name, D4File(sample.coverage_file_path)) for sample in form_data.samples
+    ]
+
+    gene: SQLGene = get_hgnc_gene(
+        build=form_data.build, hgnc_id=form_data.hgnc_gene_id, db=session
+    )
+
+    samples_coverage_stats: Dict[str, List[GeneCoverage]] = {
+        sample: get_sample_interval_coverage(
+            db=session,
+            d4_file=d4_file,
+            genes=[gene],
+            interval_type=INTERVAL_TYPE_SQL_TYPE[form_data.interval_type],
+            completeness_thresholds=form_data.completeness_thresholds,
+        )
+        for sample, d4_file in samples_d4_files
+    }
+
+    return samples_coverage_stats

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -1,0 +1,89 @@
+{% macro gene_stats_macro() %}
+<div class="container">
+	<h2>Gene: {{ gene.hgnc_symbol or gene.hgnc_id }}</h2>
+	<br>
+	{% for interval_id, samples_stats in interval_coverage_stats.items() %}
+	<tr>
+		<td class="row">
+			<div class="panel-default">
+				<div class="panel-heading">
+					{{ interval_type }}: <strong>{{ interval_id }}</strong>
+				</div>
+			</div>
+			<div class="table-responsive">
+				<table class="table table-bordered">
+					<thead>
+						<th>Sample</th>
+						<th>Mean coverage</th>
+						{% for level, _ in levels.items() %}
+							<th>Completeness {{ level }}x [%]</th>
+						{% endfor %}
+					</thead>
+					<tbody>
+					{% for sample_stats in samples_stats %}
+						<td>{{ sample_stats[0] }}</td>
+						<td>{{ (sample_stats[1] * 100)|round(2) }}</td>
+						{% for level, _ in levels.items() %}
+							<td>{{ (sample_stats[2][level] * 100)|round(2) }}</td>
+						{% endfor %}
+					{% endfor %}
+					</tbody>
+				</table>
+			</div>
+		</td>
+	</tr>
+	<br>
+	{% endfor %}
+
+
+
+</div>
+{% endmacro %}
+
+<!DOCTYPE html>
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+	<title>Chanjo2 gene coverage overview</title>
+
+	<meta name="description" content="Chanjo2 Report: coverage report generator">
+	<meta name="author" content="Chiara Rasi">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+
+	<!-- place 'favicon.ico' + 'apple-touch-icon.png' in the root directory -->
+	<link rel="Shortcut Icon"
+				href="#"
+				type="image/x-icon">
+
+	{% block css %}
+		<!-- Oldish compiled and minified CSS -->
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+
+		<!-- Customizations -->
+		<link rel="stylesheet" type="text/css" href="{{ url_for('static', path='main.css') }}">
+	{% endblock %}
+
+	{% block css_style %}{% endblock %}
+
+</head>
+<body>
+	<nav class="navbar navbar-default">
+	  <div class="container">
+		<div class="navbar-header">
+		  <a class="navbar-brand" href="#">Chanjo2 report</a>
+		</div>
+	  </div><!-- /.container -->
+	</nav>
+
+{{ gene_stats_macro() }}
+
+{% block js_code %}
+	<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+	<!-- Oldish compiled and minified JavaScript -->
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+{% endblock %}
+</body>
+</html>

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -12,6 +12,7 @@
 			</div>
 			<div class="table-responsive">
 				<table class="table table-bordered">
+					<caption>Coverage overview over gene {{ gene.hgnc_symbol or gene.hgnc_id }}</caption>
 					<thead>
 						<th>Sample</th>
 						<th>Mean coverage</th>

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -56,7 +56,7 @@
 			</table>
 		</div>
 	</div>
-<
+
 	{{samples_coverage_stats}}
 
 {% endmacro %}

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -16,7 +16,13 @@
 
 
 {% macro incompletely_covered_intervals(active_level) %}
-
+ <form id="geneStatsForm" action="{{url_for('gene_overview')}}" method="post">
+	 <input type="hidden" name="build" value="{{extras.build}}"/>
+	 <input type="hidden" name="default_level" value="{{extras.default_level}}"/>
+	 <input type="hidden" name="completeness_thresholds" value="{{extras.completeness_thresholds|join(',')}}"/>
+	 <input type="hidden" name="samples" value="{{extras.samples|safe}}"/>
+	 <input type="hidden" name="interval_type" value="{{extras.interval_type}}"/>
+</form>
 	<div class="row">
 		<div class="col-md-12">
 			<table class="table table-bordered">
@@ -33,13 +39,13 @@
 					{% for row in incomplete_coverage_rows %}
 						<tr>
 							<td>
-								<a href="#">
-									{{ row[0] or row[1] }}
+								<a href="#" onclick="getGeneStatsPage({{row[1]}});" target="_blank" rel="noopener">
+									{{row[0]}}
 								</a>
 							</td>
-							<td>{{ row[1] }}</td>
 							<td>{{ row[2] }}</td>
-							<td class="text-right">{{ row[3] }}</td>
+							<td>{{ row[3] }}</td>
+							<td class="text-right">{{ row[4] }}</td>
 						</tr>
 					{% else %}
 						<tr>
@@ -50,10 +56,10 @@
 			</table>
 		</div>
 	</div>
+<
 	{{samples_coverage_stats}}
+
 {% endmacro %}
-
-
 
 
 <!DOCTYPE html>
@@ -159,6 +165,20 @@
                         console.error(error);
                 });
 			}
+
+
+			function getGeneStatsPage(hgncId)
+			{
+				event.preventDefault();
+				var theForm = document.getElementById("geneStatsForm");
+				var geneInput = document.createElement("input");
+				geneInput.setAttribute("type", "hidden");
+				geneInput.setAttribute("name", "hgnc_gene_id");
+				geneInput.setAttribute("value", hgncId);
+				theForm.appendChild(geneInput);
+				theForm.submit();
+			}
+
 		</script>
 	{% endblock %}
 </body>

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -347,9 +347,3 @@
 	{% endblock %}
 </body>
 </html>
-
-
-
-
-{% macro explanation_block() %}
-{% endmacro %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ class Endpoints(str):
     SAMPLE_EXONS_COVERAGE = "/coverage/samples/exons_coverage"
     REPORT_DEMO = "/report/demo/"
     REPORT = "/report"
+    GENE_OVERVIEW = "/gene_overview"
     OVERVIEW = "/overview"
     OVERVIEW_DEMO = "/overview/demo/"
 

--- a/tests/src/chanjo2/endpoints/test_overview.py
+++ b/tests/src/chanjo2/endpoints/test_overview.py
@@ -1,9 +1,10 @@
-from typing import Type
+from typing import Type, Dict, List
 
 from fastapi import status
 from fastapi.testclient import TestClient
 from requests.models import Response
 
+from chanjo2.constants import BUILD_37, DEFAULT_COMPLETENESS_LEVELS
 from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA
 
 
@@ -34,3 +35,31 @@ def test_overview_json_data(client: TestClient, endpoints: Type):
 
     # And return an HTML page
     assert response.template.name == "overview.html"
+
+
+def test_gene_overview(
+    client: TestClient, endpoints: Type, genomic_ids_per_build: Dict[str, List]
+):
+    """Test the endpoint that show coverage overview over the intervals of a single gene."""
+
+    # GIVEN a POST request containing form data:
+    form_data = {
+        "build": BUILD_37,
+        "completeness_thresholds": DEFAULT_COMPLETENESS_LEVELS,
+        "hgnc_gene_id": genomic_ids_per_build[BUILD_37]["hgnc_ids"][0],
+        "default_level": 10,
+        "samples": str(DEMO_COVERAGE_QUERY_DATA["samples"]),
+        "interval_type": "transcripts",
+    }
+
+    response: Response = client.post(
+        endpoints.GENE_OVERVIEW,
+        data=form_data,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    # Then the request should be successful
+    assert response.status_code == status.HTTP_200_OK
+
+    # And return an HTML page
+    assert response.template.name == "gene-overview.html"

--- a/tests/src/chanjo2/meta/test_handle_report_contents.py
+++ b/tests/src/chanjo2/meta/test_handle_report_contents.py
@@ -135,8 +135,15 @@ def test_get_genes_overview_incomplete_coverage_rows(
     )
 
     # THEN each transcript line should contain the expected values
-    for gene, transcript_id, sample, completeness in genes_overview_lines:
-        assert isinstance(gene, str)
+    for (
+        gene_symbol,
+        gene_hgnc_id,
+        transcript_id,
+        sample,
+        completeness,
+    ) in genes_overview_lines:
+        assert isinstance(gene_symbol, str)
+        assert isinstance(gene_hgnc_id, int)
         assert isinstance(transcript_id, str)
         assert sample == samples_d4_list[0][0]
         assert completeness < 1

--- a/tests/src/chanjo2/meta/test_handle_report_contents.py
+++ b/tests/src/chanjo2/meta/test_handle_report_contents.py
@@ -11,6 +11,7 @@ from chanjo2.meta.handle_report_contents import (
     get_report_completeness_rows,
     get_missing_genes_from_db,
     get_genes_overview_incomplete_coverage_rows,
+    get_gene_coverage_stats_by_interval,
 )
 from chanjo2.models.sql_models import Gene as SQLGene
 from chanjo2.models.sql_models import Transcript as SQLTranscript
@@ -147,3 +148,39 @@ def test_get_genes_overview_incomplete_coverage_rows(
         assert isinstance(transcript_id, str)
         assert sample == samples_d4_list[0][0]
         assert completeness < 1
+
+
+def test_get_gene_coverage_stats_by_interval(
+    demo_session: sessionmaker,
+    samples_d4_list: List[Tuple[str, D4File]],
+    demo_genes_37: List[SQLGene],
+):
+    """Tests the function that arranges samples coverage stats by inner interval."""
+
+    # Given coverage stats by sample
+    samples_coverage_stats: Dict[str, List[GeneCoverage]] = {
+        sample: get_sample_interval_coverage(
+            db=demo_session,
+            d4_file=d4_file,
+            genes=demo_genes_37,
+            interval_type=SQLTranscript,
+            completeness_thresholds=DEFAULT_COMPLETENESS_LEVELS,
+        )
+        for sample, d4_file in samples_d4_list
+    }
+
+    # WHEN passed to the get_gene_coverage_stats_by_interval function:
+    intervals_coverage_stats: Dict[
+        str, List[Tuple]
+    ] = get_gene_coverage_stats_by_interval(coverage_by_sample=samples_coverage_stats)
+
+    # THEN the returned data should have the expected format
+    for interval_id, stats_tuples in intervals_coverage_stats.items():
+        assert isinstance(interval_id, str)
+
+        for stats_tuple in stats_tuples:
+            assert isinstance(stats_tuple[0], str)  # sample name
+            assert isinstance(stats_tuple[1], float)  # mean coverage
+            assert isinstance(
+                stats_tuple[2], dict
+            )  # coverage completeness over threshoulds


### PR DESCRIPTION
### This PR adds | fixes:
- Gene coverage overview page (fix #160), reachable when you click on any gene link on the geneS overview page:

<img width="814" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/8c952d72-5658-4b60-b5df-5b441b7318fe">

<hr>

This link opens this page:

<img width="1215" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/6e6d2bed-ae39-412e-b6a5-bc40e4bd5576">
 

### How to test:
- Deploy this branch on cg-vm1 (already done by me)
- Go to demo genes overview page: https://chanjo2-stage.scilifelab.se/overview/demo
- Click on any gene link and see if the gene overview page is loaded

### Expected outcome:
- [x] The page should be working

### Review:
- [ ] Code approved by HS
- [x] Tests executed by CR


This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
