### PR TITLE
Add documentation on how to create custom coverage and genes overview  reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Demo and non-demo genes coverage overview endpoint
 - Incomplete intervals at different coverage thresholds on genes overview page
 - Gene coverage overview endpoint
+- Documentation to create custom genes coverage and coverage overview reports
 ### Changed
 - Moved helper function from endpoints coverage to crud samples
 - Deleted unused `src/chanjo2/meta/handle_query_intervals.py` file

--- a/README.md
+++ b/README.md
@@ -179,10 +179,27 @@ That will return this response, containing the requested statistics over the lis
 To find more information on how to set up a REST server running chanjo2 please visit the software's [documentation pages][github-docs]. Here you'll find also instructions on how to populate the database with custom cases and different genomic intervals.
 
 
+#### Coverage report and genes coverage overview
+
+Chanjo2 can be directly used to create the same types of report produced by [chanjo-report][chanjo-report] in conjunction with chanjo[chanjo].
+
+Given a running demo instance of chanjo2, with gene genes and transcripts from genome build GRCh37 loaded in the database, an example of the coverage report based on PanelAPP gene panel described is provided by this demo report endpoint: http://0.0.0.0:8000/report/demo:
+
+<img width="816" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/dfeb0db8-a5ed-4a2e-9e65-ad2fa34b9816">
+
+Similarly, an example report containing an overview of the genes with partial coverage at the given coverage thresholds is provided by the demo overview endpoint:
+
+<img width="1014" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/70bfdfb4-2345-47dd-b6e4-f6ea49d43cbc">
+
+Follow the instructions present in the [documentation pages][github-docs] to learn how to use the report and the overview endpoints to create customised gene coverage report using this software.
+
+
 
 [actions-build-status]: https://github.com/Clinical-Genomics/chanjo2/actions/workflows/build_and_push_docker_stage.yml/badge.svg
 [black-image]: https://img.shields.io/badge/code%20style-black-000000.svg
 [black-url]: https://github.com/psf/black
+[chanjo2]: https://github.com/Clinical-Genomics/chanjo
+[chanjo-report]: https://github.com/Clinical-Genomics/chanjo-report
 [codecov-img]: https://codecov.io/gh/Clinical-Genomics/chanjo2/branch/main/graph/badge.svg?token=6U8ILA2SOY
 [codecov-url]: https://codecov.io/gh/Clinical-Genomics/chanjo2
 [d4-article]: https://www.nature.com/articles/s43588-021-00085-0

--- a/docs/usage/coverage-reports.md
+++ b/docs/usage/coverage-reports.md
@@ -1,0 +1,77 @@
+# Creating a coverage report for one or more samples based on a list of genes
+
+An example of this report is shown by the demo report endpoint: http://0.0.0.0:8000/report/demo (requires all genes and gene transcripts in build GRCh37 loaded into the database).
+
+<img width="816" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/dfeb0db8-a5ed-4a2e-9e65-ad2fa34b9816">
+
+The statistics from the report above are computed using the transcripts intervals present in the provided genes.
+
+Given an application running in production settings, with <ins>genes, transcripts and exons</ins> loaded into the database, a coverage report like the one above can be created taking into account one of these types of intervals from any gene of choice.
+
+The gene list might be provided as a list of <ins>Ensembl gene IDs, HGNC gene IDs or HGNC gene symbol</INS>s.
+
+Here is what the request data of a **POST request to the `/report` endpoint** looks like:
+
+``` shell
+{
+  "build": "GRCh37",
+  "completeness_thresholds": [
+    10,
+    15,
+    20,
+    50,
+    100
+  ],
+  "ensembl_gene_ids": [],
+  "hgnc_gene_ids": [],
+  "hgnc_gene_symbols": [],
+  "interval_type": "genes",
+  "default_level": 10,
+  "panel_name": "Custom panel",
+  "case_display_name": "internal_id",
+  "samples": [
+    {
+      "name": "string",
+      "coverage_file_path": "string",
+      "case_name": "string",
+      "analysis_date": "2023-10-04T08:22:06.980106"
+    }
+  ]
+}
+```
+
+### Mandatory parameters
+
+- **build** _either "GRCh37" or "GRCh38"_
+- **ensembl_gene_ids <ins>OR</ins> hgnc_gene_ids <ins>OR</ins> hgnc_gene_symbols** _either a list of strings (for Ensembl IDs or HGNC symbols or a list of integers for HGNC IDs_
+- **interval_type** _either "genes", "transcripts" or "exons", depending on the analysis type (WGS, WES, WTS)_
+- **default_level** _default coverage threshold level to take into account for displaying the number of fully covered or partially covered intervals_
+- **samples** _mandatory parameters are **name** and <ins>either</ins> **coverage_file_path** <ins>or</ins> **case_name**_
+
+### Optional parameters
+
+- **completeness_thresholds** _the list of different coverage thresholds that will be used to calculate gene coverage completeness. If not provided, the default threshold values will be: 10, 15, 20, 50, 100_
+- **panel_name** _Add a name only if the provided genes are part of a gene panel_
+- **case_display_name** _provide this string parameter if the case belong to the same case / group_
+- **samples analysis_date** _if not provided with be set to current date_
+
+
+# Creating a genes coverage overview report to show incompletely covered genomic intervals
+
+This type of report contains stats from incompletely covered genomic intervals at different coverage thresholds and is basically the same as the genes overview report provided by [chanjo-report](https://github.com/Clinical-Genomics/chanjo-report/blob/9ca7a8ad279ab862c148ce4dfe2b2e675fdc4be4/chanjo_report/server/blueprints/report/views.py#L46).
+
+A demo genes overview report based on genes transcripts from the demo PanelApp genes is available at the demo overview endpoint: http://0.0.0.0:8000/overview/demo (requires all genes and gene transcripts in build GRCh37 loaded into the database).
+
+<img width="1014" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/70bfdfb4-2345-47dd-b6e4-f6ea49d43cbc">
+
+To create a custom genes coverage overview report, send a **POST request to the `/overview` endpoint** containing the same request data described above for the `/report` endpoint.
+
+
+
+
+
+
+
+
+
+

--- a/docs/usage/coverage-reports.md
+++ b/docs/usage/coverage-reports.md
@@ -6,9 +6,9 @@ An example of this report is shown by the demo report endpoint: http://0.0.0.0:8
 
 The statistics from the report above are computed using the transcripts intervals present in the provided genes.
 
-Given an application running in production settings, with <ins>genes, transcripts and exons</ins> loaded into the database, a coverage report like the one above can be created taking into account one of these types of intervals from any gene of choice.
+Given an application running in production settings, with **genes, transcripts and exons** loaded into the database, a coverage report like the one above can be created taking into account one of these types of intervals from any gene of choice.
 
-The gene list might be provided as a list of <ins>Ensembl gene IDs, HGNC gene IDs or HGNC gene symbol</INS>s.
+The gene list might be provided as a list of **Ensembl gene IDs, HGNC gene IDs or HGNC gene symbols**.
 
 Here is what the request data of a **POST request to the `/report` endpoint** looks like:
 
@@ -43,10 +43,10 @@ Here is what the request data of a **POST request to the `/report` endpoint** lo
 ### Mandatory parameters
 
 - **build** _either "GRCh37" or "GRCh38"_
-- **ensembl_gene_ids <ins>OR</ins> hgnc_gene_ids <ins>OR</ins> hgnc_gene_symbols** _either a list of strings (for Ensembl IDs or HGNC symbols or a list of integers for HGNC IDs_
+- **ensembl_gene_ids OR hgnc_gene_ids OR hgnc_gene_symbols** _either a list of strings (for Ensembl IDs or HGNC symbols or a list of integers for HGNC IDs_
 - **interval_type** _either "genes", "transcripts" or "exons", depending on the analysis type (WGS, WES, WTS)_
 - **default_level** _default coverage threshold level to take into account for displaying the number of fully covered or partially covered intervals_
-- **samples** _mandatory parameters are **name** and <ins>either</ins> **coverage_file_path** <ins>or</ins> **case_name**_
+- **samples** _mandatory parameters are **name** and either **coverage_file_path** or **case_name**_
 
 ### Optional parameters
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,3 +13,4 @@ nav:
         - Loading and displaying genes, transcripts and exons: "usage/loading-intervals.md"
         - Cases and samples: "usage/loading-samples.md"
         - Coverage and coverage completeness queries: "usage/sample-coverage.md"
+        - Coverage and genes overview reports: "usage/coverage-reports.md"


### PR DESCRIPTION
### This PR adds | fixes:
- Adds the docs to create coverage and genes overview reports - fix #199 


<img width="1161" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/e7154465-df99-463a-b802-e2c8fcf5c73b">


### How to test:
- create docs pages locally with mkdocs serve

### Expected outcome:
- [x] The new page should work

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
