### PR TITLE
Common HTML template used by all report HTML pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed documentation according to changed coverage API
 - Removed unused `sqlmodel` and updated some other dependencies
 - Show only RefSeq transcripts in coverage report and overview
+- Refactored HTML templates to reduce repetitions by inheriting code from base template
 ### Fixed
 - Bump certifi from 2022.12.7 to 2023.7.22
 - Database connection parameters in documentation files

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ That will return this response, containing the requested statistics over the lis
 To find more information on how to set up a REST server running chanjo2 please visit the software's [documentation pages][github-docs]. Here you'll find also instructions on how to populate the database with custom cases and different genomic intervals.
 
 
-#### Coverage report and genes coverage overview
+## Coverage report and genes coverage overview
 
 Chanjo2 can be directly used to create the same types of report produced by [chanjo-report][chanjo-report] in conjunction with chanjo[chanjo].
 

--- a/src/chanjo2/templates/base-layout.html
+++ b/src/chanjo2/templates/base-layout.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+
+    {% block title %}
+    {% endblock %}
+
+	<meta name="description" content="Chanjo2 Report: coverage report generator">
+	<meta name="author" content="Chiara Rasi">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+
+	<!-- place 'favicon.ico' + 'apple-touch-icon.png' in the root directory -->
+	<link rel="Shortcut Icon"
+				href="#"
+				type="image/x-icon">
+
+	{% block css %}
+		<!-- Oldish compiled and minified CSS -->
+		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+
+		<!-- Customizations -->
+		<link rel="stylesheet" type="text/css" href="{{ url_for('static', path='main.css') }}">
+	{% endblock %}
+
+
+</head>
+<body>
+
+	<nav class="navbar navbar-default">
+	  <div class="container">
+		<div class="navbar-header">
+		  <a class="navbar-brand" href="#">Chanjo2</a>
+		</div>
+		  {% block pdf_export %}
+		  {% endblock %}
+	  </div><!-- /.container -->
+	</nav>
+
+	<div class="container">
+
+        {% block content %}
+        {% endblock %}
+
+	</div>
+
+
+	{% block js_code %}
+	<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+	<!-- Oldish compiled and minified JavaScript -->
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+	{% endblock %}
+</body>
+</html>

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -36,8 +36,6 @@
 	<br>
 	{% endfor %}
 
-
-
 </div>
 {% endmacro %}
 

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -1,5 +1,6 @@
+{% extends "base-layout.html" %}
+
 {% macro gene_stats_macro() %}
-<div class="container">
 	<h2>Gene: {{ gene.hgnc_symbol or gene.hgnc_id }}</h2>
 	<br>
 	{% for interval_id, samples_stats in interval_coverage_stats.items() %}
@@ -35,54 +36,16 @@
 	</tr>
 	<br>
 	{% endfor %}
-
-</div>
 {% endmacro %}
 
-<!DOCTYPE html>
-<head>
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-
-	<title>Chanjo2 gene coverage overview</title>
-
-	<meta name="description" content="Chanjo2 Report: coverage report generator">
-	<meta name="author" content="Chiara Rasi">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
-
-	<!-- place 'favicon.ico' + 'apple-touch-icon.png' in the root directory -->
-	<link rel="Shortcut Icon"
-				href="#"
-				type="image/x-icon">
-
-	{% block css %}
-		<!-- Oldish compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-
-		<!-- Customizations -->
-		<link rel="stylesheet" type="text/css" href="{{ url_for('static', path='main.css') }}">
-	{% endblock %}
-
-	{% block css_style %}{% endblock %}
-
-</head>
-<body>
-	<nav class="navbar navbar-default">
-	  <div class="container">
-		<div class="navbar-header">
-		  <a class="navbar-brand" href="#">Chanjo2 report</a>
-		</div>
-	  </div><!-- /.container -->
-	</nav>
-
-{{ gene_stats_macro() }}
-
-{% block js_code %}
-	<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-	<!-- Oldish compiled and minified JavaScript -->
-	<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+{% block title %}
+<title>Chanjo2 gene coverage overview</title>
 {% endblock %}
-</body>
-</html>
+
+{% block content %}
+{{ gene_stats_macro() }}
+{% endblock%}
+
+
+
+

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -1,3 +1,5 @@
+{% extends "base-layout.html" %}
+
 {% macro completeness_cutoffs() %}
 	<div class="row">
 		<div class="col-md-12">
@@ -61,61 +63,25 @@
 
 {% endmacro %}
 
+{% block title %}
+<title>Chanjo2 genes coverage overview</title>
+{% endblock %}
 
-<!DOCTYPE html>
-<head>
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 
-	<title>Chanjo2 genes coverage overview</title>
-
-	<meta name="description" content="Chanjo2 Report: coverage report generator">
-	<meta name="author" content="Chiara Rasi">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
-
-	<!-- place 'favicon.ico' + 'apple-touch-icon.png' in the root directory -->
-	<link rel="Shortcut Icon"
-				href="#"
-				type="image/x-icon">
-
-	{% block css %}
-		<!-- Oldish compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-
-		<!-- Customizations -->
-		<link rel="stylesheet" type="text/css" href="{{ url_for('static', path='main.css') }}">
-	{% endblock %}
-
-	{% block css_style %}{% endblock %}
-
-</head>
-<body>
-
-	<nav class="navbar navbar-default">
-	  <div class="container">
-		<div class="navbar-header">
-		  <a class="navbar-brand" href="#">Chanjo2 report</a>
-		</div>
-	  </div><!-- /.container -->
-	</nav>
-
-	<div class="container">
-		<div class="row">
-		<div class="col-md-12">
-			<div class="panel panel-default">
-				<div class="panel-heading">
-					<h4>Incomplete {{ extras.interval_type }}</h4>
-				</div>
-				<ul class="list-group">
-					<li class="list-group-item">
-						Samples:
-						{% for sample in extras.samples %}
-							<strong>{{ sample.name }}</strong>
-						{% endfor %}
-					</li>
-				</ul>
+{% block content %}
+	<div class="col-md-12">
+		<div class="panel panel-default">
+			<div class="panel-heading">
+				<h4>Incomplete {{ extras.interval_type }}</h4>
 			</div>
+			<ul class="list-group">
+				<li class="list-group-item">
+					Samples:
+					{% for sample in extras.samples %}
+						<strong>{{ sample.name }}</strong>
+					{% endfor %}
+				</li>
+			</ul>
 		</div>
 	</div>
 
@@ -125,61 +91,56 @@
 
 	{{ incompletely_covered_intervals() }}
 
-	{% block js_code %}
-		<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-		<!-- Oldish compiled and minified JavaScript -->
-		<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+{% endblock %}
 
-		<script>
 
-			// Extracts the content of the body element of an HTML page as a string
-			function updatedReportBody(html)
-			{
-				return /<body.*?>([\s\S]*)<\/body>/.exec(html)[1];
+{% block js_code %}
+	<script>
+
+		// Extracts the content of the body element of an HTML page as a string
+		function updatedReportBody(html)
+		{
+			return /<body.*?>([\s\S]*)<\/body>/.exec(html)[1];
+		}
+
+		function updateOverview(customLevel)
+		{
+			let formDict = {
+				'build' : '{{ extras.build }}',
+				'completeness_thresholds' : {{ extras.completeness_thresholds }},
+				'hgnc_gene_ids' : {{ extras.hgnc_gene_ids }},
+				'interval_type' : '{{ extras.interval_type }}',
+				'default_level' : customLevel,
+				'samples' : {{ extras.samples|safe }},
 			}
 
-			function updateOverview(customLevel)
-			{
-				let formDict = {
-					'build' : '{{ extras.build }}',
-					'completeness_thresholds' : {{ extras.completeness_thresholds }},
-					'hgnc_gene_ids' : {{ extras.hgnc_gene_ids }},
-					'interval_type' : '{{ extras.interval_type }}',
-					'default_level' : customLevel,
-					'samples' : {{ extras.samples|safe }},
-				}
-
-				fetch('/overview', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
-                        body: JSON.stringify(formDict)
-                    })
-                    .then(resp => resp.text())
-                    .then(html => {
-                    	document.body.innerHTML = updatedReportBody(html);
-                    })
-                    .catch(error => {
-                        console.error(error);
-                });
-			}
+			fetch('/overview', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify(formDict)
+				})
+				.then(resp => resp.text())
+				.then(html => {
+					document.body.innerHTML = updatedReportBody(html);
+				})
+				.catch(error => {
+					console.error(error);
+			});
+		}
 
 
-			function getGeneStatsPage(hgncId)
-			{
-				event.preventDefault();
-				var theForm = document.getElementById("geneStatsForm");
-				var geneInput = document.createElement("input");
-				geneInput.setAttribute("type", "hidden");
-				geneInput.setAttribute("name", "hgnc_gene_id");
-				geneInput.setAttribute("value", hgncId);
-				theForm.appendChild(geneInput);
-				theForm.submit();
-			}
-
-		</script>
-	{% endblock %}
-</body>
-</html>
+		function getGeneStatsPage(hgncId)
+		{
+			event.preventDefault();
+			var theForm = document.getElementById("geneStatsForm");
+			var geneInput = document.createElement("input");
+			geneInput.setAttribute("type", "hidden");
+			geneInput.setAttribute("name", "hgnc_gene_id");
+			geneInput.setAttribute("value", hgncId);
+			theForm.appendChild(geneInput);
+			theForm.submit();
+		}
+	</script>
+{% endblock %}

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -210,7 +210,7 @@
 {% block pdf_export %}
 	<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
 		<div class="nav navbar-nav navbar-right">
-			<button class="navbar-brand" onclick="window.print();">Create PDF</button>
+			<button class="navbar-brand" onclick="window.focus(); window.print();">Create PDF</button>
 		</div>
 	</div><!-- /.navbar-collapse -->
 	{% endblock %}

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -251,6 +251,7 @@
 
 
 {% block js_code %}
+	{{ super() }}
 	<script>
 		function toggle_visibility(ids)
 		{

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -207,15 +207,6 @@
 <title>Coverage report</title>
 {% endblock %}
 
-
-{% block css %}
-	<!-- Oldish compiled and minified CSS -->
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-
-	<!-- Customizations -->
-	<link rel="stylesheet" type="text/css" href="{{ url_for('static', path='main.css') }}">
-{% endblock %}
-
 {% block pdf_export %}
 	<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
 		<div class="nav navbar-nav navbar-right">
@@ -260,11 +251,6 @@
 
 
 {% block js_code %}
-	<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-	<!-- Oldish compiled and minified JavaScript -->
-	<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-
 	<script>
 		function toggle_visibility(ids)
 		{
@@ -324,5 +310,3 @@
 	</script>
 
 {% endblock %}
-</body>
-</html>

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -1,3 +1,5 @@
+{% extends "base-layout.html" %}
+
 {% macro errors_block() %}
 	{% for error_description, error_content in errors %}
 		{% if error_content %}
@@ -201,149 +203,126 @@
 
 {% endmacro %}
 
-<!DOCTYPE html>
-<head>
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+{% block title %}
+<title>Coverage report</title>
+{% endblock %}
 
-	<title>Coverage report</title>
 
-	<meta name="description" content="Chanjo2 Report: coverage report generator">
-	<meta name="author" content="Chiara Rasi">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
+{% block css %}
+	<!-- Oldish compiled and minified CSS -->
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
 
-	<!-- place 'favicon.ico' + 'apple-touch-icon.png' in the root directory -->
-	<link rel="Shortcut Icon"
-				href="#"
-				type="image/x-icon">
+	<!-- Customizations -->
+	<link rel="stylesheet" type="text/css" href="{{ url_for('static', path='main.css') }}">
+{% endblock %}
 
-	{% block css %}
-		<!-- Oldish compiled and minified CSS -->
-		<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
-
-		<!-- Customizations -->
-		<link rel="stylesheet" type="text/css" href="{{ url_for('static', path='main.css') }}">
-	{% endblock %}
-
-	{% block css_style %}{% endblock %}
-
-</head>
-<body>
-
-	<nav class="navbar navbar-default">
-	  <div class="container">
-		<div class="navbar-header">
-		  <a class="navbar-brand" href="#">Chanjo2</a>
-		</div>
-		<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-		  <div class="nav navbar-nav navbar-right">
+{% block pdf_export %}
+	<div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+		<div class="nav navbar-nav navbar-right">
 			<button class="navbar-brand" onclick="window.print();">Create PDF</button>
-		  </div>
-		</div><!-- /.navbar-collapse -->
-	  </div><!-- /.container -->
-	</nav>
-
-	<div class="container">
-
-		{{ report_filters() }}
-
-		{% if extras.case_name %}
-			<h2>Case name: {{extras.case_name}}</h2>
-		{% endif %}
-
-		<!-- Quality report -->
-
-		<h2>Quality report: clinical sequencing</h2>
-		{% if extras.panel_name %}
-			<p>Based on gene panel: <strong>{{ extras.panel_name }}</strong></p>
-		{% endif %}
-
-		{{ sex_rows_block() }}
-
-		<h3>Generally important metrics</h3>
-
-		{{ important_metrics() }}
-
-		<h3> Transcript coverage at {{ extras.default_level }}x</h3>
-
-		{{ default_level_metrics() }}
-		<hr>
-		{{ errors_block() }}
-		<!--End of Quality report -->
-
-		<h3>Explanations</h3>
-
-		{{ explanations() }}
-
-
-	</div>
-
-
-	{% block js_code %}
-		<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-		<!-- Oldish compiled and minified JavaScript -->
-		<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
-
-		<script>
-			function toggle_visibility(ids)
-			{
-				for (let id of ids) {
-					var e = document.getElementById(id);
-					if (e.style.display == 'block'){
-						e.style.display = 'none';
-					}
-					else {
-						e.style.display = 'block';
-					}
-				}
-			}
-
-			// Extracts the content of the body element of an HTML page as a string
-			function updatedReportBody(html)
-			{
-				return /<body.*?>([\s\S]*)<\/body>/.exec(html)[1];
-			}
-
-			// Returns the list of HGNC genes present in the user query as a sring as a list of integers
-			function getFormGeneIDsAsList()
-			{
-				return document.getElementById("hgnc_gene_ids").value.replace(/\s/g, '').split(",").map(Number);
-			}
-
-			function submitAsJson()
-			{
-				event.preventDefault();
-				let formDict = {
-					'build' : '{{ extras.build }}',
-					'completeness_thresholds' : {{ extras.completeness_thresholds }},
-					'hgnc_gene_ids' : getFormGeneIDsAsList(),
-					'interval_type' : '{{ extras.interval_type }}',
-					'panel_name' : document.getElementById("panel_name").value,
-					'default_level' : document.getElementById("default_level").value,
-					'case_display_name' : '{{ extras.case_name }}',
-					'samples' : {{ extras.samples|safe }},
-				}
-
-				fetch('/report', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json'
-                        },
-                        body: JSON.stringify(formDict)
-                    })
-                    .then(resp => resp.text())
-                    .then(html => {
-                    	document.body.innerHTML = updatedReportBody(html);
-                    })
-                    .catch(error => {
-                        console.error(error);
-                });
-			}
-
-    	</script>
-
+		</div>
+	</div><!-- /.navbar-collapse -->
 	{% endblock %}
+
+	{% block content %}
+
+	{{ report_filters() }}
+
+	{% if extras.case_name %}
+		<h2>Case name: {{extras.case_name}}</h2>
+	{% endif %}
+
+	<!-- Quality report -->
+
+	<h2>Quality report: clinical sequencing</h2>
+	{% if extras.panel_name %}
+		<p>Based on gene panel: <strong>{{ extras.panel_name }}</strong></p>
+	{% endif %}
+
+	{{ sex_rows_block() }}
+
+	<h3>Generally important metrics</h3>
+
+	{{ important_metrics() }}
+
+	<h3> Transcript coverage at {{ extras.default_level }}x</h3>
+
+	{{ default_level_metrics() }}
+	<hr>
+	{{ errors_block() }}
+	<!--End of Quality report -->
+
+	<h3>Explanations</h3>
+
+	{{ explanations() }}
+
+{% endblock %}
+
+
+{% block js_code %}
+	<!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.min.js" integrity="sha512-ju6u+4bPX50JQmgU97YOGAXmRMrD9as4LE05PdC3qycsGQmjGlfm041azyB1VfCXpkpt1i9gqXCT6XuxhBJtKg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+	<!-- Oldish compiled and minified JavaScript -->
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@3.3.7/dist/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+	<script>
+		function toggle_visibility(ids)
+		{
+			for (let id of ids) {
+				var e = document.getElementById(id);
+				if (e.style.display == 'block'){
+					e.style.display = 'none';
+				}
+				else {
+					e.style.display = 'block';
+				}
+			}
+		}
+
+		// Extracts the content of the body element of an HTML page as a string
+		function updatedReportBody(html)
+		{
+			return /<body.*?>([\s\S]*)<\/body>/.exec(html)[1];
+		}
+
+		// Returns the list of HGNC genes present in the user query as a sring as a list of integers
+		function getFormGeneIDsAsList()
+		{
+			return document.getElementById("hgnc_gene_ids").value.replace(/\s/g, '').split(",").map(Number);
+		}
+
+		function submitAsJson()
+		{
+			event.preventDefault();
+			let formDict = {
+				'build' : '{{ extras.build }}',
+				'completeness_thresholds' : {{ extras.completeness_thresholds }},
+				'hgnc_gene_ids' : getFormGeneIDsAsList(),
+				'interval_type' : '{{ extras.interval_type }}',
+				'panel_name' : document.getElementById("panel_name").value,
+				'default_level' : document.getElementById("default_level").value,
+				'case_display_name' : '{{ extras.case_name }}',
+				'samples' : {{ extras.samples|safe }},
+			}
+
+			fetch('/report', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify(formDict)
+				})
+				.then(resp => resp.text())
+				.then(html => {
+					document.body.innerHTML = updatedReportBody(html);
+				})
+				.catch(error => {
+					console.error(error);
+			});
+		}
+
+	</script>
+
+{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
### This PR adds | fixes:
- Reduce code redundancy by creating a common template and having the other templates extending this one -> Fix #195

### How to test:
- Deploy on cg-vm1 or locally

### Expected outcome:
- [x] All HTML pages (report, genes overview, gene overview) should work as expected 

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
