### PR TITLE
Modify coverage report form to accept genes as HGNC IDs, HGNC symbols and Ensembl IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - Fixed documentation according to changed coverage API
 - Removed unused `sqlmodel` and updated some other dependencies
 - Show only RefSeq transcripts in coverage report and overview
+- Coverage report form to accept genes as Ensembl IDS, HGNC IDs and HGNC symbols
+- Moved coverage report "show genes" outside form and just above custom coverage stats table
 ### Fixed
 - Bump certifi from 2022.12.7 to 2023.7.22
 - Database connection parameters in documentation files

--- a/src/chanjo2/endpoints/report.py
+++ b/src/chanjo2/endpoints/report.py
@@ -51,7 +51,7 @@ async def demo_report(request: Request, db: Session = Depends(get_session)):
 
 @router.post("/report", response_class=HTMLResponse)
 async def report(
-        request: Request, report_query: ReportQuery, db: Session = Depends(get_session)
+    request: Request, report_query: ReportQuery, db: Session = Depends(get_session)
 ):
     """Return a coverage report over a list of genes for a list of samples."""
     report_content: Dict = get_report_data(

--- a/src/chanjo2/endpoints/report.py
+++ b/src/chanjo2/endpoints/report.py
@@ -51,7 +51,7 @@ async def demo_report(request: Request, db: Session = Depends(get_session)):
 
 @router.post("/report", response_class=HTMLResponse)
 async def report(
-    request: Request, report_query: ReportQuery, db: Session = Depends(get_session)
+        request: Request, report_query: ReportQuery, db: Session = Depends(get_session)
 ):
     """Return a coverage report over a list of genes for a list of samples."""
     report_content: Dict = get_report_data(

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -42,12 +42,7 @@
 				  <div class="row" {% if hidden %}hidden{% endif %}>
 					<div class="col-xs-7">
 					  <label class="control-label">Included genes</label>
-					  <div><input class="form-control" type="text" name="hgnc_gene_ids" id ="hgnc_gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="ADK,GIT"></div>
-					</div>
-
-					<div class="col-xs-3">
-					  <label class="control-label">Show genes</label>
-					  <div><input type="checkbox" name="show_genes" onclick="toggle_visibility(['incompletelyCoveredGenesHeader', 'incompletelyCoveredGenesCell']);"></div>
+					  <div><input class="form-control" type="text" name="gene_ids" id ="gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="ADK,GIT"></div>
 					</div>
 
 					<div class="col-xs-2">
@@ -130,6 +125,10 @@
 {% endmacro %}
 
 {% macro default_level_metrics() %}
+ <div class="col-xs-1 col-xs-offset-9" style="text-align: right;"><input type="checkbox" name="show_genes" onclick="toggle_visibility(['incompletelyCoveredGenesHeader', 'incompletelyCoveredGenesCell']);"></div>
+	 <div class="col-xs-2">
+		 <label class="control-label">Show genes</label>
+	 </div>
 <table class="table table-bordered table-hover">
 	 <caption>Genes/Transcripts/Exons coverage at default coverage threshold</caption>
       <thead>
@@ -309,16 +308,30 @@
 			// Returns the list of HGNC genes present in the user query as a sring as a list of integers
 			function getFormGeneIDsAsList()
 			{
-				return document.getElementById("hgnc_gene_ids").value.replace(/\s/g, '').split(",").map(Number);
+				let geneIdsTypes = [null, null, null]; // [Ensembl_ids_list, HGNC_ids_list, HGNC_symbols_list];
+				let formGeneIds = document.getElementById('gene_ids').value.replace(/\s/g, '').split(",");
+				if (!isNaN(formGeneIds[0])) {
+					geneIdsTypes[1] = formGeneIds.map(Number);
+				}
+				else if (formGeneIds[0].startsWith('ENSG')){
+					geneIdsTypes[0] = formGeneIds;
+				}
+				else{
+					geneIdsTypes[2] = formGeneIds;
+				}
+				return geneIdsTypes;
 			}
 
 			function submitAsJson()
 			{
 				event.preventDefault();
+				let geneIds = getFormGeneIDsAsList();
 				let formDict = {
 					'build' : '{{ extras.build }}',
 					'completeness_thresholds' : {{ extras.completeness_thresholds }},
-					'hgnc_gene_ids' : getFormGeneIDsAsList(),
+					'ensembl_gene_ids': geneIds[0],
+					'hgnc_gene_ids' : geneIds[1],
+					'hgnc_gene_symbols' : geneIds[2],
 					'interval_type' : '{{ extras.interval_type }}',
 					'panel_name' : document.getElementById("panel_name").value,
 					'default_level' : document.getElementById("default_level").value,

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -41,7 +41,7 @@
 				<div class="form-group">
 				  <div class="row" {% if hidden %}hidden{% endif %}>
 					<div class="col-xs-7">
-					  <label class="control-label">Included genes</label>
+					  <label class="control-label">Included genes (Comma separated list of Ensembl IDs, HGNC IDs or HGNC symbols)</label>
 					  <div><input class="form-control" type="text" name="gene_ids" id ="gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="ADK,GIT"></div>
 					</div>
 


### PR DESCRIPTION
In current main branch it is only possible use the form to submit genes as HGNC IDs

<img width="758" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/daf93062-e8ac-4f1e-b69d-6278c1be904d">


### This PR adds | fixes:
- Fix #202  
- Moved the `show genes` checkbox outside the form above and just above where it is used, in the custom coverage stats section:

<img width="643" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/8bac064b-1fd5-4031-8176-0d56a4652ce8">

<hr>

**How to prepare for test**:
- [ ] Deploy to cg-vm1 

### How to test:
- Go to demo report page: https://chanjo2-stage.scilifelab.se/report/demo
- Use the form to search genes as Ensembl IDs and HGNC symbols and make sure there are no errors in returning stats


### Expected outcome:
- [ ]

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
