### PR TITLE
Simplified import of SQL classes from scout.models.sql_model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Changed
+- Simplified the import of SQL classes from `scout.models.sql_model`
+
 ## [1.2]
 ### Added
 - Load genes, transcripts and exons from pre-downloaded files

--- a/src/chanjo2/crud/cases.py
+++ b/src/chanjo2/crud/cases.py
@@ -4,10 +4,8 @@ from sqlalchemy import delete
 from sqlalchemy.engine.cursor import CursorResult
 from sqlalchemy.orm import Session, query
 
+from chanjo2.models import SQLCase, SQLSample, CaseSample
 from chanjo2.models.pydantic_models import Case, CaseCreate
-from chanjo2.models.sql_models import Case as SQLCase
-from chanjo2.models.sql_models import CaseSample
-from chanjo2.models.sql_models import Sample as SQLSample
 
 
 def filter_cases_by_name(cases: query.Query, case_name: str) -> SQLCase:

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -12,9 +12,7 @@ from chanjo2.models.pydantic_models import (
     TranscriptBase,
     TranscriptTag,
 )
-from chanjo2.models.sql_models import Exon as SQLExon
-from chanjo2.models.sql_models import Gene as SQLGene
-from chanjo2.models.sql_models import Transcript as SQLTranscript
+from chanjo2.models import SQLGene, SQLExon, SQLTranscript
 
 LOG = logging.getLogger("uvicorn.access")
 

--- a/src/chanjo2/crud/samples.py
+++ b/src/chanjo2/crud/samples.py
@@ -10,10 +10,8 @@ from sqlalchemy.sql.expression import Delete
 from chanjo2.constants import SAMPLE_NOT_FOUND, WRONG_COVERAGE_FILE_MSG
 from chanjo2.crud.cases import filter_cases_by_name
 from chanjo2.meta.handle_d4 import get_d4_file
+from chanjo2.models import SQLCase, SQLSample, CaseSample
 from chanjo2.models.pydantic_models import SampleCreate
-from chanjo2.models.sql_models import Case as SQLCase
-from chanjo2.models.sql_models import CaseSample
-from chanjo2.models.sql_models import Sample as SQLSample
 
 
 def _filter_samples_by_name(

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -21,6 +21,7 @@ from chanjo2.meta.handle_d4 import (
     get_intervals_completeness,
     get_sample_interval_coverage,
 )
+from chanjo2.models import SQLExon, SQLGene, SQLTranscript
 from chanjo2.models.pydantic_models import (
     SampleGeneIntervalQuery,
     FileCoverageQuery,
@@ -28,9 +29,6 @@ from chanjo2.models.pydantic_models import (
     IntervalCoverage,
     GeneCoverage,
 )
-from chanjo2.models.sql_models import Exon as SQLExon
-from chanjo2.models.sql_models import Gene as SQLGene
-from chanjo2.models.sql_models import Transcript as SQLTranscript
 
 router = APIRouter()
 

--- a/src/chanjo2/endpoints/intervals.py
+++ b/src/chanjo2/endpoints/intervals.py
@@ -15,6 +15,7 @@ from chanjo2.meta.handle_load_intervals import (
     update_genes,
     update_transcripts,
 )
+from chanjo2.models import SQLExon, SQLTranscript
 from chanjo2.models.pydantic_models import (
     Builds,
     Exon,
@@ -23,8 +24,6 @@ from chanjo2.models.pydantic_models import (
     GeneQuery,
     GeneIntervalQuery,
 )
-from chanjo2.models.sql_models import Exon as SQLExon
-from chanjo2.models.sql_models import Transcript as SQLTranscript
 
 router = APIRouter()
 

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -7,6 +7,7 @@ from pyd4 import D4File
 from sqlalchemy.orm import Session
 
 from chanjo2.crud.intervals import get_gene_intervals
+from chanjo2.models import SQLExon, SQLGene, SQLTranscript
 from chanjo2.models.pydantic_models import (
     IntervalCoverage,
     Sex,
@@ -14,9 +15,6 @@ from chanjo2.models.pydantic_models import (
     IntervalType,
     TranscriptTag,
 )
-from chanjo2.models.sql_models import Exon as SQLExon
-from chanjo2.models.sql_models import Gene as SQLGene
-from chanjo2.models.sql_models import Transcript as SQLTranscript
 
 LOG = logging.getLogger("uvicorn.access")
 

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -19,6 +19,7 @@ from chanjo2.crud.intervals import (
     count_intervals_for_build,
     delete_intervals_for_build,
 )
+from chanjo2.models import SQLExon, SQLGene, SQLTranscript
 from chanjo2.models.pydantic_models import (
     Builds,
     ExonBase,
@@ -26,9 +27,6 @@ from chanjo2.models.pydantic_models import (
     IntervalType,
     TranscriptBase,
 )
-from chanjo2.models.sql_models import Exon as SQLExon
-from chanjo2.models.sql_models import Gene as SQLGene
-from chanjo2.models.sql_models import Transcript as SQLTranscript
 
 LOG = logging.getLogger("uvicorn.access")
 MAX_NR_OF_RECORDS = 10_000

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from chanjo2.crud.intervals import get_genes, get_hgnc_gene
 from chanjo2.crud.samples import get_sample
 from chanjo2.meta.handle_d4 import get_samples_sex_metrics, get_sample_interval_coverage
+from chanjo2.models import SQLExon, SQLGene, SQLSample, SQLTranscript
 from chanjo2.models.pydantic_models import (
     ReportQuery,
     ReportQuerySample,
@@ -17,10 +18,6 @@ from chanjo2.models.pydantic_models import (
     IntervalType,
     GeneReportForm,
 )
-from chanjo2.models.sql_models import Exon as SQLExon
-from chanjo2.models.sql_models import Gene as SQLGene
-from chanjo2.models.sql_models import Sample as SQLSample
-from chanjo2.models.sql_models import Transcript as SQLTranscript
 
 LOG = logging.getLogger("uvicorn.access")
 

--- a/src/chanjo2/models/__init__.py
+++ b/src/chanjo2/models/__init__.py
@@ -1,0 +1,6 @@
+from chanjo2.models.sql_models import Case as SQLCase
+from chanjo2.models.sql_models import CaseSample
+from chanjo2.models.sql_models import Exon as SQLExon
+from chanjo2.models.sql_models import Gene as SQLGene
+from chanjo2.models.sql_models import Sample as SQLSample
+from chanjo2.models.sql_models import Transcript as SQLTranscript

--- a/tests/src/chanjo2/crud/test_crud_intervals.py
+++ b/tests/src/chanjo2/crud/test_crud_intervals.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import sessionmaker
 
 from chanjo2.constants import BUILD_37
 from chanjo2.crud.intervals import get_gene_intervals
-from chanjo2.models.sql_models import Transcript as SQLTranscript
+from chanjo2.models import SQLTranscript
 
 
 def test_get_gene_intervals_all_transcripts(

--- a/tests/src/chanjo2/meta/test_handle_report_contents.py
+++ b/tests/src/chanjo2/meta/test_handle_report_contents.py
@@ -13,8 +13,7 @@ from chanjo2.meta.handle_report_contents import (
     get_genes_overview_incomplete_coverage_rows,
     get_gene_coverage_stats_by_interval,
 )
-from chanjo2.models.sql_models import Gene as SQLGene
-from chanjo2.models.sql_models import Transcript as SQLTranscript
+from chanjo2.models import SQLGene, SQLTranscript
 
 DEFAULT_COVERAGE_LEVEL = 20
 

--- a/tests/src/chanjo2/test_populate_demo.py
+++ b/tests/src/chanjo2/test_populate_demo.py
@@ -1,10 +1,11 @@
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import sessionmaker
+
 from chanjo2.crud.cases import get_cases
 from chanjo2.crud.intervals import get_genes, get_gene_intervals
 from chanjo2.crud.samples import get_samples
+from chanjo2.models import SQLCase, SQLGene, SQLTranscript, SQLExon, SQLSample
 from chanjo2.models.pydantic_models import Builds
-from chanjo2.models.sql_models import Case, Sample, Gene, Transcript, Exon
-from fastapi.testclient import TestClient
-from sqlalchemy.orm import sessionmaker
 
 
 def test_load_demo_data(demo_client: TestClient, demo_session: sessionmaker):
@@ -13,17 +14,17 @@ def test_load_demo_data(demo_client: TestClient, demo_session: sessionmaker):
     # WHEN the app is launched
     with demo_client:
         # THEN database should contain a case
-        cases: List[Case] = get_cases(db=demo_session)
-        assert isinstance(cases[0], Case)
+        cases: List[SQLCase] = get_cases(db=demo_session)
+        assert isinstance(cases[0], SQLCase)
 
         # THEN database should contain samples
-        samples: List[Sample] = get_samples(db=demo_session)
-        assert isinstance(samples[0], Sample)
+        samples: List[SQLSample] = get_samples(db=demo_session)
+        assert isinstance(samples[0], SQLSample)
 
         # THEN for each genome build
         for build in Builds.get_enum_values():
             # database should contain genes
-            genes: List[Gene] = get_genes(
+            genes: List[SQLGene] = get_genes(
                 db=demo_session,
                 build=build,
                 ensembl_ids=None,
@@ -31,10 +32,10 @@ def test_load_demo_data(demo_client: TestClient, demo_session: sessionmaker):
                 hgnc_symbols=None,
                 limit=1,
             )
-            assert isinstance(genes[0], Gene)
+            assert isinstance(genes[0], SQLGene)
 
             # database should contain transcripts
-            transcripts: List[Transcripts] = get_gene_intervals(
+            transcripts: List[SQLTranscripts] = get_gene_intervals(
                 db=demo_session,
                 build=build,
                 ensembl_ids=None,
@@ -42,12 +43,12 @@ def test_load_demo_data(demo_client: TestClient, demo_session: sessionmaker):
                 hgnc_symbols=None,
                 ensembl_gene_ids=None,
                 limit=1,
-                interval_type=Transcript,
+                interval_type=SQLTranscript,
             )
-            assert isinstance(transcripts[0], Transcript)
+            assert isinstance(transcripts[0], SQLTranscript)
 
             # database should contain exons
-            exons: List[Exon] = get_gene_intervals(
+            exons: List[SQLExon] = get_gene_intervals(
                 db=demo_session,
                 build=build,
                 ensembl_ids=None,
@@ -55,6 +56,6 @@ def test_load_demo_data(demo_client: TestClient, demo_session: sessionmaker):
                 hgnc_symbols=None,
                 ensembl_gene_ids=None,
                 limit=1,
-                interval_type=Exon,
+                interval_type=SQLExon,
             )
-            assert isinstance(exons[0], Exon)
+            assert isinstance(exons[0], SQLExon)


### PR DESCRIPTION
### This PR adds | fixes:
- Simplified import of MYSQL classes all over the place without renaming the database table (fix #207)

### How to test:
- Automatic tests

### Expected outcome:
- [x] All tests should pass

### Review:
- [ ] Code approved by
- [x] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
