### PR TITLE
Replace pyd4 with call to d4tools in endpoints.coverage.d4_interval_coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## [unreleased]
 ### Added
 - `coverage.d4_intervals_coverage` responses contain also interval name as provided in bed file
+- `coverage.d4_interval_coverage` responses now returns also the genomic region used to compute the stats on
 ### Changed
 - Speed up response by `coverage.d4_intervals_coverage` by replacing pyd4 lib with direct calls d4tools and multiprocessing
 - Removed 2 redundant functions in `meta.handle.bed.py`
+- `coverage.d4_interval_coverage` is using direct calls to d4tools to retrieve stats over an entire chromosome or a genomic interval
 
 ## [1.4]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Speed up response by `coverage.d4_intervals_coverage` by replacing pyd4 lib with direct calls d4tools and multiprocessing
 - Removed 2 redundant functions in `meta.handle.bed.py`
 - `coverage.d4_interval_coverage` is using direct calls to d4tools to retrieve stats over an entire chromosome or a genomic interval
+### Fixed
+-  `coverage.d4_interval_coverage` endpoint crashing trying to computer coverage completeness over an entire chromosome
 
 ## [1.4]
 ### Changed

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -12,26 +12,19 @@ from chanjo2.constants import WRONG_BED_FILE_MSG, WRONG_COVERAGE_FILE_MSG
 from chanjo2.crud.intervals import get_genes
 from chanjo2.crud.samples import get_samples_coverage_file
 from chanjo2.dbutil import get_session
-from chanjo2.meta.handle_d4 import (
-    get_d4_file,
-    get_d4tools_intervals_coverage,
-    get_intervals_completeness,
-    get_intervals_mean_coverage,
-    get_sample_interval_coverage,
-    get_samples_sex_metrics,
-    set_interval,
-)
 from chanjo2.meta.handle_bed import bed_file_interval_id_coords
+from chanjo2.meta.handle_d4 import (get_d4_file,
+                                    get_d4tools_intervals_coverage,
+                                    get_d4tools_intervals_mean_coverage,
+                                    get_intervals_completeness,
+                                    get_sample_interval_coverage,
+                                    get_samples_sex_metrics, set_interval)
 from chanjo2.meta.handle_tasks import coverage_completeness_multitasker
 from chanjo2.models import SQLExon, SQLGene, SQLTranscript
-from chanjo2.models.pydantic_models import (
-    FileCoverageIntervalsFileQuery,
-    FileCoverageQuery,
-    GeneCoverage,
-    IntervalCoverage,
-    IntervalType,
-    SampleGeneIntervalQuery,
-)
+from chanjo2.models.pydantic_models import (FileCoverageIntervalsFileQuery,
+                                            FileCoverageQuery, GeneCoverage,
+                                            IntervalCoverage, IntervalType,
+                                            SampleGeneIntervalQuery)
 
 router = APIRouter()
 LOG = logging.getLogger("uvicorn.access")
@@ -41,25 +34,30 @@ LOG = logging.getLogger("uvicorn.access")
 def d4_interval_coverage(query: FileCoverageQuery):
     """Return coverage on the given interval for a D4 resource located on the disk or on a remote server."""
 
-    interval: Tuple[str, Optional[int], Optional[int]] = set_interval(
-        chrom=query.chromosome, start=query.start, end=query.end
-    )
-    try:
-        d4_file: D4File = get_d4_file(query.coverage_file_path)
-    except Exception:
+    interval: str = query.chromosome
+
+    if query.start and query.end:
+        interval += f":{query.start}-{query.end}"
+
+    LOG.warning(interval)
+
+    if (
+            isfile(query.coverage_file_path) is False
+            or validators.url(query.coverage_file_path) is False
+    ):
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=WRONG_COVERAGE_FILE_MSG,
         )
 
     return IntervalCoverage(
-        mean_coverage=get_intervals_mean_coverage(
-            d4_file=d4_file, intervals=[interval]
+        mean_coverage=get_d4tools_intervals_mean_coverage(
+            d4_file_path=query.coverage_file_path, intervals=[interval]
         )[0],
-        completeness=get_intervals_completeness(
-            d4_file=d4_file,
-            intervals=[interval],
-            completeness_thresholds=query.completeness_thresholds,
+        completeness=get_d4tools_coverage_completeness(
+            d4_file_path=d4_file,
+            interval_ids_coords=[set_interval(chrom=query.chromosome, start=query.start, end=query.end)],
+            thresholds=query.completeness_thresholds,
         ),
     )
 

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -52,7 +52,7 @@ def d4_interval_coverage(query: FileCoverageQuery):
         )
 
     interval: str = query.chromosome
-    if None in [query.start, query.end]:  # Coverage over a single chromosome
+    if None in [query.start, query.end]:  # Coverage over an entire chromosome
         return IntervalCoverage(
             mean_coverage=get_d4tools_chromosome_mean_coverage(
                 d4_file_path=query.coverage_file_path, chromosome=query.chromosome

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -57,7 +57,7 @@ def get_d4tools_chromosome_mean_coverage(d4_file_path: str, chromosome=str) -> f
     for line in chromosomes_stats_mean_cmd:
         stats_data: List[str] = line.split("\t")
         if chromosome == stats_data[CHROM_INDEX]:
-            return stats_data[STATS_INDEX]
+            return stats_data[STATS_MEAN_COVERAGE_INDEX]
 
 
 def get_d4tools_intervals_mean_coverage(

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -9,13 +9,8 @@ from sqlalchemy.orm import Session
 
 from chanjo2.crud.intervals import get_gene_intervals
 from chanjo2.models import SQLExon, SQLGene, SQLTranscript
-from chanjo2.models.pydantic_models import (
-    GeneCoverage,
-    IntervalCoverage,
-    IntervalType,
-    Sex,
-    TranscriptTag,
-)
+from chanjo2.models.pydantic_models import (GeneCoverage, IntervalCoverage,
+                                            IntervalType, Sex, TranscriptTag)
 
 LOG = logging.getLogger("uvicorn.access")
 CHROM_INDEX = 0
@@ -44,6 +39,16 @@ def get_intervals_coords_list(
         interval_coords.append((interval.chromosome, interval.start, interval.stop))
     return interval_coords
 
+
+def get_d4tools_intervals_mean_coverage(d4_file_path: str, intervals: List[str]) -> List[float]:
+    """Return the mean value over a list of intervals of a d4 file."""
+
+    tmp_bed_file = tempfile.NamedTemporaryFile()
+    with open("tmp_bed_file", "w") as tmp_bed_file:
+        tmp_bed_file.write("\n".join(intervals))
+        mean_cov_by_interval: List[float] = get_d4tools_intervals_coverage(d4_file_path = d4_file_path, bed_file_path = tmp_bed_file.name)
+
+        return mean_cov_by_interval
 
 def get_intervals_mean_coverage(
     d4_file: D4File, intervals: List[Tuple[str, int, int]]

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -21,6 +21,7 @@ LOG = logging.getLogger("uvicorn.access")
 CHROM_INDEX = 0
 START_INDEX = 1
 STOP_INDEX = 2
+STATS_INDEX = 3
 
 
 def set_interval(
@@ -43,6 +44,20 @@ def get_intervals_coords_list(
     for interval in intervals:
         interval_coords.append((interval.chromosome, interval.start, interval.stop))
     return interval_coords
+
+
+def get_d4tools_chromosome_mean_coverage(d4_file_path: str, chromosome=str) -> float:
+    """Return mean coverage over one entire chromosome."""
+
+    chromosomes_stats_mean_cmd: List[str] = subprocess.check_output(
+        ["d4tools", "stat", "-s" "mean", d4_file_path],
+        text=True,
+    ).splitlines()
+
+    for line in chromosomes_stats_mean_cmd:
+        stats_data: List[str] = line.split("\t")
+        if chromosome == stats_data[CHROM_INDEX]:
+            return stats_data[STATS_INDEX]
 
 
 def get_d4tools_intervals_mean_coverage(

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -21,7 +21,7 @@ LOG = logging.getLogger("uvicorn.access")
 CHROM_INDEX = 0
 START_INDEX = 1
 STOP_INDEX = 2
-STATS_INDEX = 3
+STATS_MEAN_COVERAGE_INDEX = 3
 
 
 def set_interval(

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -9,8 +9,13 @@ from sqlalchemy.orm import Session
 
 from chanjo2.crud.intervals import get_gene_intervals
 from chanjo2.models import SQLExon, SQLGene, SQLTranscript
-from chanjo2.models.pydantic_models import (GeneCoverage, IntervalCoverage,
-                                            IntervalType, Sex, TranscriptTag)
+from chanjo2.models.pydantic_models import (
+    GeneCoverage,
+    IntervalCoverage,
+    IntervalType,
+    Sex,
+    TranscriptTag,
+)
 
 LOG = logging.getLogger("uvicorn.access")
 CHROM_INDEX = 0
@@ -40,15 +45,19 @@ def get_intervals_coords_list(
     return interval_coords
 
 
-def get_d4tools_intervals_mean_coverage(d4_file_path: str, intervals: List[str]) -> List[float]:
+def get_d4tools_intervals_mean_coverage(
+    d4_file_path: str, intervals: List[str]
+) -> List[float]:
     """Return the mean value over a list of intervals of a d4 file."""
 
     tmp_bed_file = tempfile.NamedTemporaryFile()
-    with open("tmp_bed_file", "w") as tmp_bed_file:
-        tmp_bed_file.write("\n".join(intervals))
-        mean_cov_by_interval: List[float] = get_d4tools_intervals_coverage(d4_file_path = d4_file_path, bed_file_path = tmp_bed_file.name)
+    with open(tmp_bed_file.name, "w") as bed_file:
+        bed_file.write("\n".join(intervals))
 
-        return mean_cov_by_interval
+    return get_d4tools_intervals_coverage(
+        d4_file_path=d4_file_path, bed_file_path=tmp_bed_file.name
+    )
+
 
 def get_intervals_mean_coverage(
     d4_file: D4File, intervals: List[Tuple[str, int, int]]


### PR DESCRIPTION
### This PR adds | fixes:
- Replace the python pyd4 library with a call to the rust program. The same function will be used to calculate the sex of the sample in the coverage report
- Fix #227 

**How to prepare for test**:
- Deploy locally and compute stats using a real case d4 file. Compute stats for
1. One entire chromosome (only coverage stats should be returned)
2. One region of a chromosome, for instance a gene (coverage + coverage coverage completeness should be returned, given that you provide coverage thresholds for the latter)

### How to test:
- Automatic tests should pass

### Expected outcome:
- [x] Expected stats should be returned

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
