### PR TITLE
Fix tipo in report template causing cramped error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 -  `coverage.d4_interval_coverage` endpoint crashing trying to computer coverage completeness over an entire chromosome
 - Samples mean coverage values a hundredfold higher on coverage reports
 - Install software packages using poetry v<1.8 to avoid problems installing pyd4 (pyd4 not supporting PEP 517 builds)
+- Typo in report template with unclosed span/div causing cramped genes not found message
 
 ## [1.4]
 ### Changed

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -7,7 +7,7 @@
 {% macro errors_block() %}
 	{% for error_description, error_content in errors %}
 		{% if error_content %}
-			<span class="alert alert-danger">{{error_description}}: {{error_content|join(", ")}}</span>
+			<div class="alert alert-danger">{{error_description}}: {{error_content|join(", ")}}</div>
 		{% endif %}
 	{% endfor %}
 {% endmacro %}


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #242 

Main branch:


<img width="1397" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/3c4b1e10-a474-47ee-b63b-dee39f7e2072">

<hr>

This branch:

<img width="1352" alt="image" src="https://github.com/Clinical-Genomics/chanjo2/assets/28093618/68b8cf01-8012-43e2-be48-d086adc01d8d">


### How to test:
- Connect scout to an instance of chanjo2 that doesn't have genes and exons
- Click on the demo case report in scout

### Expected outcome:
- This branch should show a clear error window

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
