### PR TITLE
Fix Mariabdb container not passing the healthcheck stage in docker-compose example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Samples mean coverage values a hundredfold higher on coverage reports
 - Install software packages using poetry v<1.8 to avoid problems installing pyd4 (pyd4 not supporting PEP 517 builds)
 - Typo in report template with unclosed span/div causing cramped genes not found message
+- Mariadb container not passing healthcheck when runned from demo docker-compose file
 
 ## [1.4]
 ### Changed

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -10,9 +10,10 @@ services:
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_DATABASE=${MYSQL_DATABASE_NAME}
+      - MYSQL_HOST_PORT=3307
       - MARIADB_RANDOM_ROOT_PASSWORD=T
     healthcheck: # Wait for the service to be ready before accepting incoming connections
-      test: "mysql --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --execute \"SHOW DATABASES;\""
+      test: "mariadb --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --execute \"SHOW DATABASES;\""
       timeout: 10s
       retries: 20
     volumes:

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -10,7 +10,7 @@ services:
       - MYSQL_USER=${MYSQL_USER}
       - MYSQL_PASSWORD=${MYSQL_PASSWORD}
       - MYSQL_DATABASE=${MYSQL_DATABASE_NAME}
-      - MYSQL_HOST_PORT=3307
+      - MYSQL_HOST_PORT=${MYSQL_HOST_PORT}
       - MARIADB_RANDOM_ROOT_PASSWORD=T
     healthcheck: # Wait for the service to be ready before accepting incoming connections
       test: "mariadb --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --execute \"SHOW DATABASES;\""


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #245

### How to test:
- [x] Start a the app in a container connected to a dockerized mariadb following the instructions present in the [docs](https://github.com/Clinical-Genomics/chanjo2/blob/main/docs/deployment/docker-deployment.md#launching-the-app-connected-to-a-mysql-database-via-docker-compose)

### Expected outcome:
- [x] The app should launch

### Review:
- [x] Code approved by Jakob37
- [x] Tests executed by CR, Jakob37

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
