### PR TITLE
Fix gene overview double-bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@
 - Renamed `handle_tasks.py` to `handle_completeness_tasks.py`
 - Refactored coverage endpoints `samples_genes_coverage`, `samples_transcripts_coverage` and `samples_exons_coverage` to use calls to d4tools instead of the pyd4 library
 - Speed up coverage report creation by collecting SQL intervals before looping through samples stats
+- Refactored gene overview to use d4tools instead of pyd4 lib to compute gene-level intervals stats
 ### Fixed
 -  `coverage.d4_interval_coverage` endpoint crashing trying to computer coverage completeness over an entire chromosome
 - Samples mean coverage values a hundredfold higher on coverage reports
 - Install software packages using poetry v<1.8 to avoid problems installing pyd4 (pyd4 not supporting PEP 517 builds)
 - Typo in report template with unclosed span/div causing cramped genes not found message
 - Mariadb container not passing healthcheck when runned from demo docker-compose file
+- Fixed an error on gene overview that made the coverage seem 100-folds higher
 
 ## [1.4]
 ### Changed

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -203,10 +203,6 @@ def get_gene_overview_coverage_stats(form_data: GeneReportForm, session: Session
 
     set_samples_coverage_files(session=session, samples=form_data.samples)
 
-    samples_d4_files: List[Tuple[str, D4File]] = [
-        (sample.name, D4File(sample.coverage_file_path)) for sample in form_data.samples
-    ]
-
     gene: SQLGene = get_hgnc_gene(
         build=form_data.build, hgnc_id=form_data.hgnc_gene_id, db=session
     )
@@ -215,14 +211,14 @@ def get_gene_overview_coverage_stats(form_data: GeneReportForm, session: Session
     gene_stats["gene"] = gene
 
     samples_coverage_stats: Dict[str, List[GeneCoverage]] = {
-        sample: get_sample_interval_coverage(
+        sample.name: get_sample_interval_coverage(
             db=session,
-            d4_file=d4_file,
+            d4_file_path=sample.coverage_file_path,
             genes=[gene],
             interval_type=INTERVAL_TYPE_SQL_TYPE[form_data.interval_type],
             completeness_thresholds=form_data.completeness_thresholds,
         )
-        for sample, d4_file in samples_d4_files
+        for sample in form_data.samples
     }
     gene_stats["samples_coverage_stats_by_interval"] = (
         get_gene_coverage_stats_by_interval(coverage_by_sample=samples_coverage_stats)

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -13,7 +13,7 @@
 			</div>
 			<div class="table-responsive">
 				<table class="table table-bordered">
-					<caption>Coverage overview over gene {{ gene.hgnc_symbol or gene.hgnc_id }}</caption>
+					<caption>Coverage overview over gene {{ gene.hgnc_symbol or gene.hgnc_id }} - {{interval_id}}</caption>
 					<thead>
 						<th>Sample</th>
 						<th>Mean coverage</th>

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -24,7 +24,7 @@
 					<tbody>
 					{% for sample_stats in samples_stats %}
 						<td>{{ sample_stats[0] }}</td>
-						<td>{{ (sample_stats[1] * 100)|round(2) }}</td>
+						<td>{{ sample_stats[1]|round(2) }}</td>
 						{% for level, _ in levels.items() %}
 							<td>{{ (sample_stats[2][level] * 100)|round(2) }}</td>
 						{% endfor %}


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #248
- Fix the interval coverage value displayed on the gene overview (there is a bug on current main that multiplies this value by 100)

### How to test:
- On a local instance of chanjo2 go to geneS overview demo page: http://localhost:8000/overview/demo
- Click on the link of any gene

### Expected outcome:
- [x] Gene overview page should be displayed as expected

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
