### PR TITLE
Minor release 1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [1.5]
 ### Added
 - `coverage.d4_intervals_coverage` responses contain also interval name as provided in bed file
 - `coverage.d4_interval_coverage` responses now returns also the genomic region used to compute the stats on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - Removed 2 redundant functions in `meta.handle.bed.py`
 - `coverage.d4_interval_coverage` is using direct calls to d4tools to retrieve stats over an entire chromosome or a genomic interval
 - Reformat report sample' sex rows and coverage.get_samples_predicted_sex endpoint to use d4tools and not pyd4 for evaluating sample sex
-- Dockerized chanjo2 uses pyd4 v0.3.9 already provided in the Docker base image
 - Refactored code to create coverage report and genes overview report to be faster by using d4tools calls and multiprocessing
 - Renamed `handle_tasks.py` to `handle_completeness_tasks.py`
 - Refactored coverage endpoints `samples_genes_coverage`, `samples_transcripts_coverage` and `samples_exons_coverage` to use calls to d4tools instead of the pyd4 library

--- a/src/chanjo2/__init__.py
+++ b/src/chanjo2/__init__.py
@@ -1,4 +1,4 @@
 from dotenv import load_dotenv
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 load_dotenv()


### PR DESCRIPTION
## [1.5]
### Added
- `coverage.d4_intervals_coverage` responses contain also interval name as provided in bed file
- `coverage.d4_interval_coverage` responses now returns also the genomic region used to compute the stats on
- Test for modified function collecting coverage report data
### Changed
- Speed up response by `coverage.d4_intervals_coverage` by replacing pyd4 lib with direct calls d4tools and multiprocessing
- Removed 2 redundant functions in `meta.handle.bed.py`
- `coverage.d4_interval_coverage` is using direct calls to d4tools to retrieve stats over an entire chromosome or a genomic interval
- Reformat report sample' sex rows and coverage.get_samples_predicted_sex endpoint to use d4tools and not pyd4 for evaluating sample sex
- Refactored code to create coverage report and genes overview report to be faster by using d4tools calls and multiprocessing
- Renamed `handle_tasks.py` to `handle_completeness_tasks.py`
- Refactored coverage endpoints `samples_genes_coverage`, `samples_transcripts_coverage` and `samples_exons_coverage` to use calls to d4tools instead of the pyd4 library
- Speed up coverage report creation by collecting SQL intervals before looping through samples stats
- Refactored gene overview to use d4tools instead of pyd4 lib to compute gene-level intervals stats
- Removed pyd4 lib and all remaining code which was still using it
### Fixed
-  `coverage.d4_interval_coverage` endpoint crashing trying to computer coverage completeness over an entire chromosome
- Samples mean coverage values a hundredfold higher on coverage reports
- Install software packages using poetry v<1.8 to avoid problems installing pyd4 (pyd4 not supporting PEP 517 builds)
- Typo in report template with unclosed span/div causing cramped genes not found message
- Mariadb container not passing healthcheck when runned from demo docker-compose file
- Fixed an error on gene overview that made the coverage seem 100-folds higher
- Return error when genes are not provided in the request form to create a coverage report

### Review:
- [ ] Code approved by
- [ ] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
