### PR TITLE
Fix connection gone error by changing engine settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Fixed
+- Avoid MySQLdb.OperationalError `Server has gone away` by modifying by setting `pool_pre_ping=True` when creating the engine
+
 ## [1.5]
 ### Added
 - `coverage.d4_intervals_coverage` responses contain also interval name as provided in bed file

--- a/src/chanjo2/dbutil.py
+++ b/src/chanjo2/dbutil.py
@@ -30,7 +30,7 @@ else:
         host = ":".join([host_name, port_no])
 
     mysql_url = f"mysql://{db_user}:{db_password}@{host}/{db_name}"
-    engine = create_engine(mysql_url, echo=True, future=True)
+    engine = create_engine(mysql_url, echo=True, future=True, pool_pre_ping=True)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)
 Base = declarative_base()


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #256 . Solution found [here](https://stackoverflow.com/questions/61074352/pymysql-err-operationalerror-2006-mysql-server-has-gone-away-timeouterror1)

### How to test:
- Deploy on stage and wait some time for the connection
- Try to create the demo report (https://chanjo2-stage.scilifelab.se/report/demo)

### Expected outcome:
- [x] The server gone away error should not happen again

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
