### PR TITLE
Gene coverage overview to display transcript-level stats for WGS data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Fixed
 - Avoid MySQLdb.OperationalError `Server has gone away` by modifying by setting `pool_pre_ping=True` when creating the engine
 - Coverage report screenshot displayed on README page and on the documenattion to reflect true statistics from the demo samples
+- Coverage overview over a gene should return transcript statistics if D4 file contains WGS data
 
 ## [1.5]
 ### Added

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -274,7 +274,7 @@ class GeneReportForm(BaseModel):
 
     @field_validator("interval_type", mode="before")
     def interval_type_validator(cls, interval_type: IntervalType) -> IntervalType:
-        """Make sure that Gene stats are including transcript data even if it's a WGS analysis."""
+        """Make sure that gene stats include transcript data even if it's a WGS analysis."""
         if interval_type == IntervalType.GENES:
             return IntervalType.TRANSCRIPTS
         return interval_type

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -272,6 +272,13 @@ class GeneReportForm(BaseModel):
         thresholds: List[str] = completeness_thresholds.split(",")
         return [int(threshold.strip()) for threshold in thresholds]
 
+    @field_validator("interval_type", mode="before")
+    def interval_type_validator(cls, interval_type: IntervalType):
+        """Make sure that Gene stats are including transcript data even if"""
+        if interval_type == IntervalType.GENES:
+            return IntervalType.TRANSCRIPTS
+        return interval_type
+
 
 class SampleSexRow(BaseModel):
     sample: str

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -274,7 +274,7 @@ class GeneReportForm(BaseModel):
 
     @field_validator("interval_type", mode="before")
     def interval_type_validator(cls, interval_type: IntervalType):
-        """Make sure that Gene stats are including transcript data even if"""
+        """Make sure that Gene stats are including transcript data even if it's a WGS analysis."""
         if interval_type == IntervalType.GENES:
             return IntervalType.TRANSCRIPTS
         return interval_type

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -273,7 +273,7 @@ class GeneReportForm(BaseModel):
         return [int(threshold.strip()) for threshold in thresholds]
 
     @field_validator("interval_type", mode="before")
-    def interval_type_validator(cls, interval_type: IntervalType):
+    def interval_type_validator(cls, interval_type: IntervalType) -> IntervalType:
         """Make sure that Gene stats are including transcript data even if it's a WGS analysis."""
         if interval_type == IntervalType.GENES:
             return IntervalType.TRANSCRIPTS


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #262 

### How to test:
- Deploy on cg-vm1
- Deploy [this branch](https://github.com/Clinical-Genomics/scout/pull/4529) of Scout 
- Go to [this scout case](https://scout-stage.scilifelab.se/cust000/F0006358-mip7)
- Click on genes coverage report overview for the HPO panel
- Click on the link of one of the genes in the report above

### Expected outcome:
- [x] Main branch of chanjo2 should not display any stats
- [x] This branch should instead show transcripts stats

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
