### PR TITLE
Prepare patch release 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [1.5.1]
 ### Fixed
 - Avoid MySQLdb.OperationalError `Server has gone away` by modifying by setting `pool_pre_ping=True` when creating the engine
 - Coverage report screenshot displayed on README page and on the documenattion to reflect true statistics from the demo samples

--- a/src/chanjo2/__init__.py
+++ b/src/chanjo2/__init__.py
@@ -1,4 +1,4 @@
 from dotenv import load_dotenv
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"
 load_dotenv()


### PR DESCRIPTION
## [1.5.1]
### Fixed
- Avoid MySQLdb.OperationalError `Server has gone away` by modifying by setting `pool_pre_ping=True` when creating the engine
- Coverage report screenshot displayed on README page and on the documenattion to reflect true statistics from the demo samples
- Coverage report/overview page crashing when transcripts or exons intervals are required only genes are loaded
- Coverage overview over a gene should return transcript statistics if D4 file contains WGS data


### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
