### PR TITLE
Speed up genes coverage overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Fixed
+- Faster genes overview report loading
+
 ## [1.5.1]
 ### Fixed
 - Avoid MySQLdb.OperationalError `Server has gone away` by modifying by setting `pool_pre_ping=True` when creating the engine

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -34,7 +34,9 @@ async def demo_overview(request: Request, db: Session = Depends(get_session)):
     """Return a demo genes overview page over a list of genes for a list of samples."""
 
     overview_query = ReportQuery(**DEMO_COVERAGE_QUERY_DATA)
-    overview_content: dict = get_report_data(query=overview_query, session=db)
+    overview_content: dict = get_report_data(
+        query=overview_query, session=db, is_overview=True
+    )
     return templates.TemplateResponse(
         "overview.html",
         {
@@ -52,7 +54,9 @@ async def overview(
 ):
     """Return the genes overview page over a list of genes for a list of samples."""
 
-    overview_content: dict = get_report_data(query=report_query, session=db)
+    overview_content: dict = get_report_data(
+        query=report_query, session=db, is_overview=True
+    )
     return templates.TemplateResponse(
         "overview.html",
         {

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -63,7 +63,9 @@ def _serialize_sample(sample: ReportQuerySample) -> Dict[str, str]:
     }
 
 
-def get_report_data(query: ReportQuery, session: Session) -> Dict:
+def get_report_data(
+    query: ReportQuery, session: Session, is_overview: Optional[boolean] = False
+) -> Dict:
     """Return the information that will be displayed in the coverage report or in the genes overview report.."""
 
     set_samples_coverage_files(session=session, samples=query.samples)
@@ -133,7 +135,9 @@ def get_report_data(query: ReportQuery, session: Session) -> Dict:
             gene_ids_mapping=gene_ids_mapping,
             sql_intervals=sql_intervals,
             intervals_coords=intervals_coords,
-            completeness_thresholds=query.completeness_thresholds,
+            completeness_thresholds=(
+                query.default_level if is_overview else query.completeness_thresholds
+            ),
             default_threshold=query.default_level,
             report_data=data,
         )

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -64,7 +64,7 @@ def _serialize_sample(sample: ReportQuerySample) -> Dict[str, str]:
 
 
 def get_report_data(
-    query: ReportQuery, session: Session, is_overview: Optional[boolean] = False
+    query: ReportQuery, session: Session, is_overview: Optional[bool] = False
 ) -> Dict:
     """Return the information that will be displayed in the coverage report or in the genes overview report.."""
 

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -136,7 +136,7 @@ def get_report_data(
             sql_intervals=sql_intervals,
             intervals_coords=intervals_coords,
             completeness_thresholds=(
-                query.default_level if is_overview else query.completeness_thresholds
+                [query.default_level] if is_overview else query.completeness_thresholds
             ),
             default_threshold=query.default_level,
             report_data=data,


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #265 -> Avoid creating unused stats when loading genes overview page

### How to test:
- Deploy on stage
- Test by creating a genes coverage overview with scout case [safeguinea](https://scout-stage.scilifelab.se/cust000/F0006358-mip7)

### Expected outcome:
- [x] Mitocarta panel (around 1K genes), **it takes 15 seconds on main branch and 9 seconds with this branch**

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
