### PR TITLE
Modify pydantic model so report endpoints accept either JSON or form data

### DIFF
--- a/.github/workflows/tests_n_coverage.yml
+++ b/.github/workflows/tests_n_coverage.yml
@@ -55,7 +55,7 @@ jobs:
           poetry run pytest --cov=./ --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           flags: unittests
           files: ./coverage.xml

--- a/.github/workflows/tests_n_coverage.yml
+++ b/.github/workflows/tests_n_coverage.yml
@@ -55,12 +55,10 @@ jobs:
           poetry run pytest --cov=./ --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           flags: unittests
           files: ./coverage.xml
           name: codecov-umbrella
           fail_ci_if_error: true
           verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests_n_coverage.yml
+++ b/.github/workflows/tests_n_coverage.yml
@@ -62,3 +62,5 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: true
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [unreleased]
 ### Added
 - Coverage report and genes coverage overview endpoints now accept also requests with application/x-www-form-urlencoded data
+### Changed
+- Updated codecov-action to version 4
 ### Fixed
 - Faster genes overview report loading
 - Broken GitHub action due to d4tools failing to install using cargo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ### Fixed
 - Faster genes overview report loading
 
+## [unreleased]
+### Added
+- Coverage report and genes coverage overview endpoints now accept also requests with application/x-www-form-urlencoded data
+
 ## [1.5.1]
 ### Fixed
 - Avoid MySQLdb.OperationalError `Server has gone away` by modifying by setting `pool_pre_ping=True` when creating the engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 ## [unreleased]
 ### Added
-- Coverage report and gene coverage overview accept also requests with application/x-www-form-urlencoded data
+- Coverage report and genes coverage overview endpoints now accept also requests with application/x-www-form-urlencoded data
 ### Fixed
 - Faster genes overview report loading
-
-## [unreleased]
-### Added
-- Coverage report and genes coverage overview endpoints now accept also requests with application/x-www-form-urlencoded data
 
 ## [1.5.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## [unreleased]
 ### Added
 - Coverage report and genes coverage overview endpoints now accept also requests with application/x-www-form-urlencoded data
-### Changed
-- Updated codecov-action to version 4
 ### Fixed
 - Faster genes overview report loading
 - Broken GitHub action due to d4tools failing to install using cargo

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 from importlib_resources import files
 
-from chanjo2.constants import BUILD_37
+from chanjo2.constants import BUILD_37, DEFAULT_COMPLETENESS_LEVELS
 
 BASE_PATH: str = "chanjo2.demo"
 
@@ -57,5 +57,8 @@ DEMO_COVERAGE_QUERY_FORM = {
     "ensembl_gene_ids": [],
     "hgnc_gene_ids": [],
     "hgnc_gene_symbols": ",".join(DEMO_HGNC_GENE_SYMBOLS),
-    "default_level": '20',
+    "default_level": "20",
+    "completeness_thresholds": ",".join(
+        [str(threshold) for threshold in DEFAULT_COMPLETENESS_LEVELS]
+    ),
 }

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -25,8 +25,9 @@ DEMO_SAMPLE: Dict[str, str] = {
 
 HTTP_SERVER_D4_file = "https://d4-format-testing.s3.us-west-1.amazonaws.com/hg002.d4"
 DEMO_HGNC_GENE_SYMBOLS = ["MTHFR", "DHFR", "FOLR1", "SLC46A1", "LAMA1", "PIPPI6"]
+ANALYSIS_DATE = "2023-04-23T10:20:30.400+02:30"
 
-# Data for generating a demo coverage report
+# JSON Data for generating a demo coverage report
 DEMO_COVERAGE_QUERY_DATA = {
     "build": BUILD_37,
     "samples": [
@@ -34,7 +35,7 @@ DEMO_COVERAGE_QUERY_DATA = {
             "name": DEMO_SAMPLE["name"],
             "case_name": DEMO_CASE["name"],
             "coverage_file_path": d4_demo_path,
-            "analysis_date": "2023-04-23T10:20:30.400+02:30",
+            "analysis_date": ANALYSIS_DATE,
         }
     ],
     "case_display_name": "643594",
@@ -43,5 +44,18 @@ DEMO_COVERAGE_QUERY_DATA = {
     "ensembl_gene_ids": [],
     "hgnc_gene_ids": [],
     "hgnc_gene_symbols": DEMO_HGNC_GENE_SYMBOLS,
+    "default_level": 20,
+}
+
+# HTTP FORM-like data for generating a demo coverage report
+DEMO_COVERAGE_QUERY_FORM = {
+    "build": BUILD_37,
+    "samples": f"[{{'name': '{DEMO_SAMPLE['name']}', 'coverage_file_path': '{d4_demo_path}', 'case_name': '{DEMO_CASE['name']}', 'analysis_date': '{ANALYSIS_DATE}'}}]",
+    "case_display_name": DEMO_CASE["name"],
+    "gene_panel": "A test Panel 1.0",
+    "interval_type": "transcripts",
+    "ensembl_gene_ids": [],
+    "hgnc_gene_ids": [],
+    "hgnc_gene_symbols": ",".join(DEMO_HGNC_GENE_SYMBOLS),
     "default_level": 20,
 }

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -57,5 +57,5 @@ DEMO_COVERAGE_QUERY_FORM = {
     "ensembl_gene_ids": [],
     "hgnc_gene_ids": [],
     "hgnc_gene_symbols": ",".join(DEMO_HGNC_GENE_SYMBOLS),
-    "default_level": 20,
+    "default_level": '20',
 }

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -58,9 +58,9 @@ async def overview(
     request_headers: str = request.headers.get("Content-Type")
     try:
         if request_headers == "application/json":
-            overview_query: dict = ReportQuery(**await request.json())
+            overview_query = ReportQuery(**await request.json())
         else:
-            overview_query: dict = ReportQuery.as_form(await request.form())
+            overview_query = ReportQuery.as_form(await request.form())
 
     except ValidationError as ve:
         raise HTTPException(

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -50,7 +50,9 @@ async def demo_overview(request: Request, db: Session = Depends(get_session)):
 
 @router.post("/overview", response_class=HTMLResponse)
 async def overview(
-    request: Request, report_query: ReportQuery, db: Session = Depends(get_session)
+    request: Request,
+    report_query: ReportQuery = Depends(ReportQuery.as_form),
+    db: Session = Depends(get_session),
 ):
     """Return the genes overview page over a list of genes for a list of samples."""
 

--- a/src/chanjo2/endpoints/report.py
+++ b/src/chanjo2/endpoints/report.py
@@ -60,9 +60,11 @@ async def report(
     request_headers: str = request.headers.get("Content-Type")
 
     try:
+        LOG.warning("JSON")
         if request_headers == "application/json":
             report_query = ReportQuery(**await request.json())
         else:
+            LOG.warning("FORM")
             report_query = ReportQuery.as_form(await request.form())
     except ValidationError as ve:
         raise HTTPException(

--- a/src/chanjo2/endpoints/report.py
+++ b/src/chanjo2/endpoints/report.py
@@ -50,7 +50,9 @@ async def demo_report(request: Request, db: Session = Depends(get_session)):
 
 @router.post("/report", response_class=HTMLResponse)
 async def report(
-    request: Request, report_query: ReportQuery, db: Session = Depends(get_session)
+    request: Request,
+    report_query: ReportQuery = Depends(ReportQuery.as_form),
+    db: Session = Depends(get_session),
 ):
     """Return a coverage report over a list of genes for a list of samples."""
 

--- a/src/chanjo2/endpoints/report.py
+++ b/src/chanjo2/endpoints/report.py
@@ -63,7 +63,6 @@ async def report(
         if request_headers == "application/json":
             report_query = ReportQuery(**await request.json())
         else:
-            LOG.warning(await request.form())
             report_query = ReportQuery.as_form(await request.form())
     except ValidationError as ve:
         raise HTTPException(

--- a/src/chanjo2/endpoints/report.py
+++ b/src/chanjo2/endpoints/report.py
@@ -61,9 +61,9 @@ async def report(
 
     try:
         if request_headers == "application/json":
-            report_query: dict = ReportQuery(**await request.json())
+            report_query = ReportQuery(**await request.json())
         else:
-            report_query: dict = ReportQuery.as_form(await request.form())
+            report_query = ReportQuery.as_form(await request.form())
     except ValidationError as ve:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/src/chanjo2/endpoints/report.py
+++ b/src/chanjo2/endpoints/report.py
@@ -60,11 +60,10 @@ async def report(
     request_headers: str = request.headers.get("Content-Type")
 
     try:
-        LOG.warning("JSON")
         if request_headers == "application/json":
             report_query = ReportQuery(**await request.json())
         else:
-            LOG.warning("FORM")
+            LOG.warning(await request.form())
             report_query = ReportQuery.as_form(await request.form())
     except ValidationError as ve:
         raise HTTPException(

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -239,17 +239,11 @@ class ReportQuery(BaseModel):
         return cls(
             build=form_data.get("build"),
             completeness_thresholds=[
-                int(threshold) for threshold in form_data.getlist("hgnc_gene_ids")
+                int(threshold) for threshold in form_data.get("completeness_thresholds")
             ],
-            ensembl_gene_ids=[
-                ensembl_id for ensembl_id in form_data.getlist("ensembl_gene_ids")
-            ],
-            hgnc_gene_ids=[
-                int(hgnc_id) for hgnc_id in form_data.getlist("hgnc_gene_ids")
-            ],
-            hgnc_gene_symbols=[
-                gene_symbol for gene_symbol in form_data.getlist("hgnc_gene_symbols")
-            ],
+            ensembl_gene_ids=form_data.get("ensembl_gene_ids"),
+            hgnc_gene_ids=[int(hgnc_id) for hgnc_id in form_data.get("hgnc_gene_ids")],
+            hgnc_gene_symbols=form_data.get("hgnc_gene_symbols"),
             interval_type=form_data.get("interval_type"),
             default_level=form_data.get("default_level"),
             panel_name=form_data.get("panel_name"),

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -1,6 +1,5 @@
 import json
 import logging
-from ast import literal_eval
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -235,20 +234,20 @@ class ReportQuery(BaseModel):
     samples: List[ReportQuerySample]
 
     @staticmethod
-    def format_list(str_list):
-        if isinstance(str_list, str):
-            return literal_eval(str_list)
+    def format_list(str_list: str, cast_type: Union[int, str]):
+        if str_list and isinstance(str_list, str):
+            return list([cast_type(item) for item in str_list.split(",")])
 
     @classmethod
     def as_form(
         cls,
         build: str = Form(...),
-        completeness_thresholds: Union[list, str] = Form(
-            str(DEFAULT_COMPLETENESS_LEVELS)
+        completeness_thresholds: Optional[str] = Form(
+            ",".join([str(num) for num in DEFAULT_COMPLETENESS_LEVELS])
         ),
-        ensembl_gene_ids: Union[list, str] = Form(None),
-        hgnc_gene_ids: Union[list, str] = Form(None),
-        hgnc_gene_symbols: Union[list, str] = Form(None),
+        ensembl_gene_ids: Optional[str] = Form(None),
+        hgnc_gene_ids: Optional[str] = Form(None),
+        hgnc_gene_symbols: Optional[str] = Form(None),
         interval_type: str = Form(...),
         default_level: int = Form(...),
         panel_name: Optional[str] = Form(...),
@@ -257,10 +256,10 @@ class ReportQuery(BaseModel):
     ):
         return cls(
             build=build,
-            completeness_thresholds=cls.format_list(completeness_thresholds),
-            ensembl_gene_ids=cls.format_list(ensembl_gene_ids),
-            hgnc_gene_ids=cls.format_list(hgnc_gene_ids),
-            hgnc_gene_symbols=cls.format_list(hgnc_gene_symbols),
+            completeness_thresholds=cls.format_list(completeness_thresholds, int),
+            ensembl_gene_ids=cls.format_list(ensembl_gene_ids, str),
+            hgnc_gene_ids=cls.format_list(hgnc_gene_ids, int),
+            hgnc_gene_symbols=cls.format_list(hgnc_gene_symbols, str),
             interval_type=interval_type,
             default_level=default_level,
             panel_name=panel_name,

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -235,7 +235,7 @@ class ReportQuery(BaseModel):
 
     @staticmethod
     def fix_string_list_values(
-        string_list: Optional[str], items_format: Union[str, int]
+        comma_sep_values: Optional[str], items_format: Union[str, int]
     ) -> Optional[List[Union[str, int]]]:
         """Helper function that formats list of strings or integers passed by a form as comma separated values."""
         if string_list is None:

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -234,33 +234,34 @@ class ReportQuery(BaseModel):
     samples: List[ReportQuerySample]
 
     @staticmethod
-    def fix_string_list_values(
+    def comma_sep_values_to_list(
         comma_sep_values: Optional[str], items_format: Union[str, int]
     ) -> Optional[List[Union[str, int]]]:
         """Helper function that formats list of strings or integers passed by a form as comma separated values."""
-        if string_list is None:
+        if comma_sep_values is None:
             return
         if items_format == str:
-            return [item.strip() for item in string_list.split(",")]
+            return [item.strip() for item in comma_sep_values.split(",")]
         else:
-            return [int(item.strip()) for item in string_list.split(",")]
+            return [int(item.strip()) for item in comma_sep_values.split(",")]
 
     @classmethod
     def as_form(cls, form_data: FormData) -> "ReportQuery":
-        return cls(
+        report_query = cls(
             build=form_data.get("build"),
-            completeness_thresholds=cls.fix_string_list_values(
-                string_list=form_data.get("completeness_thresholds"), items_format=int
+            completeness_thresholds=cls.comma_sep_values_to_list(
+                comma_sep_values=form_data.get("completeness_thresholds"),
+                items_format=int,
             )
             or DEFAULT_COMPLETENESS_LEVELS,
-            ensembl_gene_ids=cls.fix_string_list_values(
-                string_list=form_data.get("ensembl_gene_ids"), items_format=str
+            ensembl_gene_ids=cls.comma_sep_values_to_list(
+                comma_sep_values=form_data.get("ensembl_gene_ids"), items_format=str
             ),
-            hgnc_gene_ids=cls.fix_string_list_values(
-                string_list=form_data.get("hgnc_gene_ids"), items_format=int
+            hgnc_gene_ids=cls.comma_sep_values_to_list(
+                comma_sep_values=form_data.get("hgnc_gene_ids"), items_format=int
             ),
-            hgnc_gene_symbols=cls.fix_string_list_values(
-                string_list=form_data.get("hgnc_gene_symbols"), items_format=str
+            hgnc_gene_symbols=cls.comma_sep_values_to_list(
+                comma_sep_values=form_data.get("hgnc_gene_symbols"), items_format=str
             ),
             interval_type=form_data.get("interval_type"),
             default_level=form_data.get("default_level"),
@@ -268,6 +269,7 @@ class ReportQuery(BaseModel):
             case_display_name=form_data.get("case_display_name"),
             samples=form_data.get("samples"),
         )
+        return report_query
 
     @field_validator("samples", mode="before")
     def samples_validator(cls, sample_list):

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -246,10 +246,7 @@ class ReportQuery(BaseModel):
             default_level=form_data.get("default_level"),
             panel_name=form_data.get("panel_name"),
             case_display_name=form_data.get("case_display_name"),
-            samples=[
-                ast.literal_eval(string_sample)
-                for string_sample in form_data.getlist("samples")
-            ],
+            samples=form_data.get("samples"),
         )
 
     @field_validator("samples", mode="before")

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -247,12 +247,12 @@ class ReportQuery(BaseModel):
 
     @classmethod
     def as_form(cls, form_data: FormData) -> "ReportQuery":
-        LOG.warning(form_data.get("hgnc_gene_symbols"))
         return cls(
             build=form_data.get("build"),
             completeness_thresholds=cls.fix_string_list_values(
                 string_list=form_data.get("completeness_thresholds"), items_format=int
-            ),
+            )
+            or DEFAULT_COMPLETENESS_LEVELS,
             ensembl_gene_ids=cls.fix_string_list_values(
                 string_list=form_data.get("ensembl_gene_ids"), items_format=str
             ),

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -238,10 +238,18 @@ class ReportQuery(BaseModel):
     def as_form(cls, form_data: FormData) -> "ReportQuery":
         return cls(
             build=form_data.get("build"),
-            completeness_thresholds=form_data.getlist("completeness_thresholds"),
-            ensembl_gene_ids=form_data.getlist("ensembl_gene_ids"),
-            hgnc_gene_ids=form_data.getlist("hgnc_gene_ids"),
-            hgnc_gene_symbols=form_data.getlist("hgnc_gene_symbols"),
+            completeness_thresholds=[
+                int(threshold) for threshold in form_data.getlist("hgnc_gene_ids")
+            ],
+            ensembl_gene_ids=[
+                ensembl_id for ensembl_id in form_data.getlist("ensembl_gene_ids")
+            ],
+            hgnc_gene_ids=[
+                int(hgnc_id) for hgnc_id in form_data.getlist("hgnc_gene_ids")
+            ],
+            hgnc_gene_symbols=[
+                gene_symbol for gene_symbol in form_data.getlist("hgnc_gene_symbols")
+            ],
             interval_type=form_data.get("interval_type"),
             default_level=form_data.get("default_level"),
             panel_name=form_data.get("panel_name"),

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -1,11 +1,13 @@
 import json
 import logging
+from ast import literal_eval
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import validators
+from fastapi import Form
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import SettingsConfigDict
 
@@ -231,6 +233,40 @@ class ReportQuery(BaseModel):
     panel_name: Optional[str] = "Custom panel"
     case_display_name: Optional[str] = None
     samples: List[ReportQuerySample]
+
+    @staticmethod
+    def format_list(str_list):
+        if isinstance(str_list, str):
+            return literal_eval(str_list)
+
+    @classmethod
+    def as_form(
+        cls,
+        build: str = Form(...),
+        completeness_thresholds: Union[list, str] = Form(
+            str(DEFAULT_COMPLETENESS_LEVELS)
+        ),
+        ensembl_gene_ids: Union[list, str] = Form(None),
+        hgnc_gene_ids: Union[list, str] = Form(None),
+        hgnc_gene_symbols: Union[list, str] = Form(None),
+        interval_type: str = Form(...),
+        default_level: int = Form(...),
+        panel_name: Optional[str] = Form(...),
+        case_display_name: Optional[str] = Form(...),
+        samples: str = Form(...),
+    ):
+        return cls(
+            build=build,
+            completeness_thresholds=cls.format_list(completeness_thresholds),
+            ensembl_gene_ids=cls.format_list(ensembl_gene_ids),
+            hgnc_gene_ids=cls.format_list(hgnc_gene_ids),
+            hgnc_gene_symbols=cls.format_list(hgnc_gene_symbols),
+            interval_type=interval_type,
+            default_level=default_level,
+            panel_name=panel_name,
+            case_display_name=case_display_name,
+            samples=samples,
+        )
 
     @field_validator("samples", mode="before")
     def samples_validator(cls, sample_list):

--- a/tests/src/chanjo2/endpoints/test_overview.py
+++ b/tests/src/chanjo2/endpoints/test_overview.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from requests.models import Response
 
 from chanjo2.constants import BUILD_37, DEFAULT_COMPLETENESS_LEVELS
-from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA
+from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA, DEMO_COVERAGE_QUERY_FORM
 
 
 def test_demo_overview(client: TestClient, endpoints: Type):
@@ -44,7 +44,7 @@ def test_overview_form_data(client: TestClient, endpoints: Type):
     # GIVEN a query with application/x-www-form-urlencoded data to the genes coverage overview endpoint
     response: Response = client.post(
         endpoints.OVERVIEW,
-        data=DEMO_COVERAGE_QUERY_DATA,
+        data=DEMO_COVERAGE_QUERY_FORM,
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     # Then the request should be successful

--- a/tests/src/chanjo2/endpoints/test_overview.py
+++ b/tests/src/chanjo2/endpoints/test_overview.py
@@ -1,3 +1,4 @@
+import json
 from typing import Dict, List, Type
 
 from fastapi import status
@@ -22,7 +23,7 @@ def test_demo_overview(client: TestClient, endpoints: Type):
 
 
 def test_overview_json_data(client: TestClient, endpoints: Type):
-    """Test the endpoint that creates the genes coverage overview page by providing json data in POST request."""
+    """Test the endpoint that creates the genes coverage overview page by providing json data in the POST request."""
 
     # GIVEN a query with json data to the genes coverage overview endpoint
     response: Response = client.post(
@@ -30,6 +31,22 @@ def test_overview_json_data(client: TestClient, endpoints: Type):
         json=DEMO_COVERAGE_QUERY_DATA,
     )
 
+    # Then the request should be successful
+    assert response.status_code == status.HTTP_200_OK
+
+    # And return an HTML page
+    assert response.template.name == "overview.html"
+
+
+def test_overview_form_data(client: TestClient, endpoints: Type):
+    """Test the endpoint that creates the genes coverage overview page by providing application/x-www-form-urlencoded data in the POST request."""
+
+    # GIVEN a query with application/x-www-form-urlencoded data to the genes coverage overview endpoint
+    response: Response = client.post(
+        endpoints.OVERVIEW,
+        data=DEMO_COVERAGE_QUERY_DATA,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
     # Then the request should be successful
     assert response.status_code == status.HTTP_200_OK
 

--- a/tests/src/chanjo2/endpoints/test_report.py
+++ b/tests/src/chanjo2/endpoints/test_report.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from requests.models import Response
 
 from chanjo2.constants import GENE_LISTS_NOT_SUPPORTED_MSG
-from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA
+from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA, DEMO_COVERAGE_QUERY_FORM
 
 
 def test_demo_report(client: TestClient, endpoints: Type):
@@ -63,7 +63,7 @@ def test_report_form_data(client: TestClient, endpoints: Type):
     # GIVEN a query with application/x-www-form-urlencoded data to the report endpoint
     response: Response = client.post(
         endpoints.REPORT,
-        data=DEMO_COVERAGE_QUERY_DATA,
+        data=DEMO_COVERAGE_QUERY_FORM,
         headers={"Content-Type": "application/x-www-form-urlencoded"},
     )
     # Then the request should be successful

--- a/tests/src/chanjo2/endpoints/test_report.py
+++ b/tests/src/chanjo2/endpoints/test_report.py
@@ -61,7 +61,6 @@ def test_report_form_data(client: TestClient, endpoints: Type):
     """Test the coverage report endpoint by providing application/x-www-form-urlencoded data in a POST request."""
 
     # GIVEN a query with application/x-www-form-urlencoded data to the report endpoint
-    # GIVEN a query with json data to the report endpoint
     response: Response = client.post(
         endpoints.REPORT,
         data=DEMO_COVERAGE_QUERY_DATA,

--- a/tests/src/chanjo2/endpoints/test_report.py
+++ b/tests/src/chanjo2/endpoints/test_report.py
@@ -38,11 +38,11 @@ def test_report_request_no_genes(client: TestClient, endpoints: Type):
     # THEN the response should return the expected error code and message
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     result = response.json()
-    assert GENE_LISTS_NOT_SUPPORTED_MSG in result["detail"][0]["msg"]
+    assert GENE_LISTS_NOT_SUPPORTED_MSG in result["detail"]
 
 
 def test_report_json_data(client: TestClient, endpoints: Type):
-    """Test the coverage report endpoint by providing json data in POST request."""
+    """Test the coverage report endpoint by providing json data in a POST request."""
 
     # GIVEN a query with json data to the report endpoint
     response: Response = client.post(
@@ -51,6 +51,23 @@ def test_report_json_data(client: TestClient, endpoints: Type):
     )
 
     # THEN the request should be successful
+    assert response.status_code == status.HTTP_200_OK
+
+    # And return an HTML page
+    assert response.template.name == "report.html"
+
+
+def test_report_form_data(client: TestClient, endpoints: Type):
+    """Test the coverage report endpoint by providing application/x-www-form-urlencoded data in a POST request."""
+
+    # GIVEN a query with application/x-www-form-urlencoded data to the report endpoint
+    # GIVEN a query with json data to the report endpoint
+    response: Response = client.post(
+        endpoints.REPORT,
+        data=DEMO_COVERAGE_QUERY_DATA,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    # Then the request should be successful
     assert response.status_code == status.HTTP_200_OK
 
     # And return an HTML page


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #271 
 
### How to test:
- Deploy on stage and use in a combo with [this scout branch](https://github.com/Clinical-Genomics/scout/pull/4553) 

### Expected outcome:
- [x] Coverage report and coverage overview reports should be created

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
