### PR TITLE
Simplify templates to submit form data without transforming it to json first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [unreleased]
 ### Added
 - Coverage report and genes coverage overview endpoints now accept also requests with application/x-www-form-urlencoded data
+### Changed
+- Templates form submit data as application/x-www-form-urlencoded without having to transform it into json
 ### Fixed
 - Faster genes overview report loading
 - Broken GitHub action due to d4tools failing to install using cargo

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -11,7 +11,7 @@
     <ul class="navbar-nav">
 		{% for level_id, _ in levels.items() %}
 			<li class="nav-item">
-				<a class="nav-link {% if level_id == extras.default_level %}active{% endif %}" href="#" onclick="updateOverview({{level_id}});">Completeness {{ level_id }}x</a>
+				<a class="nav-link {% if level_id == extras.default_level %}active{% endif %}" href="#" onclick="return updateOverview({{level_id}});">Completeness {{ level_id }}x</a>
 			</li>
 		{% endfor%}
     </ul>
@@ -23,10 +23,13 @@
 {% macro incompletely_covered_intervals(active_level) %}
  <form id="geneStatsForm" action="{{url_for('gene_overview')}}" method="post">
 	 <input type="hidden" name="build" value="{{extras.build}}"/>
-	 <input type="hidden" name="default_level" value="{{extras.default_level}}"/>
+	 <input type="hidden" name="default_level" id="defaultLevel" value="{{extras.default_level}}"/>
 	 <input type="hidden" name="completeness_thresholds" value="{{extras.completeness_thresholds|join(',')}}"/>
 	 <input type="hidden" name="samples" value="{{extras.samples|safe}}"/>
 	 <input type="hidden" name="interval_type" value="{{extras.interval_type}}"/>
+	 {% if extras.hgnc_gene_ids %} <!-- genes should be loaded in database -->
+	 	<input type="hidden" name="hgnc_gene_ids" value="{{extras.hgnc_gene_ids|join(',')}}"/>
+	 {% endif %}
 </form>
 	<div class="row">
 		<div class="col-md-12">
@@ -100,40 +103,15 @@
 {% block js_code %}
 	{{ super() }}
 	<script>
-
-		// Extracts the content of the body element of an HTML page as a string
-		function updatedReportBody(html)
-		{
-			return /<body.*?>([\s\S]*)<\/body>/.exec(html)[1];
-		}
+		let theForm = document.getElementById("geneStatsForm");
 
 		function updateOverview(customLevel)
 		{
-			let formDict = {
-				'build' : '{{ extras.build }}',
-				'completeness_thresholds' : {{ extras.completeness_thresholds }},
-				'hgnc_gene_ids' : {{ extras.hgnc_gene_ids }},
-				'interval_type' : '{{ extras.interval_type }}',
-				'default_level' : customLevel,
-				'samples' : {{ extras.samples|safe }},
-			}
-
-			fetch('/overview', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json'
-					},
-					body: JSON.stringify(formDict)
-				})
-				.then(resp => resp.text())
-				.then(html => {
-					document.body.innerHTML = updatedReportBody(html);
-				})
-				.catch(error => {
-					console.error(error);
-			});
+			document.getElementById("defaultLevel").value = customLevel;
+			var theForm = document.getElementById("geneStatsForm");
+			theForm.action = '/overview';
+			theForm.submit();
 		}
-
 
 		function getGeneStatsPage(hgncId)
 		{

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -108,7 +108,6 @@
 		function updateOverview(customLevel)
 		{
 			document.getElementById("defaultLevel").value = customLevel;
-			var theForm = document.getElementById("geneStatsForm");
 			theForm.action = '/overview';
 			theForm.submit();
 		}
@@ -116,7 +115,6 @@
 		function getGeneStatsPage(hgncId)
 		{
 			event.preventDefault();
-			var theForm = document.getElementById("geneStatsForm");
 			var geneInput = document.createElement("input");
 			geneInput.setAttribute("type", "hidden");
 			geneInput.setAttribute("name", "hgnc_gene_id");

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -264,62 +264,6 @@
 				}
 			}
 		}
-
-		// Extracts the content of the body element of an HTML page as a string
-		function updatedReportBody(html)
-		{
-			return /<body.*?>([\s\S]*)<\/body>/.exec(html)[1];
-		}
-
-		// Returns the list of HGNC genes present in the user query as a sring as a list of integers
-		function getFormGeneIDsAsList()
-		{
-			let geneIdsTypes = [null, null, null]; // [Ensembl_ids_list, HGNC_ids_list, HGNC_symbols_list];
-			let formGeneIds = document.getElementById('gene_ids').value.replace(/\s/g, '').split(",");
-			if (!isNaN(formGeneIds[0])) {
-				geneIdsTypes[1] = formGeneIds.map(Number);
-			}
-			else if (formGeneIds[0].startsWith('ENSG')){
-				geneIdsTypes[0] = formGeneIds;
-			}
-			else{
-				geneIdsTypes[2] = formGeneIds;
-			}
-			return geneIdsTypes;
-		}
-
-		function submitAsJson()
-		{
-			event.preventDefault();
-			let geneIds = getFormGeneIDsAsList();
-			let formDict = {
-				'build' : '{{ extras.build }}',
-				'completeness_thresholds' : {{ extras.completeness_thresholds }},
-				'ensembl_gene_ids': geneIds[0],
-				'hgnc_gene_ids' : geneIds[1],
-				'hgnc_gene_symbols' : geneIds[2],
-				'interval_type' : '{{ extras.interval_type }}',
-				'panel_name' : document.getElementById("panel_name").value,
-				'default_level' : document.getElementById("default_level").value,
-				'case_display_name' : '{{ extras.case_name }}',
-				'samples' : {{ extras.samples|safe }},
-			}
-
-			fetch('/report', {
-					method: 'POST',
-					headers: {
-						'Content-Type': 'application/json'
-					},
-					body: JSON.stringify(formDict)
-				})
-				.then(resp => resp.text())
-				.then(html => {
-					document.body.innerHTML = updatedReportBody(html);
-				})
-				.catch(error => {
-					console.error(error);
-			});
-		}
 	</script>
 
 {% endblock %}

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -48,7 +48,7 @@
 			<div class="row">
 				<div class="col-7">
 				  <label class="form-label">Included genes (Comma separated list HGNC IDs)</label>
-				  <div><input class="form-control" type="text" name="hgnc_gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="ADK,GIT"></div>
+				  <div><input class="form-control" type="text" name="hgnc_gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="17284,21022,.."></div>
 				</div>
 				<div class="col-4 offset-1 mt-2">
 				  <button class="btn btn-primary mt-4" type="submit">Update</button>

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -26,6 +26,7 @@
 			<form name="customizeForm" action="{{url_for('report')}}" method="post">
 			<input type="hidden" id="build" name="build" value="{{extras.build}}">
 			<input type="hidden" id="interval_type" name="interval_type" value="{{extras.interval_type}}">
+			<input type="hidden" name="samples" value="{{extras.samples|safe}}"/>
 			  <div>
 				<div class="form-group">
 				  <div class="row" {% if hidden %}hidden{% endif %}>
@@ -48,16 +49,12 @@
 			<div class="row">
 				<div class="col-7">
 				  <label class="form-label">Included genes (Comma separated list HGNC IDs)</label>
-				  <div><input class="form-control" type="text" name="hgnc_gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="17284,21022,.."></div>
+				  <div><input class="form-control" type="text" name="hgnc_gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="17284, 21022,.."></div>
 				</div>
 				<div class="col-4 offset-1 mt-2">
 				  <button class="btn btn-primary mt-4" type="submit">Update</button>
 				</div>
 			</div>
-
-			{% for sample_id in sample_ids %}
-			  <input type="text" name="sample_id" value="{{ sample_id }}" hidden>
-			{% endfor %}
 			</form>
 		</div>
 	</div>

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -23,6 +23,7 @@
     <div id="flush-collapseOne" class="accordion-collapse collapse" aria-labelledby="flush-headingOne" data-bs-parent="#accordionFlushExample">
 		<div class="accordion-body">
 			<!-- hidden fields passed from previous query -->
+			<form name="customizeForm" action="{{url_for('report')}}" method="post"
 			<input type="hidden" id="build" name="build" value="{{extras.build}}">
 			<input type="hidden" id="interval_type" name="interval_type" value="{{extras.interval_type}}">
 			  <div>
@@ -50,7 +51,7 @@
 				  <div><input class="form-control" type="text" name="gene_ids" id ="gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="ADK,GIT"></div>
 				</div>
 				<div class="col-4 offset-1 mt-2">
-				  <button class="btn btn-primary mt-4" type="button" onclick="submitAsJson();">Update</button>
+				  <button class="btn btn-primary mt-4" type="submit">Update</button>
 				</div>
 			</div>
 

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -23,7 +23,7 @@
     <div id="flush-collapseOne" class="accordion-collapse collapse" aria-labelledby="flush-headingOne" data-bs-parent="#accordionFlushExample">
 		<div class="accordion-body">
 			<!-- hidden fields passed from previous query -->
-			<form name="customizeForm" action="{{url_for('report')}}" method="post"
+			<form name="customizeForm" action="{{url_for('report')}}" method="post">
 			<input type="hidden" id="build" name="build" value="{{extras.build}}">
 			<input type="hidden" id="interval_type" name="interval_type" value="{{extras.interval_type}}">
 			  <div>
@@ -47,8 +47,8 @@
 
 			<div class="row">
 				<div class="col-7">
-				  <label class="form-label">Included genes (Comma separated list of Ensembl IDs, HGNC IDs or HGNC symbols)</label>
-				  <div><input class="form-control" type="text" name="gene_ids" id ="gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="ADK,GIT"></div>
+				  <label class="form-label">Included genes (Comma separated list HGNC IDs)</label>
+				  <div><input class="form-control" type="text" name="hgnc_gene_ids" value="{{ extras.hgnc_gene_ids|join(', ') }}" placeholder="ADK,GIT"></div>
 				</div>
 				<div class="col-4 offset-1 mt-2">
 				  <button class="btn btn-primary mt-4" type="submit">Update</button>
@@ -58,8 +58,7 @@
 			{% for sample_id in sample_ids %}
 			  <input type="text" name="sample_id" value="{{ sample_id }}" hidden>
 			{% endfor %}
-
-			</div>
+			</form>
 		</div>
 	</div>
   </div>


### PR DESCRIPTION
### This PR adds | fixes:
- Since report endpoints are accepting form data, templates can submit forms without having to do the json transformation step now.

### How to test:
- Deploy on stage 
- Gp to demo report page, modify the query in "customize" and submit the form
- Go to demo overview page and click on a different completeness tab 

### Expected outcome:
- [x] Report and overview pages should work

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
