### PR TITLE
Fix updating gene panel name displayed on report page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+## [unreleased]
 ### Fixed
 - Updating gene panel name using the web form on report page
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Fixed
+- Updating gene panel name using the web form on report page
+
 ## [1.6]
 ### Added
 - Coverage report and genes coverage overview endpoints now accept also requests with application/x-www-form-urlencoded data

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -86,7 +86,10 @@ def get_report_data(
             "default_level": query.default_level,
             "interval_type": query.interval_type.value,
             "case_name": query.case_display_name,
-            "hgnc_gene_ids": [gene.hgnc_id for gene in genes],
+            "hgnc_gene_ids": [gene.hgnc_id for gene in genes]
+            or query.hgnc_gene_ids
+            or query.hgnc_gene_symbols
+            or query.ensembl_gene_ids,
             "build": query.build.value,
             "completeness_thresholds": query.completeness_thresholds,
             "samples": [_serialize_sample(sample) for sample in query.samples],

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -41,7 +41,7 @@
 
 				<div class="col-6">
 				  <label class="form-label">Gene panel name to display</label>
-				  <input class="form-control" id="panel_name" type="text" placeholder="Skeletal dysplasia 3.2" value="{{ extras.panel_name or '' }}">
+				  <input class="form-control" id="panel_name" name="panel_name" type="text" placeholder="Skeletal dysplasia 3.2" value="{{ extras.panel_name or '' }}">
 				</div>
 			  </div>
 			</div>


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #296 

### How to test:
Locally, from demo report: http://localhost:8000/report/demo
- Use Customize form to change displayed gene panel
- Gene panel should be modified

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
