### PR TITLE
Fix 'show genes' checkbox position on report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Fixed
+- Position of `Show genes` checkbox on report page
+
 ## [1.6]
 ### Added
 - Coverage report and genes coverage overview endpoints now accept also requests with application/x-www-form-urlencoded data

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -125,8 +125,10 @@
 
 {% macro default_level_metrics() %}
 <div>
-	 <span><label class="control-label">Show genes</label></span>
-	 <span><input type="checkbox" name="show_genes" onclick="toggle_visibility(['incompletelyCoveredGenesHeader', 'incompletelyCoveredGenesCell']);"></span>
+	<label>
+		Show genes
+		<input type="checkbox" name="show_genes" style="vertical-align:middle;" onclick="toggle_visibility(['incompletelyCoveredGenesHeader', 'incompletelyCoveredGenesCell']);">
+	</label>
 </div>
 <table class="table table-bordered table-hover">
 	 <caption>Genes/Transcripts/Exons coverage at default coverage threshold</caption>

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -124,10 +124,10 @@
 {% endmacro %}
 
 {% macro default_level_metrics() %}
- <div class="col-xs-1 col-xs-offset-9" style="text-align: right;"><input type="checkbox" name="show_genes" onclick="toggle_visibility(['incompletelyCoveredGenesHeader', 'incompletelyCoveredGenesCell']);"></div>
-	 <div class="col-xs-2">
-		 <label class="control-label">Show genes</label>
-	 </div>
+<div>
+	 <span><label class="control-label">Show genes</label></span>
+	 <span><input type="checkbox" name="show_genes" onclick="toggle_visibility(['incompletelyCoveredGenesHeader', 'incompletelyCoveredGenesCell']);"></span>
+</div>
 <table class="table table-bordered table-hover">
 	 <caption>Genes/Transcripts/Exons coverage at default coverage threshold</caption>
       <thead>

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -127,7 +127,7 @@
 <div>
 	<label>
 		Show genes
-		<input type="checkbox" name="show_genes" style="vertical-align:middle;" onclick="toggle_visibility(['incompletelyCoveredGenesHeader', 'incompletelyCoveredGenesCell']);">
+		<input type="checkbox" name="show_genes" style="vertical-align:middle;" onKeyDown="doSomething();" tabindex="0" onclick="toggle_visibility(['incompletelyCoveredGenesHeader', 'incompletelyCoveredGenesCell']);">
 	</label>
 </div>
 <table class="table table-bordered table-hover">


### PR DESCRIPTION
### This PR adds | fixes:
- Closes #295 

**How to prepare for test**:
- Deploy on stage env

### How to test:
-Check position of the checkbox on the page

### Expected outcome:
- Checkbox and its label should be close and aligned

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
