### PR TITLE
Prepare release 1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [1.7]
 ### Added
 - An environment.yml with the minimum supported python version (3.8) and the installed libs
 ### Changed

--- a/src/chanjo2/__init__.py
+++ b/src/chanjo2/__init__.py
@@ -1,4 +1,4 @@
 from dotenv import load_dotenv
 
-__version__ = "1.6"
+__version__ = "1.7"
 load_dotenv()


### PR DESCRIPTION
## [1.7]
### Added
- An environment.yml with the minimum supported python version (3.8) and the installed libs
### Changed
- pyd4 library no longer available in chanjo2 Docker image
### Fixed
- Position of `Show genes` checkbox on report page
- Updating gene panel name using the web form on report page

### Review:
- [ ] Code approved by
- [x] Tests executed by CR, Jakob37

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
