### PR TITLE
Move logging setup outside lifespan and db initialisation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [unreleased]
+### CHanged
+- Moved logging setup out of app lifespan and db initialization logic
 ### Fixed
 - Updated version of external images used in GitHub actions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [unreleased]
 ### CHanged
-- Moved logging setup out of app lifespan and db initialization logic
+- Moved logging setup out of app lifespan and db initialisation logic
 ### Fixed
 - Updated version of external images used in GitHub actions
 

--- a/src/chanjo2/logger.py
+++ b/src/chanjo2/logger.py
@@ -1,0 +1,14 @@
+import logging
+
+import uvicorn
+
+LOG = logging.getLogger("uvicorn.access")
+
+
+console_formatter = uvicorn.logging.ColourizedFormatter(
+    "{levelprefix} {asctime} : {message}", style="{", use_colors=True
+)
+if LOG.handlers:
+    LOG.handlers[0].setFormatter(console_formatter)
+else:
+    logging.basicConfig()

--- a/src/chanjo2/main.py
+++ b/src/chanjo2/main.py
@@ -23,6 +23,15 @@ APP_ROUTER_TAGS: List[Tuple] = [
     (overview.router, "overview"),
 ]
 
+# Configure logging
+console_formatter = uvicorn.logging.ColourizedFormatter(
+    "{levelprefix} {asctime} : {message}", style="{", use_colors=True
+)
+if LOG.handlers:
+    LOG.handlers[0].setFormatter(console_formatter)
+else:
+    logging.basicConfig()
+
 
 def create_db_and_tables():
     Base.metadata.create_all(engine)
@@ -56,15 +65,6 @@ for router, tag in APP_ROUTER_TAGS:
 
 
 async def startup_db():
-    # Configure logging
-    console_formatter = uvicorn.logging.ColourizedFormatter(
-        "{levelprefix} {asctime} : {message}", style="{", use_colors=True
-    )
-    if LOG.handlers:
-        LOG.handlers[0].setFormatter(console_formatter)
-    else:
-        logging.basicConfig()
-
     # Create database tables
     create_db_and_tables()
 

--- a/src/chanjo2/main.py
+++ b/src/chanjo2/main.py
@@ -1,19 +1,17 @@
-import logging
 import os
 from contextlib import asynccontextmanager
 from typing import List, Tuple
 
-import uvicorn
 from fastapi import FastAPI, status
 from fastapi.staticfiles import StaticFiles
 
 from chanjo2 import __version__
 from chanjo2.dbutil import engine
 from chanjo2.endpoints import cases, coverage, intervals, overview, report, samples
+from chanjo2.logger import LOG
 from chanjo2.models.sql_models import Base
 from chanjo2.populate_demo import load_demo_data
 
-LOG = logging.getLogger("uvicorn.access")
 APP_ROUTER_TAGS: List[Tuple] = [
     (intervals.router, "intervals"),
     (coverage.router, "coverage"),
@@ -22,15 +20,6 @@ APP_ROUTER_TAGS: List[Tuple] = [
     (report.router, "report"),
     (overview.router, "overview"),
 ]
-
-# Configure logging
-console_formatter = uvicorn.logging.ColourizedFormatter(
-    "{levelprefix} {asctime} : {message}", style="{", use_colors=True
-)
-if LOG.handlers:
-    LOG.handlers[0].setFormatter(console_formatter)
-else:
-    logging.basicConfig()
 
 
 def create_db_and_tables():


### PR DESCRIPTION
## Description
It's not a fix for #308, but setting up logging should be outside the function for the database setup 
- Moved logging setup out of app lifespan and db initialisation logic

### How to test
- [x]  Deploy on stage and make sure that the app starts and prints logging messages

## Review
- [x] Tests executed by CR
- [x] "Merge and deploy" approved by HS

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions