### PR TITLE
Update Dockefile to use d4tools 0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [unreleased]
 ### Fixed
 - Updated dependencies to address dependabot's security alerts
+- Use a base image containing d4tools 0.3.10 in Dockerfile
 
 ## [1.8]
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM clinicalgenomics/python3.11-venv-d4tools:1.0
+FROM clinicalgenomics/python3.11-venv-d4tools:2.0
 
 LABEL about.home="https://github.com/Clinical-Genomics/chanjo2"
 LABEL about.license="MIT License (MIT)"


### PR DESCRIPTION
## Description
### Fixed
- Change Dockerfile to use [a new base image](https://github.com/Clinical-Genomics/docker-base-images/pull/26) containing d4tools 0.3.10 (closes #299)

### How to test
- [x] Deploy image and run stats test 

### Expected outcome
- Stats should be consistent

## Review
- [x] Tests executed by Jakob37
- [x] "Merge and deploy" approved by Jakob37

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions