### PR TITLE
Fix tests GitHub action to use d4tools 0.3.10

### DIFF
--- a/.github/workflows/tests_n_coverage.yml
+++ b/.github/workflows/tests_n_coverage.yml
@@ -9,14 +9,12 @@ jobs:
       - name: Check out git repository
         uses: actions/checkout@v4
 
-      - name: Workaround for installing d4tools
-        run: |
-          echo 'location' >> ~/.curlrc # https://github.com/38/d4-format/pull/77#issuecomment-2044438359
-
       - name: Install d4tools
         uses: baptiste0928/cargo-install@v3
         with:
           crate: d4tools
+          git: https://github.com/38/d4-format.git
+          tag: v0.3.10
 
       - name: Set up python
         id: setup-python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [unreleased]
+### Changed
+- GitHub tests action to use d4tools 0.3.10
 ### Fixed
 - Updated dependencies to address dependabot's security alerts
 


### PR DESCRIPTION
## Description
### Changed
- Tests action to be using the same d4tools version as chanjo2

### How to test
- [x] Automatic tests

### Expected outcome
- All tests should pass

## Review
- [x] Tests executed by GitHub actions
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions