### PR TITLE
Minor release 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [1.9]
 ### Added
 - Condensed `/coverage/d4/genes/summary` for condensed stats over a gene list
 ### Changed

--- a/src/chanjo2/__init__.py
+++ b/src/chanjo2/__init__.py
@@ -1,4 +1,4 @@
 from dotenv import load_dotenv
 
-__version__ = "1.8"
+__version__ = "1.9"
 load_dotenv()


### PR DESCRIPTION
## [1.9]
### Added
- Condensed `/coverage/d4/genes/summary` for condensed stats over a gene list
- Documentation for new coverage summary endpoint
### Changed
- GitHub tests action to use d4tools 0.3.10
### Fixed
- Updated dependencies to address dependabot's security alerts
- Use a base image containing d4tools 0.3.10 in Dockerfile

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions