### PR TITLE
Expand coverage report explanation to better understand how coverage and coverage completeness values were calculated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Added
+- Improve report explanation to better interpret average coverage and coverage completeness stats shown on the coverage report
+
 ## [1.9]
 ### Added
 - Condensed `/coverage/d4/genes/summary` for condensed stats over a gene list

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -180,9 +180,15 @@
 {% endif %}
 
 <p>
+  <strong>Average coverage</strong>:
+  defined as the mean coverage over a list of genes. Values were calculated as the mean of coverage values over single genes or intervals (transcripts or exons) from single genes
+  e.g. 38.24
+</p>
+
+<p>
   <strong>Completeness</strong>:
   defined as the ratio of bases
-  sequenced deeper than a specified cutoff
+  sequenced deeper than a specified cutoff. Values were calculated across pooled genes or genes' intervals, according to the sequencing technology used
   e.g. 10x
 </p>
 
@@ -250,6 +256,11 @@
 	{{ super() }}
 
 	<script>
+		// Enable tooltips
+		$(document).ready(function(){
+    		$('[data-toggle="tooltip"]').tooltip();
+		});
+
 		function toggle_visibility(ids)
 		{
 			for (let id of ids) {

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -256,11 +256,6 @@
 	{{ super() }}
 
 	<script>
-		// Enable tooltips
-		$(document).ready(function(){
-    		$('[data-toggle="tooltip"]').tooltip();
-		});
-
 		function toggle_visibility(ids)
 		{
 			for (let id of ids) {


### PR DESCRIPTION
Closes #325. I have reasoned that tooltips might be useful on the web report, but would disappear if the report is exported to PDF. This way the explanation id downloaded with the page

## Description
### Added/Changed/Fixed
- Expanded the stats explanation on the coverage report

### How to test
- [x] Deploy locally or or stage

### Expected outcome
- New explanation should be shown

## Review
- [x] Tests executed by CR
- [x] "Merge and deploy" approved by Jakob37

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions