### PR TITLE
Replaced deprecated Pydantic parse_obj method with model_validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Check that provided d4 files when running queries using `/coverage/d4/genes/summary` endpoint are valid, with test
 ### Changed
 - How parameters are passed to starlette.templating since it was raising a deprecation warning.
+- Replaced deprecated Pydantic `parse_obj` method with `model_validate`
 
 ## [1.9]
 ### Added

--- a/tests/src/chanjo2/meta/test_handle_report_contents.py
+++ b/tests/src/chanjo2/meta/test_handle_report_contents.py
@@ -3,8 +3,10 @@ from typing import List, Tuple
 from sqlalchemy.orm import sessionmaker
 
 from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA
-from chanjo2.meta.handle_report_contents import (get_missing_genes_from_db,
-                                                 get_report_data)
+from chanjo2.meta.handle_report_contents import (
+    get_missing_genes_from_db,
+    get_report_data,
+)
 from chanjo2.models import SQLGene
 from chanjo2.models.pydantic_models import ReportQuery
 

--- a/tests/src/chanjo2/meta/test_handle_report_contents.py
+++ b/tests/src/chanjo2/meta/test_handle_report_contents.py
@@ -3,10 +3,8 @@ from typing import List, Tuple
 from sqlalchemy.orm import sessionmaker
 
 from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA
-from chanjo2.meta.handle_report_contents import (
-    get_missing_genes_from_db,
-    get_report_data,
-)
+from chanjo2.meta.handle_report_contents import (get_missing_genes_from_db,
+                                                 get_report_data)
 from chanjo2.models import SQLGene
 from chanjo2.models.pydantic_models import ReportQuery
 
@@ -49,7 +47,7 @@ def test_get_report_data(demo_session: sessionmaker):
     """Test the function that collects the deta required for creating a coverage/overview report."""
 
     # GIVEN a user query containing the expected parameters
-    query = ReportQuery.parse_obj(DEMO_COVERAGE_QUERY_DATA)
+    query = ReportQuery.model_validate(DEMO_COVERAGE_QUERY_DATA)
     report_data: dict = get_report_data(query=query, session=demo_session)
 
     # THEN get_report_data should return a dictionary with the expected report info


### PR DESCRIPTION
## Description
### Fixed
- Fixed #332 

### How to test
- [x] Automatic tests

### Expected outcome
- [x] All tests should pass without warnings

## Review
- [x] Tests executed by GitHub actions

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions