### PR TITLE
Genes overview endpoint to accept only form data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Changed
 - How parameters are passed to starlette.templating since it was raising a deprecation warning.
 - Replaced deprecated Pydantic `parse_obj` method with `model_validate`
-- Report endpoint accepts only POST requests with form data now (application/x-www-form-urlencoded) - no json
+- Report and genes overview endpoints accept only POST requests with form data now (application/x-www-form-urlencoded) - no json
 
 ## [1.9]
 ### Added

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -28,25 +28,6 @@ DEMO_HGNC_GENE_SYMBOLS = ["MTHFR", "DHFR", "FOLR1", "SLC46A1", "LAMA1", "PIPPI6"
 DEMO_HGNC_IDS = [7436, 2861, 3791, 30521]
 ANALYSIS_DATE = "2023-04-23T10:20:30.400+02:30"
 
-# JSON Data for generating a demo coverage report
-DEMO_COVERAGE_QUERY_DATA = {
-    "build": BUILD_37,
-    "samples": [
-        {
-            "name": DEMO_SAMPLE["name"],
-            "case_name": DEMO_CASE["name"],
-            "coverage_file_path": d4_demo_path,
-            "analysis_date": ANALYSIS_DATE,
-        }
-    ],
-    "case_display_name": "643594",
-    "gene_panel": "A test Panel 1.0",
-    "interval_type": "transcripts",
-    "ensembl_gene_ids": [],
-    "hgnc_gene_ids": [],
-    "hgnc_gene_symbols": DEMO_HGNC_GENE_SYMBOLS,
-    "default_level": 20,
-}
 
 # HTTP FORM-like data for generating a demo coverage report
 DEMO_COVERAGE_QUERY_FORM = {

--- a/tests/src/chanjo2/endpoints/test_overview.py
+++ b/tests/src/chanjo2/endpoints/test_overview.py
@@ -1,4 +1,3 @@
-import json
 from typing import Dict, List, Type
 
 from fastapi import status
@@ -6,7 +5,7 @@ from fastapi.testclient import TestClient
 from requests.models import Response
 
 from chanjo2.constants import BUILD_37, DEFAULT_COMPLETENESS_LEVELS
-from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA, DEMO_COVERAGE_QUERY_FORM
+from chanjo2.demo import DEMO_COVERAGE_QUERY_FORM
 
 
 def test_demo_overview(client: TestClient, endpoints: Type):
@@ -14,22 +13,6 @@ def test_demo_overview(client: TestClient, endpoints: Type):
 
     # GIVEN a query to the demo genes coverage overview endpoint
     response: Response = client.get(endpoints.OVERVIEW_DEMO)
-
-    # Then the request should be successful
-    assert response.status_code == status.HTTP_200_OK
-
-    # And return an HTML page
-    assert response.template.name == "overview.html"
-
-
-def test_overview_json_data(client: TestClient, endpoints: Type):
-    """Test the endpoint that creates the genes coverage overview page by providing json data in the POST request."""
-
-    # GIVEN a query with json data to the genes coverage overview endpoint
-    response: Response = client.post(
-        endpoints.OVERVIEW,
-        json=DEMO_COVERAGE_QUERY_DATA,
-    )
 
     # Then the request should be successful
     assert response.status_code == status.HTTP_200_OK
@@ -65,7 +48,7 @@ def test_gene_overview(
         "completeness_thresholds": DEFAULT_COMPLETENESS_LEVELS,
         "hgnc_gene_id": genomic_ids_per_build[BUILD_37]["hgnc_ids"][0],
         "default_level": 10,
-        "samples": str(DEMO_COVERAGE_QUERY_DATA["samples"]),
+        "samples": str(DEMO_COVERAGE_QUERY_FORM["samples"]),
         "interval_type": "transcripts",
     }
 

--- a/tests/src/chanjo2/endpoints/test_report.py
+++ b/tests/src/chanjo2/endpoints/test_report.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from requests.models import Response
 
 from chanjo2.constants import GENE_LISTS_NOT_SUPPORTED_MSG
-from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA, DEMO_COVERAGE_QUERY_FORM
+from chanjo2.demo import DEMO_COVERAGE_QUERY_FORM
 
 
 def test_demo_report(client: TestClient, endpoints: Type):

--- a/tests/src/chanjo2/meta/test_handle_report_contents.py
+++ b/tests/src/chanjo2/meta/test_handle_report_contents.py
@@ -2,7 +2,7 @@ from typing import List, Tuple
 
 from sqlalchemy.orm import sessionmaker
 
-from chanjo2.demo import DEMO_COVERAGE_QUERY_DATA
+from chanjo2.demo import DEMO_COVERAGE_QUERY_FORM
 from chanjo2.meta.handle_report_contents import (
     get_missing_genes_from_db,
     get_report_data,
@@ -37,7 +37,7 @@ def test_get_missing_genes_from_db(
     # WHEN coverage query contains gene symbols that are not present in the database
     missing_gene_error: Tuple[str, List[Union[int, str]]] = get_missing_genes_from_db(
         sql_genes=demo_genes_37,
-        hgnc_symbols=DEMO_COVERAGE_QUERY_DATA["hgnc_gene_symbols"],
+        hgnc_symbols=DEMO_COVERAGE_QUERY_FORM["hgnc_gene_symbols"],
     )
 
     # THEN the get_missing_genes_from_db function should return the expected error, containing description and missing IDs
@@ -49,7 +49,7 @@ def test_get_report_data(demo_session: sessionmaker):
     """Test the function that collects the deta required for creating a coverage/overview report."""
 
     # GIVEN a user query containing the expected parameters
-    query = ReportQuery.model_validate(DEMO_COVERAGE_QUERY_DATA)
+    query = ReportQuery.as_form(DEMO_COVERAGE_QUERY_FORM)
     report_data: dict = get_report_data(query=query, session=demo_session)
 
     # THEN get_report_data should return a dictionary with the expected report info


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Similarly to report endpoint

### How to test
- [x] Deploy on stage
- [x] Test with a demo scout case

### Expected outcome
- Genes overview page should be shown

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions