### PR TITLE
Fixed colors in logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Fixed
 - Updated dependencies including `certifi` to address dependabot alert
 - Update pytest to v.7.4.4 to address a `ReDoS` vulnerability
+- Colored logs
 
 ## [1.9]
 ### Added

--- a/poetry.lock
+++ b/poetry.lock
@@ -262,6 +262,23 @@ files = [
 ]
 
 [[package]]
+name = "coloredlogs"
+version = "15.0.1"
+description = "Colored terminal output for Python's logging module"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934"},
+    {file = "coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0"},
+]
+
+[package.dependencies]
+humanfriendly = ">=9.1"
+
+[package.extras]
+cron = ["capturer (>=2.4)"]
+
+[[package]]
 name = "coverage"
 version = "7.6.1"
 description = "Code coverage measurement for Python"
@@ -718,6 +735,20 @@ brotli = ["brotli", "brotlicffi"]
 cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<13)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
+
+[[package]]
+name = "humanfriendly"
+version = "10.0"
+description = "Human friendly output for text interfaces using Python"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477"},
+    {file = "humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc"},
+]
+
+[package.dependencies]
+pyreadline3 = {version = "*", markers = "sys_platform == \"win32\" and python_version >= \"3.8\""}
 
 [[package]]
 name = "idna"
@@ -1280,6 +1311,20 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyreadline3"
+version = "3.5.4"
+description = "A python implementation of GNU readline."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyreadline3-3.5.4-py3-none-any.whl", hash = "sha256:eaf8e6cc3c49bcccf145fc6067ba8643d1df34d604a1ec0eccbf7a18e6d3fae6"},
+    {file = "pyreadline3-3.5.4.tar.gz", hash = "sha256:8d57d53039a1c75adba8e50dd3d992b28143480816187ea5efbd5c78e6c885b7"},
+]
+
+[package.extras]
+dev = ["build", "flake8", "mypy", "pytest", "twine"]
 
 [[package]]
 name = "pytest"
@@ -2168,4 +2213,4 @@ m1 = []
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "062fd1befeeba4ea7af68a11dc46dee6774d27fef96da26fb1c61ada7d2d13b5"
+content-hash = "15329a0cdd138ab849aa247d343947fd3f91f4b58dc2ee2b71cec1692654ae31"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ python-multipart = "^0.0.9"
 schug = "1.6.0"
 certifi = "^2024.7.4"
 pytest = "7.4.4"
+coloredlogs = "^15.0.1"
 
 [tool.poetry.extras]
 m1 = ["pyd4"]

--- a/src/chanjo2/logger.py
+++ b/src/chanjo2/logger.py
@@ -1,16 +1,11 @@
 import logging
 
-import uvicorn
+import coloredlogs
+from fastapi.applications import FastAPI
 
-LOG = logging.getLogger(__name__)
 
-
-def configure_log():
+def configure_log(log: logging.Logger, app: FastAPI):
     """Configure logging."""
-    console_formatter = uvicorn.logging.ColourizedFormatter(
-        "{levelprefix} {asctime} : {message}", style="{", use_colors=True
-    )
-    if LOG.handlers:
-        LOG.handlers[0].setFormatter(console_formatter)
-    else:
-        logging.basicConfig()
+
+    current_log_level = log.getEffectiveLevel()
+    coloredlogs.install(level="DEBUG" if app.debug else current_log_level)

--- a/src/chanjo2/main.py
+++ b/src/chanjo2/main.py
@@ -28,7 +28,7 @@ def create_db_and_tables():
 
 @asynccontextmanager
 async def lifespan(app_: FastAPI):
-    configure_log()
+    configure_log(app=app, log=LOG)
     LOG.info("Starting up...")
     await startup_db()
     yield


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Fix #346 - Reintroduce colors in logging

### How to test
- [x] Introduce a log message in one of the endpoints (for instance demo report) and go that page in the browser

### Expected outcome
- Logging should have colors

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions