### PR TITLE
Fix link for switching between overview thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Update pytest to v.7.4.4 to address a `ReDoS` vulnerability
 - Colored logs
 - Link for switching between coverage thresholds on overview report
+- Gene links in genes overview page open into new tabs
 
 ## [1.9]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Updated dependencies including `certifi` to address dependabot alert
 - Update pytest to v.7.4.4 to address a `ReDoS` vulnerability
 - Colored logs
+- Link for switching between coverage thresholds on overview report
 
 ## [1.9]
 ### Added

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -109,6 +109,7 @@
 		{
 			document.getElementById("defaultLevel").value = customLevel;
 			theForm.action = '{{url_for("overview")}}';
+			theForm.removeAttribute("target");
 			theForm.submit();
 		}
 

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -47,7 +47,7 @@
 					{% for row in incomplete_coverage_rows %}
 						<tr>
 							<td>
-								<a href="#" onclick="getGeneStatsPage({{row[1]}});" target="_blank" rel="noopener">
+								<a href="#" onclick="getGeneStatsPage({{row[1]}});">
 									{{row[0]}}
 								</a>
 							</td>
@@ -120,6 +120,8 @@
 			geneInput.setAttribute("name", "hgnc_gene_id");
 			geneInput.setAttribute("value", hgncId);
 			theForm.appendChild(geneInput);
+			theForm.setAttribute("target", "_blank");
+			theForm.setAttribute("rel", "noopener");
 			theForm.submit();
 		}
 	</script>

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -21,7 +21,7 @@
 
 
 {% macro incompletely_covered_intervals(active_level) %}
- <form id="geneStatsForm" action="{{url_for('gene_overview')}}" method="post">
+ <form id="geneStatsForm" action="{{url_for('overview')}}" method="post">
 	 <input type="hidden" name="build" value="{{extras.build}}"/>
 	 <input type="hidden" name="default_level" id="defaultLevel" value="{{extras.default_level}}"/>
 	 <input type="hidden" name="completeness_thresholds" value="{{extras.completeness_thresholds|join(',')}}"/>
@@ -108,7 +108,6 @@
 		function updateOverview(customLevel)
 		{
 			document.getElementById("defaultLevel").value = customLevel;
-			theForm.action = '/overview';
 			theForm.submit();
 		}
 

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -21,7 +21,7 @@
 
 
 {% macro incompletely_covered_intervals(active_level) %}
- <form id="geneStatsForm" action="{{url_for('overview')}}" method="post">
+ <form id="geneStatsForm" action="{{url_for('gene_overview')}}" method="post">
 	 <input type="hidden" name="build" value="{{extras.build}}"/>
 	 <input type="hidden" name="default_level" id="defaultLevel" value="{{extras.default_level}}"/>
 	 <input type="hidden" name="completeness_thresholds" value="{{extras.completeness_thresholds|join(',')}}"/>
@@ -108,6 +108,7 @@
 		function updateOverview(customLevel)
 		{
 			document.getElementById("defaultLevel").value = customLevel;
+			theForm.action = '{{url_for("overview")}}';
 			theForm.submit();
 		}
 


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Tentative fix #356

### How to test
- [ ] Deploy on stage
- [ ] Switch between thresholds on overview report

### Expected outcome
- The links should work

## Review
- [ ] Tests executed by 
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions