### PR TITLE
Fom MANE overview, link out to gene overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Check that provided d4 files when running queries using `/coverage/d4/genes/summary` endpoint are valid, with test
 - General report with coverage over the entire genome when no genes or genes panels are provided
 - A MANE coverage report, showing coverage and coverage completeness only on MANE transcripts for the provided list of genes
+- Link out from MANE overview to gene overview
 ### Changed
 - Do not use stored cases/samples any more and run stats exclusively on d4 files paths provided by the user in real time
 - How parameters are passed to starlette.templating since it was raising a deprecation warning.

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -141,9 +141,9 @@ async def demo_mane_overview(
 @router.post("/mane_overview", response_class=HTMLResponse)
 async def mane_overview(
     request: Request,
-    build=Annotated[Builds, Form(...)],
+    build=Annotated[Builds, Form(Builds.build_38)],
     samples=Annotated[str, Form(...)],
-    interval_type=Annotated[IntervalType, Form(...)],
+    interval_type=Annotated[IntervalType, Form(IntervalType.TRANSCRIPTS)],
     completeness_thresholds=Annotated[Optional[str], Form(None)],
     ensembl_gene_ids=Annotated[Optional[str], Form(None)],
     hgnc_gene_ids=Annotated[Optional[str], Form(None)],

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -141,13 +141,14 @@ async def demo_mane_overview(
 @router.post("/mane_overview", response_class=HTMLResponse)
 async def mane_overview(
     request: Request,
+    build=Annotated[Builds, Form(...)],
     samples=Annotated[str, Form(...)],
+    interval_type=Annotated[IntervalType, Form(...)],
     completeness_thresholds=Annotated[Optional[str], Form(None)],
     ensembl_gene_ids=Annotated[Optional[str], Form(None)],
     hgnc_gene_ids=Annotated[Optional[str], Form(None)],
     hgnc_gene_symbols=Annotated[Optional[str], Form(None)],
-    case_display_name=Annotated[Optional[str], Form(None)],
-    panel_name=Annotated[Optional[str], Form("Custom panel")],
+    default_level=Annotated[Optional[int], Form(DEFAULT_COVERAGE_LEVEL)],
     db: Session = Depends(get_session),
 ):
     """Returns coverage overview stats for a group of samples over MANE transcripts of a list of genes."""

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -263,6 +263,7 @@ def get_mane_overview_coverage_stats(query: ReportQuery, session: Session) -> Di
             or query.hgnc_gene_symbols
             or query.ensembl_gene_ids,
             "interval_type": query.interval_type.value,
+            "default_level": query.default_level,
             "completeness_thresholds": query.completeness_thresholds,
             "samples": [_serialize_sample(sample) for sample in query.samples],
             "panel_name": query.panel_name,

--- a/src/chanjo2/templates/mane-overview.html
+++ b/src/chanjo2/templates/mane-overview.html
@@ -27,6 +27,7 @@
 			<!-- hidden fields passed from previous query -->
 			<form name="customizeForm" action="{{url_for('mane_overview')}}" method="post">
 			<input type="hidden" name="build" value="GRCh38"/>
+			<input type="hidden" name="default_level" id="defaultLevel" value="{{extras.default_level}}"/>
 			<input type="hidden" name="completeness_thresholds" value="{{extras.completeness_thresholds|join(',')}}"/>
 			<input type="hidden" name="interval_type" value="transcripts"/>
 			<input type="hidden" name="samples" value="{{extras.samples|safe}}"/>
@@ -112,6 +113,7 @@
 	{% else %}
 	No MANE transcripts found in database for the provided gene list.
 	{% endfor %}
+	</form>
 {% endmacro %}
 
 {% block title %}

--- a/src/chanjo2/templates/mane-overview.html
+++ b/src/chanjo2/templates/mane-overview.html
@@ -126,6 +126,7 @@
 {% endblock %}
 
 {% block js_code %}
+	{{ super() }}
 	<script>
 		let theForm = document.getElementById("maneStatsForm");
 		function getGeneStatsPage(hgncId)

--- a/src/chanjo2/templates/mane-overview.html
+++ b/src/chanjo2/templates/mane-overview.html
@@ -27,6 +27,7 @@
 			<!-- hidden fields passed from previous query -->
 			<form name="customizeForm" action="{{url_for('mane_overview')}}" method="post">
 			<input type="hidden" name="build" value="GRCh38"/>
+			<input type="hidden" name="completeness_thresholds" value="{{extras.completeness_thresholds|join(',')}}"/>
 			<input type="hidden" name="interval_type" value="transcripts"/>
 			<input type="hidden" name="samples" value="{{extras.samples|safe}}"/>
 
@@ -59,12 +60,21 @@
 		<p>Based on gene panel: <strong>{{ extras.panel_name }}</strong></p>
 	{% endif %}
 	<br>
+	<form id="maneStatsForm" action="{{url_for('gene_overview')}}" method="post">
+		<input type="hidden" name="build" value="GRCh38"/>
+		<input type="hidden" name="default_level" id="defaultLevel" value="{{extras.default_level}}"/>
+		<input type="hidden" name="completeness_thresholds" value="{{extras.completeness_thresholds|join(',')}}"/>
+		<input type="hidden" name="interval_type" value="transcripts"/>
+		<input type="hidden" name="samples" value="{{extras.samples|safe}}"/>
+
 	{% for gene_id, samples_stats in mane_coverage_stats|sort(attribute='0') %}
 	<tr>
         <td class="row">
             <div class="panel-default">
 				<div class="panel-heading">
-					<strong>Gene {{ gene_id or samples_stats.gene.hgnc_id }}</strong>
+					<strong>Gene <a href="#" onclick="getGeneStatsPage({{samples_stats.gene.hgnc_id}});">
+									{{ gene_id or samples_stats.gene.hgnc_id }}
+								</a></strong>
 					{% if samples_stats.transcript.mane_select %}
 						<span class="badge">MANE Select: {{samples_stats.transcript.mane_select}}</span>
 					{% endif %}
@@ -112,3 +122,21 @@
 {{report_filters() }}
 {{ mane_stats_macro() }}
 {% endblock %}
+
+{% block js_code %}
+	<script>
+		let theForm = document.getElementById("maneStatsForm");
+		function getGeneStatsPage(hgncId)
+		{
+			var geneInput = document.createElement("input");
+			geneInput.setAttribute("type", "hidden");
+			geneInput.setAttribute("name", "hgnc_gene_id");
+			geneInput.setAttribute("value", hgncId);
+			theForm.appendChild(geneInput);
+			theForm.setAttribute("target", "_blank");
+			theForm.setAttribute("rel", "noopener");
+			theForm.submit();
+		}
+	</script>
+{% endblock %}
+


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Adds links to gene overview in the MANE overview - Closes #367 

<img width="1278" alt="image" src="https://github.com/user-attachments/assets/44eaa5c0-3777-42d0-8713-c33a2c5108cc">


### How to test
- [x] Deploy on stage server and make sure gene links on MANE page work

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions