### PR TITLE
Add exons stats to gene overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Computing coverage completeness stats using d4tools `perc_cov` stat function (much quicker reports)
 - Moved functions computing the coverage stats to a separate `meta/handle_coverage_stats.py` module
 - Refactored code collecting stats shown on gene overview report
+- Gene report to contain both transcripts and exons stats
 ### Fixed
 - Updated dependencies including `certifi` to address dependabot alert
 - Update pytest to v.7.4.4 to address a `ReDoS` vulnerability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - A MANE coverage report, showing coverage and coverage completeness only on MANE transcripts for the provided list of genes
 - Link out from MANE overview to gene overview
 - Display MANE badges on gene overview report
+- `Create PDF` button on MANE overview and gene overview pages
 ### Changed
 - Do not use stored cases/samples any more and run stats exclusively on d4 files paths provided by the user in real time
 - How parameters are passed to starlette.templating since it was raising a deprecation warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - General report with coverage over the entire genome when no genes or genes panels are provided
 - A MANE coverage report, showing coverage and coverage completeness only on MANE transcripts for the provided list of genes
 - Link out from MANE overview to gene overview
+- Display MANE badges on gene overview report
 ### Changed
 - Do not use stored cases/samples any more and run stats exclusively on d4 files paths provided by the user in real time
 - How parameters are passed to starlette.templating since it was raising a deprecation warning.

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -108,16 +108,7 @@ async def gene_overview(
     )
 
     return templates.TemplateResponse(
-        request=request,
-        name="gene-overview.html",
-        context={
-            "interval_type": gene_overview_content["interval_type"],
-            "gene": gene_overview_content.get("gene"),
-            "interval_coverage_stats": gene_overview_content.get(
-                "samples_coverage_stats_by_interval"
-            ),
-            "levels": gene_overview_content["levels"],
-        },
+        request=request, name="gene-overview.html", context=gene_overview_content
     )
 
 

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -107,6 +107,8 @@ async def gene_overview(
         get_gene_overview_coverage_stats(form_data=validated_form, session=db)
     )
 
+    print(gene_overview_content)
+
     return templates.TemplateResponse(
         request=request, name="gene-overview.html", context=gene_overview_content
     )

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -107,8 +107,6 @@ async def gene_overview(
         get_gene_overview_coverage_stats(form_data=validated_form, session=db)
     )
 
-    print(gene_overview_content)
-
     return templates.TemplateResponse(
         request=request, name="gene-overview.html", context=gene_overview_content
     )

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -220,12 +220,14 @@ def get_gene_overview_coverage_stats(form_data: GeneReportForm, session: Session
         return gene_stats
 
     gene_stats["gene"] = gene
-    sql_intervals = set_sql_intervals(
+    transcripts_intervals = set_sql_intervals(
         db=session,
         interval_type=SQLTranscript,
         genes=[gene],
         transcript_tags=[],
     )
+    exons_intervals = set_sql_intervals(db=session, interval_type=SQLExon, genes=[gene])
+    sql_intervals = transcripts_intervals + exons_intervals
     gene_stats["samples_coverage_stats_by_interval"] = get_gene_overview_stats(
         sql_intervals=sql_intervals,
         samples=form_data.samples,

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -251,24 +251,19 @@ def get_gene_overview_coverage_stats(form_data: GeneReportForm, session: Session
                 "stats": samples_coverage_by_interval[sql_interval.ensembl_id],
                 "length": interval_length,
                 "coordinates": coords,
-                "exons": [],
+                "exons": {},
             }
             continue
 
         gene_stats["transcript_coverage_stats"][sql_interval.ensembl_transcript_id][
             "exons"
-        ].append(
-            (
-                sql_interval.ensembl_id,
-                {
-                    "interval_type": "exon",
-                    "transcript_rank": sql_interval.rank_in_transcript,
-                    "stats": samples_coverage_by_interval[sql_interval.ensembl_id],
-                    "length": interval_length,
-                    "coordinates": coords,
-                },
-            )
-        )
+        ][sql_interval.ensembl_id] = {
+            "interval_type": "exon",
+            "transcript_rank": sql_interval.rank_in_transcript,
+            "stats": samples_coverage_by_interval[sql_interval.ensembl_id],
+            "length": interval_length,
+            "coordinates": coords,
+        }
 
     return gene_stats
 

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -217,6 +217,7 @@ def get_gene_overview_coverage_stats(form_data: GeneReportForm, session: Session
         build=form_data.build, hgnc_id=form_data.hgnc_gene_id, db=session
     )
     if gene is None:
+        gene_stats["gene"] = {"hgnc_id": form_data.hgnc_gene_id}
         return gene_stats
 
     gene_stats["gene"] = gene

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -244,11 +244,11 @@ def get_gene_overview_coverage_stats(form_data: GeneReportForm, session: Session
                 "mane_plus_clinical": sql_interval.refseq_mane_plus_clinical,
                 "stats": samples_coverage_by_interval[sql_interval.ensembl_id],
             }
-        else:
-            gene_stats["interval_coverage_stats"][sql_interval.ensembl_id] = {
-                "interval_type": "exon",
-                "stats": samples_coverage_by_interval[sql_interval.ensembl_id],
-            }
+            continue
+        gene_stats["interval_coverage_stats"][sql_interval.ensembl_id] = {
+            "interval_type": "exon",
+            "stats": samples_coverage_by_interval[sql_interval.ensembl_id],
+        }
 
     return gene_stats
 

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -259,7 +259,7 @@ def get_gene_overview_coverage_stats(form_data: GeneReportForm, session: Session
             "exons"
         ][sql_interval.ensembl_id] = {
             "interval_type": "exon",
-            "transcript_rank": sql_interval.rank_in_transcript,
+            "transcript_rank": int(sql_interval.rank_in_transcript),
             "stats": samples_coverage_by_interval[sql_interval.ensembl_id],
             "length": interval_length,
             "coordinates": coords,

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -17,6 +17,12 @@
 </style>
 {% endblock %}
 
+{% block pdf_export %}
+	<div class="collapse navbar-collapse justify-content-end" id="bs-example-navbar-collapse-1">
+		<button class="navbar-brand" onclick="window.focus(); window.print();">Create PDF</button>
+	</div><!-- /.navbar-collapse -->
+{% endblock %}
+
 {% macro gene_stats_macro() %}
 	<h2>Gene: {{ gene.hgnc_symbol or gene.hgnc_id }}</h2>
 	<br>

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -4,13 +4,13 @@
 {{ super() }}
 <style>
 .badge {
-	background-color: black;
 	color: white;
 	padding: 4px 8px;
 	text-align: center;
 	border-radius: 5px;
 	float: right;
 }
+
 .exon_blue {
 	color: #2874a6;
 }
@@ -23,46 +23,84 @@
 	</div><!-- /.navbar-collapse -->
 {% endblock %}
 
+
+{% macro one_interval_table(interval_id, interval_features) %}
+<tr>
+	<td class="row">
+		<div class="panel-default">
+			<div class="panel-heading {% if interval_features.interval_type == 'exon' %} exon_blue {% endif %}" >
+				{{ interval_features.interval_type|capitalize }} <strong>{{ interval_id }}</strong>
+				<span> - Coordinates:{{interval_features.coordinates}}</span>
+				<span> - size:{{interval_features.length}}</span>
+				{% if interval_features.mane_select %}
+					<span class="badge" style="background-color: black;">MANE Select: {{interval_features.mane_select}}</span>
+				{% endif %}
+				{% if interval_features.mane_plus_clinical %}
+					<span class="badge" style="background-color: black;">MANE Plus Clinical: {{interval_features.mane_plus_clinical}}</span>
+				{% endif %}
+				{% if interval_features.mrna %}
+					<span class="badge" style="background-color: gray;">{{interval_features.mrna}}</span>
+				{% endif %}
+				{% if interval_features.transcript_rank %}
+					<span class="badge" style="background-color: #2874a6">rank: {{interval_features.transcript_rank}}</span>
+				{% endif  %}
+			</div>
+		</div>
+		<div class="table-responsive">
+			<table class="table table-bordered {% if interval_features.interval_type == 'exon' %} exon_blue {% endif %}">
+				<thead>
+					<th>Sample</th>
+					<th>Mean coverage</th>
+					{% for level, _ in levels.items() %}
+						<th>Completeness {{ level }}x [%]</th>
+					{% endfor %}
+				</thead>
+				<tbody>
+				{% for sample_stats in interval_features.stats %}
+					<td>{{ sample_stats[0] }}</td>
+					<td>{{ sample_stats[1]|round(2) }}</td>
+					{% for level, _ in levels.items() %}
+						<td>{{ (sample_stats[2][level] * 100)|round(2) }}</td>
+					{% endfor %}
+				{% endfor %}
+				</tbody>
+			</table>
+		</div>
+	</td>
+</tr>
+{% endmacro %}
+
+
 {% macro gene_stats_macro() %}
 	<h2>Gene: {{ gene.hgnc_symbol or gene.hgnc_id }}</h2>
 	<br>
-	{% for interval_id, interval_features in interval_coverage_stats.items() %}
-	<tr>
-		<td class="row">
-			<div class="panel-default">
-				<div class="panel-heading {% if interval_features.interval_type == 'exon' %} exon_blue {% endif %}" >
-					{{ interval_features.interval_type|capitalize }} <strong>{{ interval_id }}</strong>
-					{% if interval_features.mane_select %}
-						<span class="badge">MANE Select: {{interval_features.mane_select}}</span>
-					{% endif %}
-					{% if interval_features.mane_plus_clinical %}
-						<span class="badge">MANE Plus Clinical: {{interval_features.mane_plus_clinical}}</span>
-					{% endif %}
+	{% for transcript_id, transcript_features in transcript_coverage_stats.items() %}
+
+		{{ one_interval_table(transcript_id, transcript_features) }}
+
+		<!-- Show eventual exons stats -->
+		<div class="accordion" id="exons-accordion">
+			<div class="accordion-item">
+				<h2 class="accordion-header" id="flush-heading_{{transcript_id}}">
+					<button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#flush-collapse_{{transcript_id}}" aria-expanded="false" aria-controls="flush-collapse_{{transcript_id}}">
+						Exons
+					</button>
+				</h2>
+				<div id="flush-collapse_{{transcript_id}}" class="accordion-collapse collapse" aria-labelledby="flush-heading_{{transcript_id}}">
+					<div class="accordion-body">
+						{% if transcript_features.exons %}
+							{% for exon_id, exon_stats in transcript_features.exons|sort(attribute='1.transcript_rank') %}
+								{{ one_interval_table(exon_id, exon_stats) }}
+							{% endfor %}
+						{% else %}
+						No exons stats available for this transcript
+						{% endif %}
+
+					</div>
 				</div>
-			</div>
-			<div class="table-responsive">
-				<table class="table table-bordered {% if interval_features.interval_type == 'exon' %} exon_blue {% endif %}">
-					<caption>Coverage overview over gene {{ gene.hgnc_symbol or gene.hgnc_id }} - {{ interval_features.interval_type }} {{interval_id}}</caption>
-					<thead>
-						<th>Sample</th>
-						<th>Mean coverage</th>
-						{% for level, _ in levels.items() %}
-							<th>Completeness {{ level }}x [%]</th>
-						{% endfor %}
-					</thead>
-					<tbody>
-					{% for sample_stats in interval_features.stats %}
-						<td>{{ sample_stats[0] }}</td>
-						<td>{{ sample_stats[1]|round(2) }}</td>
-						{% for level, _ in levels.items() %}
-							<td>{{ (sample_stats[2][level] * 100)|round(2) }}</td>
-						{% endfor %}
-					{% endfor %}
-					</tbody>
-				</table>
-			</div>
-		</td>
-	</tr>
+			</div> <!--end of accordion item -->
+		</div> <!-- end of accordion div -->
+	<br>
 	<br>
 	{% else %}
 	No intervals found in database for gene {{gene.hgnc_symbol or gene.hgnc_id}}.

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -31,7 +31,7 @@
 			<div class="panel-heading {% if interval_features.interval_type == 'exon' %} exon_blue {% endif %}" >
 				{{ interval_features.interval_type|capitalize }} <strong>{{ interval_id }}</strong>
 				<span> - Coordinates: {{interval_features.coordinates}}</span>
-				<span> - size:{{interval_features.length}}</span>
+				<span> - size: {{interval_features.length}}</span>
 				{% if interval_features.mane_select %}
 					<span class="badge" style="background-color: black;">MANE Select: {{interval_features.mane_select}}</span>
 				{% endif %}

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -1,19 +1,42 @@
 {% extends "base-layout.html" %}
 
+{% block css %}
+{{ super() }}
+<style>
+.badge {
+	background-color: black;
+	color: white;
+	padding: 4px 8px;
+	text-align: center;
+	border-radius: 5px;
+	float: right;
+}
+.exon_blue {
+	color: #2874a6;
+}
+</style>
+{% endblock %}
+
 {% macro gene_stats_macro() %}
 	<h2>Gene: {{ gene.hgnc_symbol or gene.hgnc_id }}</h2>
 	<br>
-	{% for interval_id, samples_stats in interval_coverage_stats.items() %}
+	{% for interval_id, interval_features in interval_coverage_stats.items() %}
 	<tr>
 		<td class="row">
 			<div class="panel-default">
-				<div class="panel-heading">
-					{{ interval_type }}: <strong>{{ interval_id }}</strong>
+				<div class="panel-heading {% if interval_features.interval_type == 'exon' %} exon_blue {% endif %}" >
+					{{ interval_features.interval_type|capitalize }} <strong>{{ interval_id }}</strong>
+					{% if interval_features.mane_select %}
+						<span class="badge">MANE Select: {{interval_features.mane_select}}</span>
+					{% endif %}
+					{% if interval_features.mane_plus_clinical %}
+						<span class="badge">MANE Plus Clinical: {{interval_features.mane_plus_clinical}}</span>
+					{% endif %}
 				</div>
 			</div>
 			<div class="table-responsive">
-				<table class="table table-bordered">
-					<caption>Coverage overview over gene {{ gene.hgnc_symbol or gene.hgnc_id }} - {{interval_id}}</caption>
+				<table class="table table-bordered {% if interval_features.interval_type == 'exon' %} exon_blue {% endif %}">
+					<caption>Coverage overview over gene {{ gene.hgnc_symbol or gene.hgnc_id }} - {{ interval_features.interval_type }} {{interval_id}}</caption>
 					<thead>
 						<th>Sample</th>
 						<th>Mean coverage</th>
@@ -22,7 +45,7 @@
 						{% endfor %}
 					</thead>
 					<tbody>
-					{% for sample_stats in samples_stats %}
+					{% for sample_stats in interval_features.stats %}
 						<td>{{ sample_stats[0] }}</td>
 						<td>{{ sample_stats[1]|round(2) }}</td>
 						{% for level, _ in levels.items() %}

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -89,7 +89,7 @@
 				<div id="flush-collapse_{{transcript_id}}" class="accordion-collapse collapse" aria-labelledby="flush-heading_{{transcript_id}}">
 					<div class="accordion-body">
 						{% if transcript_features.exons %}
-							{% for exon_id, exon_stats in transcript_features.exons|sort(attribute='1.transcript_rank') %}
+							{% for exon_id, exon_stats in transcript_features.exons.items()|sort(attribute='1.transcript_rank') %}
 								{{ one_interval_table(exon_id, exon_stats) }}
 							{% endfor %}
 						{% else %}

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -58,7 +58,10 @@
 		</td>
 	</tr>
 	<br>
+	{% else %}
+	No intervals found in database for gene {{gene.hgnc_symbol or gene.hgnc_id}}.
 	{% endfor %}
+
 {% endmacro %}
 
 {% block title %}

--- a/src/chanjo2/templates/gene-overview.html
+++ b/src/chanjo2/templates/gene-overview.html
@@ -30,7 +30,7 @@
 		<div class="panel-default">
 			<div class="panel-heading {% if interval_features.interval_type == 'exon' %} exon_blue {% endif %}" >
 				{{ interval_features.interval_type|capitalize }} <strong>{{ interval_id }}</strong>
-				<span> - Coordinates:{{interval_features.coordinates}}</span>
+				<span> - Coordinates: {{interval_features.coordinates}}</span>
 				<span> - size:{{interval_features.length}}</span>
 				{% if interval_features.mane_select %}
 					<span class="badge" style="background-color: black;">MANE Select: {{interval_features.mane_select}}</span>

--- a/src/chanjo2/templates/mane-overview.html
+++ b/src/chanjo2/templates/mane-overview.html
@@ -14,6 +14,12 @@
 </style>
 {% endblock %}
 
+{% block pdf_export %}
+	<div class="collapse navbar-collapse justify-content-end" id="bs-example-navbar-collapse-1">
+		<button class="navbar-brand" onclick="window.focus(); window.print();">Create PDF</button>
+	</div><!-- /.navbar-collapse -->
+{% endblock %}
+
 {% macro report_filters() %}
 <div class="accordion" id="filter-accordion">
   <div class="accordion-item">


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Closes #366
- Adds MANE badges on gene overview
- Adds a `Create PDF` button on MANE overview and gene overview pages

<img width="1068" alt="image" src="https://github.com/user-attachments/assets/55a5a66a-ec81-49a7-a464-edc1c6a8b799">

### How to test
- [x] Deploy on stage and make sure gene overview contains both transcripts and exons intervals with stats

## Review
- [x] Tests executed by CR, Jakob37 
- [x] "Merge and deploy" approved by Jakob37 

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions