### PR TITLE
Save Ensembl transcript ID and exon number in exons table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - General report with coverage over the entire genome when no genes or genes panels are provided
 - A MANE coverage report, showing coverage and coverage completeness only on MANE transcripts for the provided list of genes
 - Link out from MANE overview to gene overview
+- Save ensembl_transcript_id and exon rank info on exons database records
 ### Changed
 - Do not use stored cases/samples any more and run stats exclusively on d4 files paths provided by the user in real time
 - How parameters are passed to starlette.templating since it was raising a deprecation warning.
@@ -23,7 +24,6 @@
 - Colored logs
 - Link for switching between coverage thresholds on overview report
 - Gene links in genes overview page open into new tabs
-- Saving ensembl_transcript_id info on exons database records
 
 ## [1.9]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Colored logs
 - Link for switching between coverage thresholds on overview report
 - Gene links in genes overview page open into new tabs
+- Saving ensembl_transcript_id info on exons database records
 
 ## [1.9]
 ### Added

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -207,6 +207,7 @@ def create_db_exon(exon: ExonBase) -> SQLExon:
         stop=exon.stop,
         ensembl_id=exon.ensembl_id,
         ensembl_gene_id=exon.ensembl_gene_id,
+        ensembl_transcript_id=exon.ensembl_transcript_id,
         build=exon.build,
     )
 

--- a/src/chanjo2/crud/intervals.py
+++ b/src/chanjo2/crud/intervals.py
@@ -205,6 +205,7 @@ def create_db_exon(exon: ExonBase) -> SQLExon:
         chromosome=exon.chromosome,
         start=exon.start,
         stop=exon.stop,
+        rank_in_transcript=exon.rank_in_transcript,
         ensembl_id=exon.ensembl_id,
         ensembl_gene_id=exon.ensembl_gene_id,
         ensembl_transcript_id=exon.ensembl_transcript_id,

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -216,8 +216,6 @@ async def update_exons(
                 build=build,
             )
 
-            if exon.rank_in_transcript is None:
-                LOG.warning(exon)
             exons_bulk.append(exon)
 
             if len(exons_bulk) > MAX_NR_OF_RECORDS:

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -212,8 +212,12 @@ async def update_exons(
                 ensembl_id=items[3],
                 start=int(items[4]),
                 stop=int(items[5]),
+                rank_in_transcript=int(items[-1]),
                 build=build,
             )
+
+            if exon.rank_in_transcript is None:
+                LOG.warning(exon)
             exons_bulk.append(exon)
 
             if len(exons_bulk) > MAX_NR_OF_RECORDS:

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -204,7 +204,7 @@ async def update_exons(
         items: List = _replace_empty_cols(line=line, nr_expected_columns=len(header))
 
         try:
-            # Load transcript interval into the database
+            # Load Exon interval into the database
             exon = ExonBase(
                 chromosome=items[0],
                 ensembl_gene_id=items[1],

--- a/src/chanjo2/models/pydantic_models.py
+++ b/src/chanjo2/models/pydantic_models.py
@@ -104,6 +104,7 @@ class ExonBase(IntervalBase):
     ensembl_id: str
     ensembl_gene_id: str
     ensembl_transcript_id: str
+    rank_in_transcript: int
 
 
 class Exon(IntervalBase):

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -83,9 +83,7 @@ class Exon(Base):
     start = Column(Integer, nullable=False)
     stop = Column(Integer, nullable=False)
     ensembl_id = Column(String(24), nullable=False)
-    ensembl_transcript_id = Column(
-        String(24), ForeignKey("transcripts.ensembl_id"), nullable=False, index=True
-    )
+    ensembl_transcript_id = Column(String(24), nullable=False, index=True)
     ensembl_gene_id = Column(
         String(24), ForeignKey("genes.ensembl_id"), nullable=False, index=True
     )
@@ -96,11 +94,6 @@ class Exon(Base):
     genes = relationship(
         "Gene",
         primaryjoin="Exon.ensembl_gene_id==Gene.ensembl_id",
-    )
-
-    transcripts = relationship(
-        "Transcript",
-        primaryjoin="Exon.ensembl_transcript_id==Transcript.ensembl_id",
     )
 
     __table_args__ = (

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -50,7 +50,7 @@ class Transcript(Base):
     chromosome = Column(String(6), nullable=False)
     start = Column(Integer, nullable=False)
     stop = Column(Integer, nullable=False)
-    ensembl_id = Column(String(24), nullable=False)
+    ensembl_id = Column(String(24), nullable=False, index=True)
     refseq_mrna = Column(String(24), nullable=True)
     refseq_mrna_pred = Column(String(24), nullable=True)
     refseq_ncrna = Column(String(24), nullable=True)
@@ -69,7 +69,7 @@ class Transcript(Base):
     )
 
     __table_args__ = (
-        Index("transcript_idx_ensembl_gene_build", "ensembl_gene_id", "build"),
+        Index("ensembl_gene_build_id", "ensembl_gene_id", "build", "ensembl_id"),
     )
 
 
@@ -83,6 +83,9 @@ class Exon(Base):
     start = Column(Integer, nullable=False)
     stop = Column(Integer, nullable=False)
     ensembl_id = Column(String(24), nullable=False)
+    ensembl_transcript_id = Column(
+        String(24), ForeignKey("transcripts.ensembl_id"), nullable=False, index=True
+    )
     ensembl_gene_id = Column(
         String(24), ForeignKey("genes.ensembl_id"), nullable=False, index=True
     )
@@ -95,6 +98,16 @@ class Exon(Base):
         primaryjoin="Exon.ensembl_gene_id==Gene.ensembl_id",
     )
 
+    transcripts = relationship(
+        "Transcript",
+        primaryjoin="Exon.ensembl_transcript_id==Transcript.ensembl_id",
+    )
+
     __table_args__ = (
-        Index("exon_idx_ensembl_gene:_build", "ensembl_gene_id", "build"),
+        Index(
+            "exon_idx_ensembl_gene_build_transcript",
+            "ensembl_gene_id",
+            "build",
+            "ensembl_transcript_id",
+        ),
     )

--- a/src/chanjo2/models/sql_models.py
+++ b/src/chanjo2/models/sql_models.py
@@ -82,6 +82,7 @@ class Exon(Base):
     chromosome = Column(String(6), nullable=False)
     start = Column(Integer, nullable=False)
     stop = Column(Integer, nullable=False)
+    rank_in_transcript = Column(Integer, nullable=False)
     ensembl_id = Column(String(24), nullable=False)
     ensembl_transcript_id = Column(String(24), nullable=False, index=True)
     ensembl_gene_id = Column(


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Closes #370 

exons table before:

![image](https://github.com/user-attachments/assets/542f8e1a-f914-4b47-9141-0d980fc1db1c)

exons table after:

<img width="922" alt="image" src="https://github.com/user-attachments/assets/f476d32e-9fd6-48d8-9cec-81981213c6a7">


### How to test
- [x]  Locally, drop and re-create the sql database
- [x] Load genes, transcripts and exons
- [x] Check the exons table

### Expected outcome
- It should contain the ensembl_transcript_id field

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions