### PR TITLE
Major release 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [2.0]
 ### Added
 - Improve report explanation to better interpret average coverage and coverage completeness stats shown on the coverage report
 - Check that provided d4 files when running queries using `/coverage/d4/genes/summary` endpoint are valid, with test

--- a/src/chanjo2/__init__.py
+++ b/src/chanjo2/__init__.py
@@ -1,4 +1,4 @@
 from dotenv import load_dotenv
 
-__version__ = "1.9"
+__version__ = "2.0"
 load_dotenv()

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -2,12 +2,12 @@ from typing import Dict
 
 from importlib_resources import files
 
-from chanjo2.constants import BUILD_37, DEFAULT_COMPLETENESS_LEVELS
+from chanjo2.constants import BUILD_37, BUILD_38, DEFAULT_COMPLETENESS_LEVELS
 
 BASE_PATH: str = "chanjo2.demo"
 
 GENE_PANEL_FILE: str = "109_green.bed"
-D4_DEMO_FILE: str = "panelapp_109_example.d4"
+D4_DEMO_FILE: str = "/Users/chiararasi/Documents/work/d4_data/hg002.d4"
 
 # Paths
 gene_panel_path = str(files(BASE_PATH).joinpath(GENE_PANEL_FILE))
@@ -31,7 +31,7 @@ ANALYSIS_DATE = "2023-04-23T10:20:30.400+02:30"
 
 # HTTP FORM-like data for generating a demo coverage report
 DEMO_COVERAGE_QUERY_FORM = {
-    "build": BUILD_37,
+    "build": BUILD_38,
     "samples": f"[{{'name': '{DEMO_SAMPLE['name']}', 'coverage_file_path': '{d4_demo_path}', 'case_name': '{DEMO_CASE['name']}', 'analysis_date': '{ANALYSIS_DATE}'}}]",
     "case_display_name": DEMO_CASE["name"],
     "gene_panel": "A test Panel 1.0",

--- a/src/chanjo2/demo/__init__.py
+++ b/src/chanjo2/demo/__init__.py
@@ -2,12 +2,12 @@ from typing import Dict
 
 from importlib_resources import files
 
-from chanjo2.constants import BUILD_37, BUILD_38, DEFAULT_COMPLETENESS_LEVELS
+from chanjo2.constants import BUILD_37, DEFAULT_COMPLETENESS_LEVELS
 
 BASE_PATH: str = "chanjo2.demo"
 
 GENE_PANEL_FILE: str = "109_green.bed"
-D4_DEMO_FILE: str = "/Users/chiararasi/Documents/work/d4_data/hg002.d4"
+D4_DEMO_FILE: str = "panelapp_109_example.d4"
 
 # Paths
 gene_panel_path = str(files(BASE_PATH).joinpath(GENE_PANEL_FILE))
@@ -31,7 +31,7 @@ ANALYSIS_DATE = "2023-04-23T10:20:30.400+02:30"
 
 # HTTP FORM-like data for generating a demo coverage report
 DEMO_COVERAGE_QUERY_FORM = {
-    "build": BUILD_38,
+    "build": BUILD_37,
     "samples": f"[{{'name': '{DEMO_SAMPLE['name']}', 'coverage_file_path': '{d4_demo_path}', 'case_name': '{DEMO_CASE['name']}', 'analysis_date': '{ANALYSIS_DATE}'}}]",
     "case_display_name": DEMO_CASE["name"],
     "gene_panel": "A test Panel 1.0",


### PR DESCRIPTION
## [2.0]
### Added
- Improve report explanation to better interpret average coverage and coverage completeness stats shown on the coverage report
- Check that provided d4 files when running queries using `/coverage/d4/genes/summary` endpoint are valid, with test
- General report with coverage over the entire genome when no genes or genes panels are provided
- A MANE coverage report, showing coverage and coverage completeness only on MANE transcripts for the provided list of genes
- Link out from MANE overview to gene overview
- Save ensembl_transcript_id and exon rank info on exons database records
- Display MANE badges on gene overview report
- `Create PDF` button on MANE overview and gene overview pages
- Documentation on how to create MANE overview reports
### Changed
- Do not use stored cases/samples any more and run stats exclusively on d4 files paths provided by the user in real time
- How parameters are passed to starlette.templating since it was raising a deprecation warning.
- Replaced deprecated Pydantic `parse_obj` method with `model_validate`
- Report and genes overview endpoints accept only POST requests with form data now (application/x-www-form-urlencoded) - no json
- Sort alphabetically the list genes that are incompletely covered on report page
- `d4_genes_condensed_summary` coverage endpoint will not convert `nan` or `inf` coverage values to None, but to str(value)
- Updated the Dockerfile base image so it contains the latest d4tools (master branch)
- Updated tests workflow to cargo install the latest d4tools from git (master branch)
- Computing coverage completeness stats using d4tools `perc_cov` stat function (much quicker reports)
- Moved functions computing the coverage stats to a separate `meta/handle_coverage_stats.py` module
- Refactored code collecting stats shown on gene overview report
- Gene report to contain both transcripts and exons stats
### Fixed
- Updated dependencies including `certifi` to address dependabot alert
- Update pytest to v.7.4.4 to address a `ReDoS` vulnerability
- Colored logs
- Link for switching between coverage thresholds on overview report
- Gene links in genes overview page open into new tabs

## Review
- [ ] Tests executed by CR and Jakob37 
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions