### PR TITLE
Add refseq transcript names on genes overview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 ## [unreleased]
-### Fixed
-- Addressed the `Starlette Denial of service (DoS) via multipart/form-data` by updating starlette library. among others
-
-## [unreleased]
 ### Added
 - Refseq transcripts names on coverage overview page
+### Fixed
+- Addressed the `Starlette Denial of service (DoS) via multipart/form-data` by updating starlette library. among others
 
 ## [2.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 ### Fixed
 - Addressed the `Starlette Denial of service (DoS) via multipart/form-data` by updating starlette library. among others
 
+## [unreleased]
+### Added
+- Refseq transcripts names on coverage overview page
+
 ## [2.0]
 ### Added
 - Improve report explanation to better interpret average coverage and coverage completeness stats shown on the coverage report

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -86,11 +86,15 @@ def get_report_sample_interval_coverage(
                         interval_hgnc_symbol,
                         interval_hgnc_id,
                         interval.ensembl_id,
-                        {
-                            "mane_select": interval.refseq_mane_select,
-                            "mane_plus_clinical": interval.refseq_mane_plus_clinical,
-                            "mrna": interval.refseq_mane_select,
-                        },
+                        (
+                            {
+                                "mane_select": interval.refseq_mane_select,
+                                "mane_plus_clinical": interval.refseq_mane_plus_clinical,
+                                "mrna": interval.refseq_mane_select,
+                            }
+                            if isinstance(interval, SQLTranscript)
+                            else {}
+                        ),
                         sample_name,
                         round(interval_coverage_at_threshold * 100, 2),
                     )

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -86,6 +86,11 @@ def get_report_sample_interval_coverage(
                         interval_hgnc_symbol,
                         interval_hgnc_id,
                         interval.ensembl_id,
+                        {
+                            "mane_select": interval.refseq_mane_select,
+                            "mane_plus_clinical": interval.refseq_mane_plus_clinical,
+                            "mrna": interval.refseq_mane_select,
+                        },
                         sample_name,
                         round(interval_coverage_at_threshold * 100, 2),
                     )

--- a/src/chanjo2/meta/handle_d4.py
+++ b/src/chanjo2/meta/handle_d4.py
@@ -58,6 +58,7 @@ def get_report_sample_interval_coverage(
     genes_covered_under_custom_threshold = set()
 
     for interval_nr, interval in enumerate(sql_intervals):
+
         if interval.ensembl_id in interval_ids:
             continue
         for threshold in completeness_thresholds:
@@ -90,7 +91,7 @@ def get_report_sample_interval_coverage(
                             {
                                 "mane_select": interval.refseq_mane_select,
                                 "mane_plus_clinical": interval.refseq_mane_plus_clinical,
-                                "mrna": interval.refseq_mane_select,
+                                "mrna": interval.refseq_mrna,
                             }
                             if isinstance(interval, SQLTranscript)
                             else {}

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -134,7 +134,6 @@ def get_report_data(
             interval_type=INTERVAL_TYPE_SQL_TYPE[query.interval_type],
             genes=genes,
             transcript_tags=[
-                TranscriptTag.REFSEQ_MRNA,
                 TranscriptTag.REFSEQ_MANE_PLUS_CLINICAL,
                 TranscriptTag.REFSEQ_MANE_SELECT,
                 TranscriptTag.REFSEQ_MRNA,

--- a/src/chanjo2/meta/handle_report_contents.py
+++ b/src/chanjo2/meta/handle_report_contents.py
@@ -133,7 +133,12 @@ def get_report_data(
             db=session,
             interval_type=INTERVAL_TYPE_SQL_TYPE[query.interval_type],
             genes=genes,
-            transcript_tags=[TranscriptTag.REFSEQ_MRNA],
+            transcript_tags=[
+                TranscriptTag.REFSEQ_MRNA,
+                TranscriptTag.REFSEQ_MANE_PLUS_CLINICAL,
+                TranscriptTag.REFSEQ_MANE_SELECT,
+                TranscriptTag.REFSEQ_MRNA,
+            ],
         )
 
     for sample in query.samples:

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -39,6 +39,7 @@
 					<tr>
 						<th scope="col">Gene</th>
 						<th scope="col">{{ extras.interval_type }}</th>
+						<th></th>
 						<th scope="col">Sample</th>
 						<th scope="col">Completeness {{ extras.default_level }}x [%]</th>
 					</tr>
@@ -52,7 +53,8 @@
 								</a>
 							</td>
 							<td>{{ row[2] }}</td>
-							<td>{{ row[3] }}</td>
+							<td>{{ row }}</td>
+							<td>{{ row[4] }}</td>
 							<td class="text-right">{{ row[4] }}</td>
 						</tr>
 					{% else %}

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -52,7 +52,7 @@
 								</a> <!-- link to gene -->
 							</td>
 							<td>
-								{{ row[2] }} <!-- Ensembl transcript ID -->
+								{{ row[2] }} <!-- Ensembl ID -->
 								{% if row[3].mane_select %}
 									<span class="badge bg-dark float-end ">MANE Select: {{row[3].mane_select}}</span>
 								{% endif %}

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -81,8 +81,8 @@
 									<span class="badge">MANE Plus Clinical: {{row[3].mrna}}</span>
 								{% endif %}
 							</td>
-							<td>{{ row[4] }}</td>
-							<td class="text-right">{{ row[5] }}</td>
+							<td>{{ row[4] }}</td> <!-- sample name -->
+							<td class="text-right">{{ row[5] }}</td> <!-- coverage stats -->
 						</tr>
 					{% else %}
 						<tr>

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -2,6 +2,24 @@
 
 {% block css %}
 {{ super() }}
+<style>
+.mane_badge {
+	background-color: black;
+	color: white;
+	padding: 4px 8px;
+	text-align: center;
+	border-radius: 5px;
+	float: right;
+}
+.badge {
+	background-color: lightblue;
+	color: black;
+	padding: 4px 8px;
+	text-align: center;
+	border-radius: 5px;
+	float: right;
+}
+</style>
 {% endblock %}
 
 {% macro completeness_cutoffs() %}
@@ -39,7 +57,6 @@
 					<tr>
 						<th scope="col">Gene</th>
 						<th scope="col">{{ extras.interval_type }}</th>
-						<th></th>
 						<th scope="col">Sample</th>
 						<th scope="col">Completeness {{ extras.default_level }}x [%]</th>
 					</tr>
@@ -50,12 +67,22 @@
 							<td>
 								<a href="#" onclick="getGeneStatsPage({{row[1]}});">
 									{{row[0]}}
-								</a>
+								</a> <!-- link to gene -->
 							</td>
-							<td>{{ row[2] }}</td>
-							<td>{{ row }}</td>
+							<td>
+								{{ row[2] }} <!-- Ensembl transcript ID -->
+								{% if row[3].mane_select %}
+									<span class="mane_badge">MANE Select: {{row[3].mane_select}}</span>
+								{% endif %}
+								{% if row[3].mane_plus_clinical %}
+									<span class="mane_badge">MANE Plus Clinical: {{row[3].mane_plus_clinical}}</span>
+								{% endif %}
+								{% if row[3].mrna %}
+									<span class="badge">MANE Plus Clinical: {{row[3].mrna}}</span>
+								{% endif %}
+							</td>
 							<td>{{ row[4] }}</td>
-							<td class="text-right">{{ row[4] }}</td>
+							<td class="text-right">{{ row[5] }}</td>
 						</tr>
 					{% else %}
 						<tr>

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -2,24 +2,6 @@
 
 {% block css %}
 {{ super() }}
-<style>
-.mane_badge {
-	background-color: black;
-	color: white;
-	padding: 4px 8px;
-	text-align: center;
-	border-radius: 5px;
-	float: right;
-}
-.badge {
-	background-color: lightblue;
-	color: black;
-	padding: 4px 8px;
-	text-align: center;
-	border-radius: 5px;
-	float: right;
-}
-</style>
 {% endblock %}
 
 {% macro completeness_cutoffs() %}
@@ -72,13 +54,13 @@
 							<td>
 								{{ row[2] }} <!-- Ensembl transcript ID -->
 								{% if row[3].mane_select %}
-									<span class="mane_badge">MANE Select: {{row[3].mane_select}}</span>
+									<span class="badge bg-dark">MANE Select: {{row[3].mane_select}}</span>
 								{% endif %}
 								{% if row[3].mane_plus_clinical %}
-									<span class="mane_badge">MANE Plus Clinical: {{row[3].mane_plus_clinical}}</span>
+									<span class="badge bg-dark">MANE Plus Clinical: {{row[3].mane_plus_clinical}}</span>
 								{% endif %}
 								{% if row[3].mrna %}
-									<span class="badge">MANE Plus Clinical: {{row[3].mrna}}</span>
+									<span class="badge bg-secondary">{{row[3].mrna}}</span>
 								{% endif %}
 							</td>
 							<td>{{ row[4] }}</td> <!-- sample name -->

--- a/src/chanjo2/templates/overview.html
+++ b/src/chanjo2/templates/overview.html
@@ -54,13 +54,13 @@
 							<td>
 								{{ row[2] }} <!-- Ensembl transcript ID -->
 								{% if row[3].mane_select %}
-									<span class="badge bg-dark">MANE Select: {{row[3].mane_select}}</span>
+									<span class="badge bg-dark float-end ">MANE Select: {{row[3].mane_select}}</span>
 								{% endif %}
 								{% if row[3].mane_plus_clinical %}
-									<span class="badge bg-dark">MANE Plus Clinical: {{row[3].mane_plus_clinical}}</span>
+									<span class="badge bg-dark float-end">MANE Plus Clinical: {{row[3].mane_plus_clinical}}</span>
 								{% endif %}
 								{% if row[3].mrna %}
-									<span class="badge bg-secondary">{{row[3].mrna}}</span>
+									<span class="badge bg-secondary float-end">{{row[3].mrna}}</span>
 								{% endif %}
 							</td>
 							<td>{{ row[4] }}</td> <!-- sample name -->


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Closes #378  


<img width="1165" alt="image" src="https://github.com/user-attachments/assets/f2bfa315-5c88-493f-8bf3-a4a6fba8e244">


### How to test
- [x] Deploy on stage and check how the genes overview page looks like

### Expected outcome
- Badges with MANE and Refseq transcripts should be displayed

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions