### PR TITLE
Fix the healthcheck step of the docker-compose MySQL file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Fixed
+- The MariaDB healthcheck step in docker-compose-mysql.yml, preventing the demo app to start
+
 ## [2.1]
 ### Added
 - Refseq transcripts names on coverage overview page

--- a/docker-compose-mysql.yml
+++ b/docker-compose-mysql.yml
@@ -12,10 +12,12 @@ services:
       - MYSQL_DATABASE=${MYSQL_DATABASE_NAME}
       - MYSQL_HOST_PORT=${MYSQL_HOST_PORT}
       - MARIADB_RANDOM_ROOT_PASSWORD=T
-    healthcheck: # Wait for the service to be ready before accepting incoming connections
-      test: "mariadb --user=${MYSQL_USER} --password=${MYSQL_PASSWORD} --execute \"SHOW DATABASES;\""
-      timeout: 10s
-      retries: 20
+    healthcheck:
+      test: [ "CMD", "healthcheck.sh", "--connect", "--innodb_initialized" ]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
     volumes:
       - ${HOST_DATA_VOLUME}:${CONTAINER_DATA_VOLUME}
     networks:


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- The MariaDB healthcheck step in docker-compose-mysql.yml, preventing the demo app to start

### How to test
- [ ] Locally, run `docker-compose -f docker-compose-mysql.yml --env-file template.env up`

### Expected outcome
- The app should start without problems

## Review
- [ ] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions