### PR TITLE
Major release 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## [unreleased]
+## [3.0]
 ### Changed
 - Updated several libraries including schug (now v.7)
 - Update project's Python version to 3.9
-- Modified the structure of the database table `genes`, converting the `ensembl_id` string field to `ensembl_ids`: an array of strings. This change addresses recent changes in the MySQL: https://bugs.mysql.com/bug.php?id=114838
+- BREAKING CHANGE: modified the structure of the database table `genes`, converting the `ensembl_id` string field to `ensembl_ids`: an array of strings. This change addresses recent changes in the MySQL: https://bugs.mysql.com/bug.php?id=114838
 ### Fixed
 - The MariaDB healthcheck step in docker-compose-mysql.yml, preventing the demo app to start
 

--- a/src/chanjo2/__init__.py
+++ b/src/chanjo2/__init__.py
@@ -1,4 +1,4 @@
 from dotenv import load_dotenv
 
-__version__ = "2.1"
+__version__ = "3.0"
 load_dotenv()


### PR DESCRIPTION
## [3.0]
### Changed
- Updated several libraries including schug (now v1.7)
- Update project's Python version to 3.9
- BREAKING CHANGE: modified the structure of the database table `genes`, converting the `ensembl_id` string field to `ensembl_ids`: an array of strings. This change addresses recent changes in the MySQL: https://bugs.mysql.com/bug.php?id=114838
### Fixed
- The MariaDB healthcheck step in docker-compose-mysql.yml, preventing the demo app to start

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions