### PR TITLE
Removed code for downloading resources via schug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - To avoid timeout errors, update genes, transcripts exons only from pre-downloaded files from schug
 - Documentation on how to update genes, transcripts and exons database tables
 - Renamed Pydantic `orm_mode` config param to `model_config`
+### Removed
+- Code for downloading resources from Ensembl using the schug library
 
 ## [3.1]
 ### Changed

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -1,13 +1,9 @@
 import logging
 from typing import Iterator, List, Optional, Union
 
-import requests
-from schug.load.biomart import EnsemblBiomartClient
-from schug.models.common import Build as SchugBuild
 from sqlalchemy.orm import Session
 
 from chanjo2.constants import (
-    ENSEMBL_RESOURCE_CLIENT,
     EXONS_FILE_HEADER,
     GENES_FILE_HEADER,
     TRANSCRIPTS_FILE_HEADER,
@@ -30,17 +26,6 @@ from chanjo2.models.pydantic_models import (
 LOG = logging.getLogger(__name__)
 MAX_NR_OF_RECORDS = 10_000
 END_OF_PARSED_FILE: str = "[success]"
-
-
-def read_resource_lines(build: Builds, interval_type: IntervalType) -> Iterator[str]:
-    """Returns lines of a remote Ensembl Biomart resource (genes, transcripts or exons) in a given genome build."""
-
-    shug_client: EnsemblBiomartClient = ENSEMBL_RESOURCE_CLIENT[interval_type](
-        build=SchugBuild(build)
-    )
-    url: str = shug_client.build_url(xml=shug_client.xml)
-    response: requests.models.responses = requests.get(url, stream=True)
-    return response.iter_lines(decode_unicode=True)
 
 
 def _replace_empty_cols(line: str, nr_expected_columns: int) -> List[Union[str, None]]:

--- a/tests/src/chanjo2/endpoints/test_intervals.py
+++ b/tests/src/chanjo2/endpoints/test_intervals.py
@@ -19,8 +19,6 @@ from chanjo2.populate_demo import (
     BUILD_TRANSCRIPTS_RESOURCE,
 )
 
-MOCKED_FILE_PARSER = "chanjo2.meta.handle_load_intervals.read_resource_lines"
-
 
 @pytest.mark.parametrize("build, path", BUILD_GENES_RESOURCE)
 def test_load_genes(


### PR DESCRIPTION
## Description
### Removed
- Code for downloading resources from Ensembl using the schug library - closes #421


### How to test
- [x] Automatic tests

### Expected outcome
- All tests should pass

## Review
- [x] Tests executed by GitHub actions
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions