### PR TITLE
Minor release 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [3.2]
 ### Added
 - `/intervals/intervals_count_by_build` endpoint, which retuns the number of genes, transcripts, exons for each genome build
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chanjo2"
-version = "3.1.0"
+version = "3.2.0"
 description = "Next generation coverage analysis"
 authors = ["northwestwitch <chiara.rasi@scilifelab.se>"]
 

--- a/src/chanjo2/__init__.py
+++ b/src/chanjo2/__init__.py
@@ -1,4 +1,4 @@
 from dotenv import load_dotenv
 
-__version__ = "3.1"
+__version__ = "3.2"
 load_dotenv()


### PR DESCRIPTION
## [3.2]
### Added
- `/intervals/intervals_count_by_build` endpoint, which retuns the number of genes, transcripts, exons for each genome build
### Changed
- Updated schug library to v1.10
- Disable SQLAlchemy logger
- To avoid timeout errors, update genes, transcripts exons only from pre-downloaded files from schug
- Documentation on how to update genes, transcripts and exons database tables
- Renamed Pydantic `orm_mode` config param to `model_config`
### Removed
- Code for downloading resources from Ensembl using the schug library

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions