### PR TITLE
Ignore chromosome separators in latest Ensembl resources downloaded with schug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Fixed
 - Documentation on how to update genes/transcripts/exons
 - Installing d4tools in Tests & Coverage GitHub action
+- Ignore `[success]` lines used as separators between chromosome in the latest genes/transcripts/exons file downloaded using schug
 
 ## [3.3.1]
 ### Fixed

--- a/src/chanjo2/meta/handle_load_intervals.py
+++ b/src/chanjo2/meta/handle_load_intervals.py
@@ -27,7 +27,7 @@ from chanjo2.models.pydantic_models import (
 
 LOG = logging.getLogger(__name__)
 MAX_NR_OF_RECORDS = 10_000
-END_OF_PARSED_FILE: str = "[success]"
+CHROM_SEPARATOR: str = "[success]"
 
 
 def update_interval_table(
@@ -82,8 +82,8 @@ def update_genes(build: Builds, session: Session, lines: Iterator, nlines: int) 
     with tqdm(total=nlines - 1, desc="Processing gene lines", unit="line") as pbar:
         for line in lines:
             line = line.strip()
-            if END_OF_PARSED_FILE in line:
-                break
+            if line == CHROM_SEPARATOR:
+                continue
             items: List = _replace_empty_cols(
                 line=line, nr_expected_columns=len(header)
             )
@@ -144,8 +144,8 @@ def update_transcripts(
     ) as pbar:
         for line in lines:
             line = line.strip()
-            if END_OF_PARSED_FILE in line:
-                break
+            if line == CHROM_SEPARATOR:
+                continue
             items: List = _replace_empty_cols(
                 line=line, nr_expected_columns=len(header)
             )
@@ -209,8 +209,8 @@ def update_exons(
     with tqdm(total=nlines - 1, desc="Processing exons lines", unit="line") as pbar:
         for line in lines:
             line = line.strip()
-            if END_OF_PARSED_FILE in line:
-                break
+            if line == CHROM_SEPARATOR:
+                continue
             items: List = _replace_empty_cols(
                 line=line, nr_expected_columns=len(header)
             )


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Closes #439
 
### How to test
- [x] Locally, check the number of genes loaded using main branch and this branch

### Expected outcome

#### Genes loaded using main branch

<img width="222" alt="image" src="https://github.com/user-attachments/assets/1b84d6a0-aa16-414a-abc6-b0050eb4ccc8" />

#### Genes loaded using this branch

<img width="210" alt="image" src="https://github.com/user-attachments/assets/a185200f-5ea5-4d5e-bc21-b4525f387785" />



## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions