### PR TITLE
Minor release 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [3.4]
 ### Changed
 - General library updates
 - Remove the schug library dependency

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chanjo2"
-version = "3.3.1"
+version = "3.4.0"
 description = "Next generation coverage analysis"
 authors = ["northwestwitch <chiara.rasi@scilifelab.se>"]
 

--- a/src/chanjo2/__init__.py
+++ b/src/chanjo2/__init__.py
@@ -1,4 +1,4 @@
 from dotenv import load_dotenv
 
-__version__ = "3.3.1"
+__version__ = "3.4.0"
 load_dotenv()


### PR DESCRIPTION
## [3.4]
### Changed
- General library updates
- Remove the schug library dependency
### Fixed
- Documentation on how to update genes/transcripts/exons
- Installing d4tools in Tests & Coverage GitHub action
- Ignore `[success]` lines used as separators between chromosome in the latest genes/transcripts/exons file downloaded using schug

## Review
- [X] Tests executed by CR

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions