### PR TITLE
Patch 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [unreleased]
+## [3.5.1]
 ### Fixed
-- `d4_interval_coverage` endpoint crashing when computing stats over the `chrM` chromosome
+- `d4_interval_coverage` endpoint crashing when computing stats over the `MT` interval, when d4 file contains `chrM` chromosome (Nallo pipeline)
 
 ## [3.5]
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chanjo2"
-version = "3.5.0"
+version = "3.5.1"
 description = "Next generation coverage analysis"
 authors = ["northwestwitch <chiara.rasi@scilifelab.se>"]
 

--- a/src/chanjo2/__init__.py
+++ b/src/chanjo2/__init__.py
@@ -1,4 +1,4 @@
 from dotenv import load_dotenv
 
-__version__ = "3.5.0"
+__version__ = "3.5.1"
 load_dotenv()


### PR DESCRIPTION
## [3.5.1]
### Fixed
- `d4_interval_coverage` endpoint crashing when computing stats over the `MT` interval, when d4 file contains `chrM` chromosome (Nallo pipeline)

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions