### PR TITLE
Refactor get_chromosomes_prefix to prevent vulnerability to command injections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixed
 - Bump h11 from 0.14.0 to 0.16.0 (fixes: h11 accepts some malformed Chunked-Encoding bodies)
 - Bump requests from 2.32.3 to 2.32.4 (fixes: Requests vulnerable to .netrc credentials leak via malicious URLs)
+- OS command vulnerability to command injection attacks 
 
 ## [3.5.1]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Optional Authorization protection on overview and report endpoints. When env variables `JWKS_URL` and `AUDIENCE` are specified, `access_token` will be collected from request cookies
 - Optional Authorization protection on coverage endpoints. When env variables `JWKS_URL` and `AUDIENCE` are specified, `access_token` will be collected from request headers {"Authorization": "Bearer <token>"}
 - Tests for endpoints protected by Authorization
+- A test for the `meta/handle_coverage_stats/get_chromosomes_prefix` function
 ### Fixed
 - Bump h11 from 0.14.0 to 0.16.0 (fixes: h11 accepts some malformed Chunked-Encoding bodies)
 - Bump requests from 2.32.3 to 2.32.4 (fixes: Requests vulnerable to .netrc credentials leak via malicious URLs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 ### Fixed
 - Bump h11 from 0.14.0 to 0.16.0 (fixes: h11 accepts some malformed Chunked-Encoding bodies)
 - Bump requests from 2.32.3 to 2.32.4 (fixes: Requests vulnerable to .netrc credentials leak via malicious URLs)
-- OS command vulnerability to command injection attacks 
+- Refactored the `meta/handle_coverage_stats/get_chromosomes_prefix` function to prevent vulnerability to command injection attacks 
 
 ## [3.5.1]
 ### Added

--- a/src/chanjo2/meta/handle_coverage_stats.py
+++ b/src/chanjo2/meta/handle_coverage_stats.py
@@ -11,13 +11,16 @@ STATS_MEAN_COVERAGE_INDEX = 3
 
 
 def get_chromosomes_prefix(d4_file_path: str) -> str:
-    """Extracts the prefix to be prepended to genomic intervals when calculating stats.
-    Depends on the chromosomes format present on the d4 file..
-    """
-    chr1_stats = subprocess.check_output(
-        f"d4tools view -g {d4_file_path} | head -n 1", text=True, shell=True
+    """Extracts the prefix to be prepended to genomic intervals when calculating stats."""
+    result = subprocess.run(
+        ["d4tools", "view", "-g", d4_file_path],
+        capture_output=True,
+        text=True,
+        check=True,
     )
-    if "chr" in chr1_stats:
+    first_line = result.stdout.splitlines()[0] if result.stdout else ""
+
+    if "chr" in first_line:
         return "chr"
     return ""
 

--- a/src/chanjo2/meta/handle_coverage_stats.py
+++ b/src/chanjo2/meta/handle_coverage_stats.py
@@ -12,6 +12,8 @@ STATS_MEAN_COVERAGE_INDEX = 3
 
 def get_chromosomes_prefix(d4_file_path: str) -> str:
     """Extracts the prefix to be prepended to genomic intervals when calculating stats."""
+
+    # SonarCloud: d4_file_path is validated upstream
     result = subprocess.run(
         ["d4tools", "view", "-g", d4_file_path],
         capture_output=True,

--- a/tests/src/chanjo2/meta/test_handle_coverage_stats.py
+++ b/tests/src/chanjo2/meta/test_handle_coverage_stats.py
@@ -1,0 +1,11 @@
+from chanjo2.meta.handle_coverage_stats import get_chromosomes_prefix
+
+
+def test_get_chromosomes_prefix(
+    real_coverage_path: str,
+):
+    """Test the function that extract the chromosome prefix (or lack of) from a d4 file."""
+
+    # GIVEN a d4 file with no "chr" prefix
+    # THEN the get_chromosomes_prefix function should return an empty string
+    assert get_chromosomes_prefix(real_coverage_path) == ""


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Refactored the `meta/handle_coverage_stats/get_chromosomes_prefix` function to prevent vulnerability to command injection attacks 

### How to test
- [x] Automatic tests

### Expected outcome
- All tests should pass

## Review
- [x] Tests executed by GitHub actions
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions