### PR TITLE
Minor release 3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [unreleased]
+## [3.7]
 ### Added
 - Optional Authorization protection on overview and report endpoints. When env variables `JWKS_URL` and `AUDIENCE` are specified, `access_token` can also be collected form the request form, `access_token` key
 - Documentation on how to change the app settings to enforce authorised requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chanjo2"
-version = "3.6.0"
+version = "3.7.0"
 description = "Next generation coverage analysis"
 authors = ["northwestwitch <chiara.rasi@scilifelab.se>"]
 

--- a/src/chanjo2/__init__.py
+++ b/src/chanjo2/__init__.py
@@ -1,4 +1,4 @@
 from dotenv import load_dotenv
 
-__version__ = "3.6"
+__version__ = "3.7"
 load_dotenv()


### PR DESCRIPTION
## [3.7]
### Added
- Optional Authorization protection on overview and report endpoints. When env variables `JWKS_URL` and `AUDIENCE` are specified, `access_token` can also be collected form the request form, `access_token` key
- Documentation on how to change the app settings to enforce authorised requests


## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions