### PR TITLE
Minor release 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## [unreleased]
+## [3.8]
 ### Changed 
-- In order to support login via Google, validate `id_token` instead of `access_token` in overview and report endpoints.
+- In order to support token login via Google, validate `id_token` instead of `access_token` in overview and report endpoints.
 
 ## [3.7]
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "chanjo2"
-version = "3.7.0"
+version = "3.8.0"
 description = "Next generation coverage analysis"
 authors = ["northwestwitch <chiara.rasi@scilifelab.se>"]
 

--- a/src/chanjo2/__init__.py
+++ b/src/chanjo2/__init__.py
@@ -1,4 +1,4 @@
 from dotenv import load_dotenv
 
-__version__ = "3.7"
+__version__ = "3.8"
 load_dotenv()


### PR DESCRIPTION
## [3.8]
### Changed 
- In order to support token login via Google, validate `id_token` instead of `access_token` in overview and report endpoints.

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions