### PR TITLE
persist OIDC token in cookie for report and overview endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [3.8]
 ### Changed 
 - In order to support token login via Google, validate `id_token` instead of `access_token` in overview and report endpoints.
+- Condensed summary endpoint not protected by auth for now
 
 ## [3.7]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [unreleased]
+### Changed
+- Validate and persist OIDC token in cookie for report and overview endpoints
+
 ## [3.8]
 ### Changed 
 - In order to support token login via Google, validate `id_token` instead of `access_token` in overview and report endpoints.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [unreleased]
 ### Changed
-- Validate and persist OIDC token in cookie for report and overview endpoints
-- Condensed summary endpoint not protected by auth for now
+- Validate and persist OIDC token in cookie for report and overview endpoints (#492)
+- Condensed summary endpoint not protected by auth for now (#492)
 
 ## [3.8]
 ### Changed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## [unreleased]
 ### Changed
 - Validate and persist OIDC token in cookie for report and overview endpoints
+- Condensed summary endpoint not protected by auth for now
 
 ## [3.8]
 ### Changed 
 - In order to support token login via Google, validate `id_token` instead of `access_token` in overview and report endpoints.
-- Condensed summary endpoint not protected by auth for now
 
 ## [3.7]
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pytest = "7.4.4"
 fastapi = "^0.115.12"
 importlib-resources = "^6.5.2"
 httpx = "^0.28.1"
-python-jose = {extras = ["cryptography"], version = "^3.5.0"}
+python-jose = {version = "^3.5.0", extras = ["cryptography"]}
 respx = "^0.22.0"
 
 [tool.poetry.extras]

--- a/src/chanjo2/auth.py
+++ b/src/chanjo2/auth.py
@@ -1,7 +1,7 @@
 import base64
 import logging
 import os
-from typing import Any, Dict
+from typing import Dict
 
 import httpx
 from cryptography.hazmat.backends import default_backend

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Tuple
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
-from chanjo2.auth import get_current_user
+from chanjo2.auth import get_token
 from chanjo2.constants import WRONG_BED_FILE_MSG, WRONG_COVERAGE_FILE_MSG
 from chanjo2.crud.intervals import get_genes, set_sql_intervals
 from chanjo2.dbutil import get_session
@@ -40,7 +40,7 @@ LOG = logging.getLogger(__name__)
 
 @router.post("/coverage/d4/interval/", response_model=IntervalCoverage)
 def d4_interval_coverage(
-    query: FileCoverageQuery, user: dict = Depends(get_current_user)
+    query: FileCoverageQuery, validated_token: dict = Depends(get_token)
 ):
     """Return coverage on the given interval for a D4 resource located on the disk or on a remote server."""
 
@@ -87,7 +87,7 @@ def d4_interval_coverage(
 
 @router.post("/coverage/d4/interval_file/", response_model=List[IntervalCoverage])
 def d4_intervals_coverage(
-    query: FileCoverageIntervalsFileQuery, user: dict = Depends(get_current_user)
+    query: FileCoverageIntervalsFileQuery, validated_token: dict = Depends(get_token)
 ):
     """Return coverage on the given intervals for a D4 resource located on the disk or on a remote server."""
 
@@ -141,7 +141,7 @@ def d4_intervals_coverage(
 def d4_genes_condensed_summary(
     query: CoverageSummaryQuery,
     db: Session = Depends(get_session),
-    user: dict = Depends(get_current_user),
+    validated_token: dict = Depends(get_token),
 ):
     """Returning condensed summary containing only sample's mean coverage and completeness above a default threshold."""
 
@@ -211,7 +211,7 @@ def d4_genes_condensed_summary(
 
 @router.get("/coverage/samples/predicted_sex", response_model=Dict)
 async def get_samples_predicted_sex(
-    coverage_file_path: str, user: dict = Depends(get_current_user)
+    coverage_file_path: str, validated_token: dict = Depends(get_token)
 ):
     """Return predicted sex for a sample given the coverage over its sex chromosomes."""
     if (

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import time
 from os.path import isfile
@@ -40,7 +41,8 @@ LOG = logging.getLogger(__name__)
 
 @router.post("/coverage/d4/interval/", response_model=IntervalCoverage)
 def d4_interval_coverage(
-    query: FileCoverageQuery, validated_token: dict = Depends(get_token)
+    query: FileCoverageQuery,
+    token_data: Tuple[str, datetime.datetime] = Depends(get_token),
 ):
     """Return coverage on the given interval for a D4 resource located on the disk or on a remote server."""
 
@@ -87,7 +89,8 @@ def d4_interval_coverage(
 
 @router.post("/coverage/d4/interval_file/", response_model=List[IntervalCoverage])
 def d4_intervals_coverage(
-    query: FileCoverageIntervalsFileQuery, validated_token: dict = Depends(get_token)
+    query: FileCoverageIntervalsFileQuery,
+    token_data: Tuple[str, datetime.datetime] = Depends(get_token),
 ):
     """Return coverage on the given intervals for a D4 resource located on the disk or on a remote server."""
 
@@ -209,7 +212,8 @@ def d4_genes_condensed_summary(
 
 @router.get("/coverage/samples/predicted_sex", response_model=Dict)
 async def get_samples_predicted_sex(
-    coverage_file_path: str, validated_token: dict = Depends(get_token)
+    coverage_file_path: str,
+    token_data: Tuple[str, datetime.datetime] = Depends(get_token),
 ):
     """Return predicted sex for a sample given the coverage over its sex chromosomes."""
     if (

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -139,9 +139,7 @@ def d4_intervals_coverage(
 
 @router.post("/coverage/d4/genes/summary", response_model=Dict)
 def d4_genes_condensed_summary(
-    query: CoverageSummaryQuery,
-    db: Session = Depends(get_session),
-    validated_token: dict = Depends(get_token),
+    query: CoverageSummaryQuery, db: Session = Depends(get_session)
 ):
     """Returning condensed summary containing only sample's mean coverage and completeness above a default threshold."""
 

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -11,7 +11,7 @@ from starlette.datastructures import FormData
 from typing_extensions import Annotated
 
 from chanjo2 import __version__
-from chanjo2.auth import get_current_user
+from chanjo2.auth import get_token
 from chanjo2.constants import DEFAULT_COVERAGE_LEVEL
 from chanjo2.dbutil import get_session
 from chanjo2.demo import DEMO_COVERAGE_QUERY_FORM, DEMO_GENE_OVERVIEW_QUERY_FORM
@@ -72,7 +72,7 @@ async def overview(
     hgnc_gene_symbols=Annotated[Optional[str], Form(None)],
     default_level=Annotated[Optional[int], Form(DEFAULT_COVERAGE_LEVEL)],
     db: Session = Depends(get_session),
-    user: dict = Depends(get_current_user),
+    validated_token: dict = Depends(get_token),
 ):
     """Return the genes overview page over a list of genes for a list of samples."""
     try:
@@ -104,7 +104,7 @@ async def gene_overview(
     request: Request,
     access_token=Annotated[Optional[str], Form(None)],
     db: Session = Depends(get_session),
-    user: dict = Depends(get_current_user),
+    validated_token: dict = Depends(get_token),
 ):
     """Returns coverage overview stats for a group of samples over genomic intervals of a single gene."""
     form_data: FormData = await request.form()
@@ -174,7 +174,7 @@ async def mane_overview(
     hgnc_gene_symbols=Annotated[Optional[str], Form(None)],
     default_level=Annotated[Optional[int], Form(DEFAULT_COVERAGE_LEVEL)],
     db: Session = Depends(get_session),
-    user: dict = Depends(get_current_user),
+    validated_token: dict = Depends(get_token),
 ):
     """Returns coverage overview stats for a group of samples over MANE transcripts of a list of genes."""
     try:

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -87,7 +87,7 @@ async def overview(
     overview_content: dict = get_report_data(
         query=overview_query, session=db, is_overview=True
     )
-    return templates.TemplateResponse(
+    response = templates.TemplateResponse(
         request=request,
         name="overview.html",
         context={
@@ -97,6 +97,15 @@ async def overview(
             "incomplete_coverage_rows": overview_content["incomplete_coverage_rows"],
         },
     )
+
+    response.set_cookie(
+        key="id_token",
+        value=validated_token,
+        httponly=True,
+        secure=True,
+        samesite="Strict",
+    )
+    return response
 
 
 @router.post("/gene_overview", response_class=HTMLResponse)
@@ -122,9 +131,18 @@ async def gene_overview(
         get_gene_overview_coverage_stats(form_data=validated_form, session=db)
     )
 
-    return templates.TemplateResponse(
+    response = templates.TemplateResponse(
         request=request, name="gene-overview.html", context=gene_overview_content
     )
+
+    response.set_cookie(
+        key="id_token",
+        value=validated_token,
+        httponly=True,
+        secure=True,
+        samesite="Strict",
+    )
+    return response
 
 
 @router.get("/gene_overview/demo", response_class=HTMLResponse)
@@ -186,8 +204,17 @@ async def mane_overview(
             detail=ve.json(),
         )
 
-    return templates.TemplateResponse(
+    response = templates.TemplateResponse(
         request=request,
         name="mane-overview.html",
         context=get_mane_overview_coverage_stats(query=overview_query, session=db),
     )
+
+    response.set_cookie(
+        key="id_token",
+        value=validated_token,
+        httponly=True,
+        secure=True,
+        samesite="Strict",
+    )
+    return response

--- a/src/chanjo2/endpoints/overview.py
+++ b/src/chanjo2/endpoints/overview.py
@@ -201,6 +201,7 @@ async def mane_overview(
     token_data: Tuple[str, datetime.datetime] = Depends(get_token),
 ):
     """Returns coverage overview stats for a group of samples over MANE transcripts of a list of genes."""
+    validated_token, expires = token_data
     try:
         overview_query = ReportQuery.as_form(await request.form())
 

--- a/src/chanjo2/endpoints/report.py
+++ b/src/chanjo2/endpoints/report.py
@@ -83,7 +83,7 @@ async def report(
 
     report_content: dict = get_report_data(query=report_query, session=db)
     LOG.debug(f"Time to compute stats: {time.time() - start_time} seconds.")
-    return templates.TemplateResponse(
+    response = templates.TemplateResponse(
         request=request,
         name="report.html",
         context={
@@ -99,3 +99,12 @@ async def report(
             "errors": report_content["errors"],
         },
     )
+
+    response.set_cookie(
+        key="id_token",
+        value=validated_token,
+        httponly=True,
+        secure=True,
+        samesite="Strict",
+    )
+    return response

--- a/src/chanjo2/endpoints/report.py
+++ b/src/chanjo2/endpoints/report.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from typing_extensions import Annotated
 
 from chanjo2 import __version__
-from chanjo2.auth import get_current_user
+from chanjo2.auth import get_token
 from chanjo2.constants import DEFAULT_COVERAGE_LEVEL
 from chanjo2.dbutil import get_session
 from chanjo2.demo import DEMO_COVERAGE_QUERY_FORM
@@ -69,7 +69,7 @@ async def report(
     panel_name=Annotated[Optional[str], Form("Custom panel")],
     default_level=Annotated[Optional[int], Form(DEFAULT_COVERAGE_LEVEL)],
     db: Session = Depends(get_session),
-    user: dict = Depends(get_current_user),
+    validated_token: dict = Depends(get_token),
 ):
     """Return a coverage report over a list of genes for a list of samples."""
     start_time = time.time()

--- a/src/chanjo2/endpoints/report.py
+++ b/src/chanjo2/endpoints/report.py
@@ -1,7 +1,8 @@
+import datetime
 import logging
 import time
 from os import path
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse
@@ -69,9 +70,12 @@ async def report(
     panel_name=Annotated[Optional[str], Form("Custom panel")],
     default_level=Annotated[Optional[int], Form(DEFAULT_COVERAGE_LEVEL)],
     db: Session = Depends(get_session),
-    validated_token: dict = Depends(get_token),
+    token_data: Tuple[str, datetime.datetime] = Depends(get_token),
 ):
     """Return a coverage report over a list of genes for a list of samples."""
+
+    validated_token, expires = token_data
+
     start_time = time.time()
     try:
         report_query = ReportQuery.as_form(await request.form())
@@ -106,5 +110,6 @@ async def report(
         httponly=True,
         secure=True,
         samesite="Strict",
+        expires=expires,
     )
     return response


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Validate and persist OIDC token in cookie for report and overview endpoints, closes #490 

### How to test
- [x] Tested with Google OAUTH. Go to report, change report settings on top and click update report
- [x] Report should update without returning "missing token"

### Expected outcome
- 

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions