### PR TITLE
Handle failed token claims parsing when token is not passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## [unreleased]
 ### Changed
-- Validate and persist OIDC token in cookie for report and overview endpoints (#492)
 - Condensed summary endpoint not protected by auth for now (#492)
+### Fixed
+- Validate and persist OIDC token in cookie for report and overview endpoints (#492)
+- Fix app crashing when try validating token claims in absence of token (#494)
 
 ## [3.8]
 ### Changed 

--- a/src/chanjo2/auth.py
+++ b/src/chanjo2/auth.py
@@ -52,11 +52,11 @@ async def get_token(request: Request) -> Tuple[str, datetime.datetime]:
     if not token:
         raise HTTPException(status_code=401, detail="Missing id_token")
 
-    # Optional: log unverified claims
-    claims = jwt.get_unverified_claims(token)
-    print(f"Received a token with audience: {claims.get('aud')}")
-
     try:
+        # Optional: log unverified claims
+        claims = jwt.get_unverified_claims(token)
+        print(f"Received a token with audience: {claims.get('aud')}")
+
         # Fetch JWKS keys
         async with httpx.AsyncClient() as client:
             resp = await client.get(JWKS_URL)


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Fix #493 

### How to test
- [x] Locally or on stage, use a branch of scout that doesn't support request with wuth tokens

<img width="542" height="115" alt="image" src="https://github.com/user-attachments/assets/793375df-33b8-4843-aff7-a656286c9294" />


### Expected outcome
- This branch should show an error message instead of crashing

## Review
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions