### PR TITLE
Fix report page to reflect type of analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Validate and persist OIDC token in cookie for report and overview endpoints (#492)
 - Fix app crashing when try validating token claims in absence of token (#494)
+- On report page, fixed title `Transcript coverage at 10x` with `Genes/Transcript/Exons coverage at 10x`, reflecting the analysis type (#495)
 
 ## [3.8]
 ### Changed 

--- a/src/chanjo2/templates/report.html
+++ b/src/chanjo2/templates/report.html
@@ -238,7 +238,7 @@
 
 	{{ important_metrics() }}
 
-	<h3> Transcript coverage at {{ extras.default_level }}x</h3>
+	<h3> {{ interval_type|capitalize }} coverage at {{ extras.default_level }}x</h3>
 
 	{{ default_level_metrics() }}
 	<hr>


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- On report page, fixed title `Transcript coverage at 10x` with `Genes/Transcript/Exons coverage at 10x`, reflecting the analysis type - fix #491 


### How to test
- [x] Local test

### Expected outcome
- Demo page should load

## Review
- [ ] Tests executed by 
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions