### PR TITLE
Fix /coverage/samples/predicted_se endpoint to work with 'chr' prefixed d4 files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 - Added a select to switch between genes/transcripts/exons stats on coverage reports (#521)
 ### Changed
 - Removed support for Python 3.9 (#520)
+### Fixed
+- Sex chromosome checks for d4 files with 'chr' prefix (#523 and #526)
 
 ## [3.10.1]
 ### Changed
 - Remove PAR regions from bed files used in X/Y chromosome check (#514)
 ### Fixed
 - Exome and Transcript data sex chromosome coverage. Returning always 0 (#512)
-- Sex chromosome checks for d4 files with 'chr' prefix (#523)
 
 ## [3.10]
 ### Added

--- a/src/chanjo2/endpoints/coverage.py
+++ b/src/chanjo2/endpoints/coverage.py
@@ -21,7 +21,11 @@ from chanjo2.meta.handle_coverage_stats import (
     get_d4tools_chromosome_mean_coverage,
     get_d4tools_intervals_mean_coverage,
 )
-from chanjo2.meta.handle_d4 import get_samples_sex_metrics, set_interval_ids_coords
+from chanjo2.meta.handle_d4 import (
+    get_chromosomes_prefix,
+    get_samples_sex_metrics,
+    set_interval_ids_coords,
+)
 from chanjo2.meta.handle_report_contents import INTERVAL_TYPE_SQL_TYPE
 from chanjo2.meta.utils import get_mean
 from chanjo2.models import SQLGene
@@ -224,4 +228,7 @@ async def get_samples_predicted_sex(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=WRONG_COVERAGE_FILE_MSG,
         )
-    return get_samples_sex_metrics(d4_file_path=coverage_file_path)
+    chr_prefix = get_chromosomes_prefix(coverage_file_path)
+    return get_samples_sex_metrics(
+        d4_file_path=coverage_file_path, chr_prefix=chr_prefix
+    )


### PR DESCRIPTION
## Description
### Added/Changed/Fixed
- Closes #526 

### How to test
- [x] Run the stats with a d4 files containing 'chr' prefix

### Expected outcome
- Main branch should crash
- This branch should return stats

## Review 
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions